### PR TITLE
Fix for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,6 +78,11 @@ jobs:
       #   make bootstrap
       #   make release
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        if: env.GIT_DIFF
+      # TODO: Once the repository is public, enable the "GitHub Advanced Security"
+      #       option in the repository settings and uncomment the "Perform CodeQL Analysis"
+      #       step below. The step will not work with this option disabled and
+      #       the option can only be enabled once the repository becomes public.
+      #       More info: https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository
+      # - name: Perform CodeQL Analysis
+      #   uses: github/codeql-action/analyze@v2
+      #   if: env.GIT_DIFF

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: "-no-fail -fmt sarif -out results.sarif ./..."
         if: "env.GIT_DIFF_FILTERED != ''"
-      # TODO: Once the repository is public enable the "GitHub Advanced Security"
+      # TODO: Once the repository is public, enable the "GitHub Advanced Security"
       #       option in the repository settings and uncomment the "Upload SARIF file"
       #       step below. The step will not work with this option disabled and
       #       the option can only be enabled once the repository becomes public.


### PR DESCRIPTION
#Refs https://github.com/thesis/mezo/issues/28.
This PR comments out the CodeQL analysis step from one of the workflows.

The workflow attempts to analyse the code using CodeQL. However, the GitHub Advanced Security option must first be enabled, as shown in the error message:
` Error: Advanced Security must be enabled for this repository to use code scanning.`
 
We cannot enable GitHub Advanced Security until our repository is public. That best option for now is to simply comment out the CodeQL analysis step.