### PR TITLE
Add transient storage to `x/evm` statedb

### DIFF
--- a/x/evm/statedb/state_object.go
+++ b/x/evm/statedb/state_object.go
@@ -70,11 +70,8 @@ type stateObject struct {
 	code    []byte
 
 	// state storage
-	originStorage Storage
-	dirtyStorage  Storage
-
-	// transientStorage is an in memory storage of the latest committed entries in the current transaction execution.
-	// It is only used when multiple commits are made within the same transaction execution.
+	originStorage    Storage
+	dirtyStorage     Storage
 	transientStorage Storage
 
 	address common.Address

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -473,17 +473,16 @@ func (s *StateDB) Commit() error {
 				dirtyValue := obj.dirtyStorage[key]
 				originValue := obj.originStorage[key]
 				// Skip noop changes, persist actual changes
-				transientStorageValue, ok := obj.transientStorage[key]
-				if (ok && transientStorageValue == dirtyValue) ||
+				tsValue, ok := obj.transientStorage[key]
+				if (ok && tsValue == dirtyValue) ||
 					(!ok && dirtyValue == originValue) {
 					continue
 				}
 				s.keeper.SetState(s.ctx, obj.Address(), key, dirtyValue.Bytes())
 
-				// Update the pendingStorage cache to the new value.
-				// This is specially needed for precompiles calls where
-				// multiple Commits calls are done within the same transaction
-				// for the appropriate changes to be committed.
+				// Update the transientStorage cache. This is required for
+				// precompile calls where multiple Commits are done within
+				// the same transaction.
 				obj.transientStorage[key] = dirtyValue
 			}
 		}


### PR DESCRIPTION
This PR contains the fix for the evmos security advisory (referenced above), by adding transient storage to `x/evm` stateObject and updates `StateDB.Commit` logic.

`transientStorage` is an in memory storage of the latest committed entries in the current transaction execution. It is only used when multiple commits are made within the same transaction execution.

Due to our differing precompile implementation calling of StateDB.Commit is already being done for every Run call here: https://github.com/thesis/mezo/blob/main/precompile/contract.go#L161 I believe this to be sufficient, however I do not have a great way for testing/confirming this. More eyes would be very appreciated.