### PR TITLE
Restore original license headers

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package ante
 

--- a/app/ante/cosmos/authz.go
+++ b/app/ante/cosmos/authz.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cosmos
 
 import (

--- a/app/ante/cosmos/eip712.go
+++ b/app/ante/cosmos/eip712.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cosmos
 
 import (

--- a/app/ante/cosmos/fees.go
+++ b/app/ante/cosmos/fees.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package cosmos
 

--- a/app/ante/cosmos/interfaces.go
+++ b/app/ante/cosmos/interfaces.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package cosmos
 

--- a/app/ante/cosmos/min_price.go
+++ b/app/ante/cosmos/min_price.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cosmos
 
 import (

--- a/app/ante/cosmos/reject_msgs.go
+++ b/app/ante/cosmos/reject_msgs.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cosmos
 
 import (

--- a/app/ante/doc.go
+++ b/app/ante/doc.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 /*
 Package ante defines the SDK auth module's AnteHandler as well as an internal

--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package evm
 

--- a/app/ante/evm/fee_checker.go
+++ b/app/ante/evm/fee_checker.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/evm/fee_market.go
+++ b/app/ante/evm/fee_market.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/evm/fees.go
+++ b/app/ante/evm/fees.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/evm/sigverify.go
+++ b/app/ante/evm/sigverify.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package ante
 

--- a/app/ante/sigverify.go
+++ b/app/ante/sigverify.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package ante
 

--- a/app/ante/utils/interfaces.go
+++ b/app/ante/utils/interfaces.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package utils
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package app
 

--- a/app/ethtest_helper.go
+++ b/app/ethtest_helper.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package app
 
 import (

--- a/app/export.go
+++ b/app/export.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package app
 

--- a/app/gas.go
+++ b/app/gas.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package app
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package app
 

--- a/app/tps_counter.go
+++ b/app/tps_counter.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package app
 

--- a/client/config.go
+++ b/client/config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package client
 
 import (

--- a/client/debug/debug.go
+++ b/client/debug/debug.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package debug
 
 import (

--- a/client/export.go
+++ b/client/export.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package client
 
 import (

--- a/client/import.go
+++ b/client/import.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package client
 
 import (

--- a/client/keys.go
+++ b/client/keys.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package client
 
 import (

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keys
 
 import (

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keys
 
 import (

--- a/client/testnet.go
+++ b/client/testnet.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package client
 
 // DONTCOVER

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package config
 

--- a/cmd/config/observability.go
+++ b/cmd/config/observability.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package config
 

--- a/cmd/mezod/genaccounts.go
+++ b/cmd/mezod/genaccounts.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/cmd/mezod/init.go
+++ b/cmd/mezod/init.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/cmd/mezod/main.go
+++ b/cmd/mezod/main.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/cmd/mezod/migrate.go
+++ b/cmd/mezod/migrate.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/cmd/mezod/root.go
+++ b/cmd/mezod/root.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/cmd/mezod/testnet.go
+++ b/cmd/mezod/testnet.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package main
 

--- a/crypto/codec/amino.go
+++ b/crypto/codec/amino.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package codec
 
 import (

--- a/crypto/codec/codec.go
+++ b/crypto/codec/codec.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package codec
 
 import (

--- a/crypto/ethsecp256k1/ethsecp256k1.go
+++ b/crypto/ethsecp256k1/ethsecp256k1.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package ethsecp256k1
 

--- a/crypto/hd/algorithm.go
+++ b/crypto/hd/algorithm.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package hd
 
 import (

--- a/crypto/keyring/options.go
+++ b/crypto/keyring/options.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package keyring
 

--- a/encoding/codec/codec.go
+++ b/encoding/codec/codec.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package codec
 
 import (

--- a/encoding/config.go
+++ b/encoding/config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package encoding
 
 import (

--- a/ethereum/eip712/domain.go
+++ b/ethereum/eip712/domain.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/eip712.go
+++ b/ethereum/eip712/eip712.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/eip712_legacy.go
+++ b/ethereum/eip712/eip712_legacy.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/encoding_legacy.go
+++ b/ethereum/eip712/encoding_legacy.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/message.go
+++ b/ethereum/eip712/message.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/preprocess.go
+++ b/ethereum/eip712/preprocess.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/ethereum/eip712/types.go
+++ b/ethereum/eip712/types.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eip712
 
 import (

--- a/indexer/kv_indexer.go
+++ b/indexer/kv_indexer.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package indexer
 
 import (

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package rpc
 
 import (

--- a/rpc/backend/account_info.go
+++ b/rpc/backend/account_info.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/filters.go
+++ b/rpc/backend/filters.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/node_info.go
+++ b/rpc/backend/node_info.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/sign_tx.go
+++ b/rpc/backend/sign_tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package backend
 
 import (

--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package pubsub
 
 import (

--- a/rpc/namespaces/ethereum/debug/api.go
+++ b/rpc/namespaces/ethereum/debug/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package debug
 
 import (

--- a/rpc/namespaces/ethereum/debug/utils.go
+++ b/rpc/namespaces/ethereum/debug/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package debug
 
 import (

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package eth
 
 import (

--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package filters
 
 import (

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package filters
 
 import (

--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package filters
 
 import (

--- a/rpc/namespaces/ethereum/eth/filters/subscription.go
+++ b/rpc/namespaces/ethereum/eth/filters/subscription.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package filters
 
 import (

--- a/rpc/namespaces/ethereum/eth/filters/utils.go
+++ b/rpc/namespaces/ethereum/eth/filters/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package filters
 
 import (

--- a/rpc/namespaces/ethereum/miner/api.go
+++ b/rpc/namespaces/ethereum/miner/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package miner
 
 import (

--- a/rpc/namespaces/ethereum/miner/unsupported.go
+++ b/rpc/namespaces/ethereum/miner/unsupported.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package miner
 
 import (

--- a/rpc/namespaces/ethereum/net/api.go
+++ b/rpc/namespaces/ethereum/net/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package net
 
 import (

--- a/rpc/namespaces/ethereum/personal/api.go
+++ b/rpc/namespaces/ethereum/personal/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package personal
 
 import (

--- a/rpc/namespaces/ethereum/txpool/api.go
+++ b/rpc/namespaces/ethereum/txpool/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package txpool
 
 import (

--- a/rpc/namespaces/ethereum/web3/api.go
+++ b/rpc/namespaces/ethereum/web3/api.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package web3
 
 import (

--- a/rpc/types/addrlock.go
+++ b/rpc/types/addrlock.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/types/block.go
+++ b/rpc/types/block.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/types/events.go
+++ b/rpc/types/events.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/types/query_client.go
+++ b/rpc/types/query_client.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/types/types.go
+++ b/rpc/types/types.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package rpc
 
 import (

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package config
 
 import (

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package config
 
 // DefaultConfigTemplate defines the configuration template for the EVM RPC configuration

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package flags
 
 import (

--- a/server/indexer_cmd.go
+++ b/server/indexer_cmd.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package server
 
 import (

--- a/server/indexer_service.go
+++ b/server/indexer_service.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package server
 
 import (

--- a/server/json_rpc.go
+++ b/server/json_rpc.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package server
 
 import (

--- a/server/start.go
+++ b/server/start.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package server
 
 import (

--- a/server/util.go
+++ b/server/util.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package server
 
 import (

--- a/tests/integration/ledger/mocks/registry.go
+++ b/tests/integration/ledger/mocks/registry.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package mocks
 

--- a/tests/integration/ledger/mocks/tendermint.go
+++ b/tests/integration/ledger/mocks/tendermint.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package mocks
 

--- a/testutil/abci.go
+++ b/testutil/abci.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package testutil
 
 import (

--- a/testutil/fund.go
+++ b/testutil/fund.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package testutil
 

--- a/testutil/network/doc.go
+++ b/testutil/network/doc.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 /*
 Package network implements and exposes a fully operational in-process Tendermint

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package network
 

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package network
 

--- a/testutil/statedb.go
+++ b/testutil/statedb.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package testutil
 

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package tx
 
 import (

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package tx
 
 import (

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package tx
 
 import (

--- a/testutil/tx/signer.go
+++ b/testutil/tx/signer.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package tx
 
 import (

--- a/types/account.go
+++ b/types/account.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/block.go
+++ b/types/block.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/chain_id.go
+++ b/types/chain_id.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/codec.go
+++ b/types/codec.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/coin.go
+++ b/types/coin.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/dynamic_fee.go
+++ b/types/dynamic_fee.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package types
 

--- a/types/gasmeter.go
+++ b/types/gasmeter.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/hdpath.go
+++ b/types/hdpath.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/indexer.go
+++ b/types/indexer.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/int.go
+++ b/types/int.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/types/protocol.go
+++ b/types/protocol.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 // Constants to match up protocol versions and messages

--- a/types/validation.go
+++ b/types/validation.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 
 package utils
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package version
 
 import (

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cli
 
 import (

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cli
 
 import (

--- a/x/evm/client/cli/utils.go
+++ b/x/evm/client/cli/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cli
 
 import (

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/fees.go
+++ b/x/evm/keeper/fees.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/gas.go
+++ b/x/evm/keeper/gas.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/hooks.go
+++ b/x/evm/keeper/hooks.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/migrations.go
+++ b/x/evm/keeper/migrations.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/evm/migrations/v4/migrate.go
+++ b/x/evm/migrations/v4/migrate.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v4
 
 import (

--- a/x/evm/migrations/v4/migrate_test.go
+++ b/x/evm/migrations/v4/migrate_test.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v4_test
 
 import (

--- a/x/evm/migrations/v5/migrate.go
+++ b/x/evm/migrations/v5/migrate.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v5
 
 import (

--- a/x/evm/migrations/v5/migrate_test.go
+++ b/x/evm/migrations/v5/migrate_test.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v5_test
 
 import (

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package evm
 
 import (

--- a/x/evm/statedb/interfaces.go
+++ b/x/evm/statedb/interfaces.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package statedb
 
 import (

--- a/x/evm/statedb/state_object.go
+++ b/x/evm/statedb/state_object.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package statedb
 
 import (

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package statedb
 
 import (

--- a/x/evm/types/access_list.go
+++ b/x/evm/types/access_list.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/access_list_tx.go
+++ b/x/evm/types/access_list_tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/chain_config.go
+++ b/x/evm/types/chain_config.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/compiled_contract.go
+++ b/x/evm/types/compiled_contract.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/dynamic_fee_tx.go
+++ b/x/evm/types/dynamic_fee_tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/errors.go
+++ b/x/evm/types/errors.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/events.go
+++ b/x/evm/types/events.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 // Evm module events

--- a/x/evm/types/genesis.go
+++ b/x/evm/types/genesis.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/legacy_tx.go
+++ b/x/evm/types/legacy_tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/logs.go
+++ b/x/evm/types/logs.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/params.go
+++ b/x/evm/types/params.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/params_legacy.go
+++ b/x/evm/types/params_legacy.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"

--- a/x/evm/types/query.go
+++ b/x/evm/types/query.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/storage.go
+++ b/x/evm/types/storage.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/tracer.go
+++ b/x/evm/types/tracer.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/tx.go
+++ b/x/evm/types/tx.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/tx_args.go
+++ b/x/evm/types/tx_args.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/tx_data.go
+++ b/x/evm/types/tx_data.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/feemarket/client/cli/query.go
+++ b/x/feemarket/client/cli/query.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package cli
 
 import (

--- a/x/feemarket/genesis.go
+++ b/x/feemarket/genesis.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package feemarket
 
 import (

--- a/x/feemarket/handler.go
+++ b/x/feemarket/handler.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package feemarket
 
 import (

--- a/x/feemarket/keeper/abci.go
+++ b/x/feemarket/keeper/abci.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/keeper/eip1559.go
+++ b/x/feemarket/keeper/eip1559.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/keeper/grpc_query.go
+++ b/x/feemarket/keeper/grpc_query.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/keeper/keeper.go
+++ b/x/feemarket/keeper/keeper.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/keeper/migrations.go
+++ b/x/feemarket/keeper/migrations.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/keeper/params.go
+++ b/x/feemarket/keeper/params.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package keeper
 
 import (

--- a/x/feemarket/migrations/v4/migrate.go
+++ b/x/feemarket/migrations/v4/migrate.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v4
 
 import (

--- a/x/feemarket/migrations/v4/migrate_test.go
+++ b/x/feemarket/migrations/v4/migrate_test.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package v4_test
 
 import (

--- a/x/feemarket/migrations/v4/types/params.go
+++ b/x/feemarket/migrations/v4/types/params.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (

--- a/x/feemarket/module.go
+++ b/x/feemarket/module.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package feemarket
 
 import (

--- a/x/feemarket/types/events.go
+++ b/x/feemarket/types/events.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 // feemarket module events

--- a/x/feemarket/types/genesis.go
+++ b/x/feemarket/types/genesis.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 // DefaultGenesisState sets default fee market genesis state.

--- a/x/feemarket/types/keys.go
+++ b/x/feemarket/types/keys.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 const (

--- a/x/feemarket/types/params.go
+++ b/x/feemarket/types/params.go
@@ -1,18 +1,18 @@
 // Copyright 2022 Evmos Foundation
-// This file is part of the Mezo Network packages.
+// This file is part of the Evmos Network packages.
 //
-// Mezo is free software: you can redistribute it and/or modify
+// Evmos is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The Mezo packages are distributed in the hope that it will be useful,
+// The Evmos packages are distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the Mezo packages. If not, see https://github.com/mezo-org/mezod/blob/main/LICENSE
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
 package types
 
 import (


### PR DESCRIPTION
Restores the original Evmos license headers (modified during https://github.com/thesis/mezo/pull/218) until we decide what to do here