### PR TITLE
Temporarily disabled vulncheck workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,6 +28,12 @@ jobs:
       # - name: "Dependency Review"
       #   uses: actions/dependency-review-action@v3
       #   if: env.GIT_DIFF
-      - name: "Go vulnerability check"
-        run: make vulncheck
-        if: env.GIT_DIFF
+      # TODO: Uncomment once either a vulnerability in the `github.com/cosmos/ibc-go/v6`
+      #       package is fixed, the package is upgraded to a higher version or
+      #       the package is removed.
+      #       The `govulncheck` tool does not allow to ignore any vulnerabilities
+      #       and will only be enabled once the vulnerability in question is
+      #       resolved.
+      # - name: "Go vulnerability check"
+      #   run: make vulncheck
+      #   if: env.GIT_DIFF


### PR DESCRIPTION
#Refs https://github.com/thesis/mezo/issues/28.

This PR temporarily disables the `vulncheck` check from the `dependency-review` workflow.
The reason is because the tool detects a vulnerability in one of the packages.
The package will be removed from our repository in the future. 
The `vulncheck` will be enabled in the future.