### PR TITLE
Fix for Gosec workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,9 +36,14 @@ jobs:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: "-no-fail -fmt sarif -out results.sarif ./..."
         if: "env.GIT_DIFF_FILTERED != ''"
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: results.sarif
-        if: "env.GIT_DIFF_FILTERED != ''"
+      # TODO: Once the repository is public enable the "GitHub Advanced Security"
+      #       option in the repository settings and uncomment the "Upload SARIF file"
+      #       step below. The step will not work with this option disabled and
+      #       the option can only be enabled once the repository becomes public.
+      #       More info: https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository
+      # - name: Upload SARIF file
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   with:
+      #     # Path to SARIF file relative to the root of the repository
+      #     sarif_file: results.sarif
+      #   if: "env.GIT_DIFF_FILTERED != ''"


### PR DESCRIPTION
#Refs https://github.com/thesis/mezo/issues/28.
This PR comments out the SARIF file uploading step from the Gosec workflow.

The workflow first executes the `gosec` tool, saves the results as a SAFIR file and uploads it to GitHub's security scan.
However, as explained in [this GitHub doc](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository) uploading SARIF files requires "GitHub Advanced Security" enabled:
```
Note: If you disable GitHub Advanced Security, dependency review, secret scanning alerts for users and code scanning are disabled. Any workflows, SARIF uploads, or API calls for code scanning will fail. If GitHub Advanced Security is re-enabled, code scanning will return to its previous state.
```
We cannot enable GitHub Advanced Security until our repository is public. That best option for now is to simply comment out the upload step.