### PR TITLE
Resetting total supply tests before each run

### DIFF
--- a/precompile/btctoken/total_supply_test.go
+++ b/precompile/btctoken/total_supply_test.go
@@ -40,6 +40,7 @@ func (s *PrecompileTestSuite) TestTotalSupply() {
 
 	for testName, tc := range testcases {
 		s.Run(testName, func() {
+			s.SetupTest()
 			if tc.run != nil {
 				tc.run(s.ctx, s.app)
 			}


### PR DESCRIPTION
We observed failing tests for the total supply method in CI. In this tiny PR we fix these tests by resetting the setup before each run. 