### PR TITLE
Remove `Protobuf / break-check` CI job

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,7 +1,7 @@
 name: Protobuf
-# The workflow builds, lints and checks breakage for Protocol Buffers (`.proto`)
-# files using the `buf` tool. It runs on pull requests when changes are made to
-# files within the `proto` directory.
+# The workflow builds and lints Protocol Buffers (`.proto`) files using the
+# `buf` tool. It runs on pull requests when changes are made to files within
+# the `proto` directory.
 on:
   pull_request:
     paths:
@@ -33,13 +33,3 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto"
-
-  break-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.15.1
-      - uses: bufbuild/buf-breaking-action@v1
-        with:
-          input: "proto"
-          against: "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.ref }},ref=HEAD~1,subdir=proto"


### PR DESCRIPTION
Removes the `Protobuf / break-check` CI job. At present, this job adds no value and often fails during routine development. If a previously merged PR removed proto files, this check will often fail in new completely unrelated PRs. We could consider adding this back in the future once modules (and proto files) are finalized and less likely to be removed.