### PR TITLE
Adjust testnet deployment artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.2-bullseye AS build-env
+FROM golang:1.22.6-bullseye AS build-env
 
 WORKDIR /go/src/github.com/mezo-org/mezod
 
@@ -9,7 +9,7 @@ COPY . .
 
 RUN make build
 
-FROM golang:1.20.2-bullseye
+FROM golang:1.22.6-bullseye
 
 RUN apt-get update -y && \
     apt-get install ca-certificates jq -y

--- a/infrastructure/kubernetes/mezo-staging/mezo-genesis-config.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-genesis-config.yaml
@@ -7,28 +7,12 @@ data:
   # The file below was generated using the `scripts/public-testnet.sh` script.
   genesis.json: |
     {
-      "genesis_time": "2024-07-25T10:30:29.149843Z",
+      "app_name": "",
+      "app_version": "",
+      "genesis_time": "2024-08-19T14:35:36.025749Z",
       "chain_id": "mezo_31611-1",
-      "initial_height": "1",
-      "consensus_params": {
-        "block": {
-          "max_bytes": "22020096",
-          "max_gas": "10000000",
-          "time_iota_ms": "1000"
-        },
-        "evidence": {
-          "max_age_num_blocks": "100000",
-          "max_age_duration": "172800000000000",
-          "max_bytes": "1048576"
-        },
-        "validator": {
-          "pub_key_types": [
-            "ed25519"
-          ]
-        },
-        "version": {}
-      },
-      "app_hash": "",
+      "initial_height": 1,
+      "app_hash": null,
       "app_state": {
         "auth": {
           "params": {
@@ -42,7 +26,7 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo1dv063et0mlq2l7jqqarn4ykr47kkmrylt9ty6u",
+                "address": "mezo12wsc0qgyfwwfj3wrlpgm9q3lmndl2m4qmm34dp",
                 "pub_key": null,
                 "account_number": "0",
                 "sequence": "0"
@@ -52,9 +36,9 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo1jm53lv0944kzrgrthdgv2xa6qpdcmnw59dgmfg",
+                "address": "mezo1xqurxvvh8z2xpj6wltq0tajxm47xnv7q6rtvja",
                 "pub_key": null,
-                "account_number": "0",
+                "account_number": "1",
                 "sequence": "0"
               },
               "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
@@ -62,9 +46,9 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo1kum9w86tmafgnfyrhgzl9ja37pq2vvzf5wlufc",
+                "address": "mezo1jcurf087xx9eqsnmr8lszralupcfln2vjz8ucg",
                 "pub_key": null,
-                "account_number": "0",
+                "account_number": "2",
                 "sequence": "0"
               },
               "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
@@ -72,9 +56,9 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo14rrdcku8hgxp2xfxugkdxkdllnfrr4lagppjey",
+                "address": "mezo1j0ghx6d9kmerxhgn5ahr2nahs6yfulea4te22c",
                 "pub_key": null,
-                "account_number": "0",
+                "account_number": "3",
                 "sequence": "0"
               },
               "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
@@ -82,9 +66,9 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo1n8get9cqmljd9hqlm36cs28wa4ew747cx6r7gc",
+                "address": "mezo120mkxfvkx2t72quddqh92md2dp7csq4wgqux06",
                 "pub_key": null,
-                "account_number": "0",
+                "account_number": "4",
                 "sequence": "0"
               },
               "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
@@ -92,9 +76,9 @@ data:
             {
               "@type": "/ethermint.types.v1.EthAccount",
               "base_account": {
-                "address": "mezo10zzhztgz7se7yz2psvske8sn4n0epx2k724svr",
+                "address": "mezo1dmr6mhh352vh9wa34xs0qxtr8thkqu39pw6x2p",
                 "pub_key": null,
-                "account_number": "0",
+                "account_number": "5",
                 "sequence": "0"
               },
               "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
@@ -111,7 +95,7 @@ data:
           },
           "balances": [
             {
-              "address": "mezo1dv063et0mlq2l7jqqarn4ykr47kkmrylt9ty6u",
+              "address": "mezo1xqurxvvh8z2xpj6wltq0tajxm47xnv7q6rtvja",
               "coins": [
                 {
                   "denom": "abtc",
@@ -120,7 +104,7 @@ data:
               ]
             },
             {
-              "address": "mezo10zzhztgz7se7yz2psvske8sn4n0epx2k724svr",
+              "address": "mezo12wsc0qgyfwwfj3wrlpgm9q3lmndl2m4qmm34dp",
               "coins": [
                 {
                   "denom": "abtc",
@@ -129,7 +113,7 @@ data:
               ]
             },
             {
-              "address": "mezo1jm53lv0944kzrgrthdgv2xa6qpdcmnw59dgmfg",
+              "address": "mezo120mkxfvkx2t72quddqh92md2dp7csq4wgqux06",
               "coins": [
                 {
                   "denom": "abtc",
@@ -138,7 +122,7 @@ data:
               ]
             },
             {
-              "address": "mezo1n8get9cqmljd9hqlm36cs28wa4ew747cx6r7gc",
+              "address": "mezo1dmr6mhh352vh9wa34xs0qxtr8thkqu39pw6x2p",
               "coins": [
                 {
                   "denom": "abtc",
@@ -147,7 +131,7 @@ data:
               ]
             },
             {
-              "address": "mezo14rrdcku8hgxp2xfxugkdxkdllnfrr4lagppjey",
+              "address": "mezo1j0ghx6d9kmerxhgn5ahr2nahs6yfulea4te22c",
               "coins": [
                 {
                   "denom": "abtc",
@@ -156,7 +140,7 @@ data:
               ]
             },
             {
-              "address": "mezo1kum9w86tmafgnfyrhgzl9ja37pq2vvzf5wlufc",
+              "address": "mezo1jcurf087xx9eqsnmr8lszralupcfln2vjz8ucg",
               "coins": [
                 {
                   "denom": "abtc",
@@ -171,7 +155,8 @@ data:
               "amount": "6000000000000000000000"
             }
           ],
-          "denom_metadata": []
+          "denom_metadata": [],
+          "send_enabled": []
         },
         "bridge": {
           "params": {}
@@ -225,38 +210,15 @@ data:
           },
           "block_gas": "0"
         },
-        "params": null,
         "poa": {
           "params": {
             "max_validators": 150
           },
-          "owner": "mezo1dv063et0mlq2l7jqqarn4ykr47kkmrylt9ty6u",
+          "owner": "mezo12wsc0qgyfwwfj3wrlpgm9q3lmndl2m4qmm34dp",
           "validators": [
             {
-              "operator_bech32": "mezovaloper1jm53lv0944kzrgrthdgv2xa6qpdcmnw5gr8tg4",
-              "cons_pub_key_bech32": "mezovalconspub1zcjduepq8qzmke7jjz9dyzd5lpvk9udegpwcckfftfldxc9mkmytxxh9nwwqq72vqp",
-              "description": {
-                "moniker": "mezo-node-1",
-                "identity": "",
-                "website": "",
-                "security_contact": "",
-                "details": ""
-              }
-            },
-            {
-              "operator_bech32": "mezovaloper1dv063et0mlq2l7jqqarn4ykr47kkmrylxty5mp",
-              "cons_pub_key_bech32": "mezovalconspub1zcjduepqyeacp9yrtxk6w05q0vhv0vc0t2r85kfvh2c9kjv5y0n0snph8udszllayh",
-              "description": {
-                "moniker": "mezo-node-0",
-                "identity": "",
-                "website": "",
-                "security_contact": "",
-                "details": ""
-              }
-            },
-            {
-              "operator_bech32": "mezovaloper1kum9w86tmafgnfyrhgzl9ja37pq2vvzfeqsvg9",
-              "cons_pub_key_bech32": "mezovalconspub1zcjduepqc8hwp67vk40magqq0hx7wdq7y3yecq4f0jv6s7vla9h9sjzuhh5qfnpwdr",
+              "operator_bech32": "mezovaloper1jcurf087xx9eqsnmr8lszralupcfln2vpee7f5",
+              "cons_pub_key_bech32": "mezovalconspub1zcjduepqzxlt3ane6spyrfh56s6phm2l72f6yezu48rq85eytjsdsrz6n25s78djw7",
               "description": {
                 "moniker": "mezo-node-2",
                 "identity": "",
@@ -266,8 +228,19 @@ data:
               }
             },
             {
-              "operator_bech32": "mezovaloper1n8get9cqmljd9hqlm36cs28wa4ew747ct5vwf9",
-              "cons_pub_key_bech32": "mezovalconspub1zcjduepqqjf555wx0c8c2payst3nqht9v5mdn39m30yxr7z5wxqhsd2z67zq678u9f",
+              "operator_bech32": "mezovaloper1j0ghx6d9kmerxhgn5ahr2nahs6yfuleaxs8gmy",
+              "cons_pub_key_bech32": "mezovalconspub1zcjduepqv5thxepkqtrqlp8q50gwu2z69jy7dvq8jyzyl32eskzcfnhxnpmqc2cv5f",
+              "description": {
+                "moniker": "mezo-node-3",
+                "identity": "",
+                "website": "",
+                "security_contact": "",
+                "details": ""
+              }
+            },
+            {
+              "operator_bech32": "mezovaloper120mkxfvkx2t72quddqh92md2dp7csq4wmmzy7x",
+              "cons_pub_key_bech32": "mezovalconspub1zcjduepq6n8yrpds6fckj40ffhpyha6u44sg3egalmqlcegdzeccdad9489qxpmlqs",
               "description": {
                 "moniker": "mezo-node-4",
                 "identity": "",
@@ -277,10 +250,21 @@ data:
               }
             },
             {
-              "operator_bech32": "mezovaloper14rrdcku8hgxp2xfxugkdxkdllnfrr4la90wzce",
-              "cons_pub_key_bech32": "mezovalconspub1zcjduepqugeq4n093tskaj7gevypcl5cpyce7z6hjwu0re5a6l84cfczu6ssl9jxu3",
+              "operator_bech32": "mezovaloper1xqurxvvh8z2xpj6wltq0tajxm47xnv7qfc4wrp",
+              "cons_pub_key_bech32": "mezovalconspub1zcjduepqkr0lyt63hqxafayvg24zuvmedns7w7zt05ug79zgrca4tuq6v4zs4f74dd",
               "description": {
-                "moniker": "mezo-node-3",
+                "moniker": "mezo-node-1",
+                "identity": "",
+                "website": "",
+                "security_contact": "",
+                "details": ""
+              }
+            },
+            {
+              "operator_bech32": "mezovaloper12wsc0qgyfwwfj3wrlpgm9q3lmndl2m4qgq0hua",
+              "cons_pub_key_bech32": "mezovalconspub1zcjduepqujpmsdk9tlly48qpnkgveqxrtnskma3vt8ktn3whuudhx9wu26lqsul36g",
+              "description": {
+                "moniker": "mezo-node-0",
                 "identity": "",
                 "website": "",
                 "security_contact": "",
@@ -290,5 +274,29 @@ data:
           ]
         },
         "upgrade": {}
+      },
+      "consensus": {
+        "params": {
+          "block": {
+            "max_bytes": "22020096",
+            "max_gas": "10000000"
+          },
+          "evidence": {
+            "max_age_num_blocks": "100000",
+            "max_age_duration": "172800000000000",
+            "max_bytes": "1048576"
+          },
+          "validator": {
+            "pub_key_types": [
+              "ed25519"
+            ]
+          },
+          "version": {
+            "app": "0"
+          },
+          "abci": {
+            "vote_extensions_enable_height": "0"
+          }
+        }
       }
     }

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-0.yaml
@@ -106,8 +106,8 @@ spec:
               mountPath: /mnt/.mezod/keyring-file/mezo-node-0-key.info
               subPath: mezo-node-0-key.info
             - name: mezo-node-keystore
-              mountPath: /mnt/.mezod/keyring-file/6b1fa8e56fdfc0affa4007473a92c3afad6d8c9f.address
-              subPath: 6b1fa8e56fdfc0affa4007473a92c3afad6d8c9f.address
+              mountPath: /mnt/.mezod/keyring-file/53a18781044b9c9945c3f851b2823fdcdbf56ea0.address
+              subPath: 53a18781044b9c9945c3f851b2823fdcdbf56ea0.address
           command:
             - mezod
             - start

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-1.yaml
@@ -106,8 +106,8 @@ spec:
               mountPath: /mnt/.mezod/keyring-file/mezo-node-1-key.info
               subPath: mezo-node-1-key.info
             - name: mezo-node-keystore
-              mountPath: /mnt/.mezod/keyring-file/96e91fb1e5ad6c21a06bbb50c51bba005b8dcdd4.address
-              subPath: 96e91fb1e5ad6c21a06bbb50c51bba005b8dcdd4.address
+              mountPath: /mnt/.mezod/keyring-file/3038333197389460cb4efac0f5f646dd7c69b3c0.address
+              subPath: 3038333197389460cb4efac0f5f646dd7c69b3c0.address
           command:
             - mezod
             - start

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-2.yaml
@@ -106,8 +106,8 @@ spec:
               mountPath: /mnt/.mezod/keyring-file/mezo-node-2-key.info
               subPath: mezo-node-2-key.info
             - name: mezo-node-keystore
-              mountPath: /mnt/.mezod/keyring-file/b736571f4bdf5289a483ba05f2cbb1f040a63049.address
-              subPath: b736571f4bdf5289a483ba05f2cbb1f040a63049.address
+              mountPath: /mnt/.mezod/keyring-file/963834bcfe318b90427b19ff010fbfe0709fcd4c.address
+              subPath: 963834bcfe318b90427b19ff010fbfe0709fcd4c.address
           command:
             - mezod
             - start

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-3.yaml
@@ -106,8 +106,8 @@ spec:
               mountPath: /mnt/.mezod/keyring-file/mezo-node-3-key.info
               subPath: mezo-node-3-key.info
             - name: mezo-node-keystore
-              mountPath: /mnt/.mezod/keyring-file/a8c6dc5b87ba0c151926e22cd359bffcd231d7fd.address
-              subPath: a8c6dc5b87ba0c151926e22cd359bffcd231d7fd.address
+              mountPath: /mnt/.mezod/keyring-file/93d17369a5b6f2335d13a76e354fb786889e7f3d.address
+              subPath: 93d17369a5b6f2335d13a76e354fb786889e7f3d.address
           command:
             - mezod
             - start

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-4.yaml
@@ -106,8 +106,8 @@ spec:
               mountPath: /mnt/.mezod/keyring-file/mezo-node-4-key.info
               subPath: mezo-node-4-key.info
             - name: mezo-node-keystore
-              mountPath: /mnt/.mezod/keyring-file/99d1959700dfe4d2dc1fdc758828eeed72ef57d8.address
-              subPath: 99d1959700dfe4d2dc1fdc758828eeed72ef57d8.address
+              mountPath: /mnt/.mezod/keyring-file/53f76325963297e5038d682e556daa687d8802ae.address
+              subPath: 53f76325963297e5038d682e556daa687d8802ae.address
           command:
             - mezod
             - start

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-config.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-config.yaml
@@ -8,6 +8,7 @@ data:
   # and cleaned up from comments and blank lines to reduce size.
   app.toml: |
     minimum-gas-prices = "10000000000abtc"
+    query-gas-limit = "0"
     pruning = "nothing"
     pruning-keep-recent = "0"
     pruning-interval = "0"
@@ -18,7 +19,6 @@ data:
     index-events = []
     iavl-cache-size = 781250
     iavl-disable-fastnode = false
-    iavl-lazy-loading = false
     app-db-backend = ""
     [telemetry]    
       service-name = ""
@@ -28,6 +28,9 @@ data:
       enable-service-label = false
       prometheus-retention-time = 0
       global-labels = []
+      metrics-sink = ""
+      statsd-addr = ""
+      datadog-hostname = ""
     [api]
       enable = false
       swagger = false
@@ -36,17 +39,7 @@ data:
       rpc-read-timeout = 10
       rpc-write-timeout = 0
       rpc-max-body-bytes = 1000000
-      enabled-unsafe-cors = false
-    [rosetta]
-      enable = false
-      address = ":8080"
-      blockchain = "app"
-      network = "network"
-      retries = 3
-      offline = false
-      enable-fee-suggestion = false
-      gas-to-suggest = 200000
-      denom-to-suggest = "uatom"    
+      enabled-unsafe-cors = false  
     [grpc]
       enable = true
       address = "0.0.0.0:9090"
@@ -54,21 +47,16 @@ data:
       max-send-msg-size = "2147483647"
     [grpc-web]
       enable = true
-      address = "0.0.0.0:9091"
-      enable-unsafe-cors = false
     [state-sync]
       snapshot-interval = 5000
       snapshot-keep-recent = 2
-    [store]
-      streamers = []
-    [streamers]
-    [streamers.file]
-      keys = ["*", ]
-      write_dir = ""
-      prefix = ""
-      output-metadata = "true"
-      stop-node-on-error = "true"
-      fsync = "false"
+    [streaming]
+    [streaming.abci]
+      keys = []
+      plugin = ""
+      stop-node-on-err = true
+    [mempool]
+      max-txs = -1  
     [evm]
       tracer = ""
       max-tx-gas-wanted = 0
@@ -103,6 +91,7 @@ data:
     broadcast-mode = "sync"
 
   config.toml: |
+    version = "0.38.9"
     proxy_app = "tcp://0.0.0.0:26658"
     moniker = ""
     fast_sync = true
@@ -132,6 +121,7 @@ data:
       experimental_websocket_write_buffer_size = 200
       experimental_close_on_slow_client = false
       timeout_broadcast_tx_commit = "10s"
+      max_request_batch_size = 10
       max_body_bytes = 1000000
       max_header_bytes = 1048576
       tls_cert_file = ""
@@ -141,8 +131,7 @@ data:
       laddr = "tcp://0.0.0.0:26656"
       external_address = ""
       seeds = ""
-      persistent_peers = "4cd7d1334c93e306d2bcfe5d0182538a96f62311@mezo-node-0.test.mezo.org:26656,38116cb51a36dd921512300ce754b72b6dfef0f1@mezo-node-1.test.mezo.org:26656,a52bb0b8179c23d88ee7b84c455235115dcf8d57@mezo-node-2.test.mezo.org:26656,e616fcf7d8d85a3819ae14f4cafffe019806e6b8@mezo-node-3.test.mezo.org:26656,d6a4fc2b0dda4123853a0c4cad5ccd13e646b60e@mezo-node-4.test.mezo.org:26656"
-      upnp = false
+      persistent_peers = "e12010891c8e866caebf0a2af011396ed573485b@mezo-node-0.test.mezo.org:26656,c4b71ef1b07ec1a8bf157256974e11b5c065cd0d@mezo-node-1.test.mezo.org:26656,25440691ae65ebb8547817ee0a22eba75d56dfc7@mezo-node-2.test.mezo.org:26656,863e2707098d989aa1af814a6e2347f204e3a8a9@mezo-node-3.test.mezo.org:26656,aff788a263b957249765b8bb252e2bf6ba58a48d@mezo-node-4.test.mezo.org:26656"    
       addr_book_file = "config/addrbook.json"
       addr_book_strict = true
       max_num_inbound_peers = 240
@@ -160,8 +149,9 @@ data:
       handshake_timeout = "20s"
       dial_timeout = "3s"
     [mempool]
-      version = "v0"
+      type = "flood"
       recheck = true
+      recheck_timeout = "1s"
       broadcast = true
       wal_dir = ""
       size = 10000
@@ -170,8 +160,8 @@ data:
       keep-invalid-txs-in-cache = false
       max_tx_bytes = 1048576
       max_batch_bytes = 0
-      ttl-duration = "0s"
-      ttl-num-blocks = 0
+      experimental_max_gossip_connections_to_persistent_peers = 0
+      experimental_max_gossip_connections_to_non_persistent_peers = 0
     [statesync]
       enable = false
       rpc_servers = ""
@@ -182,7 +172,7 @@ data:
       temp_dir = ""
       chunk_request_timeout = "10s"
       chunk_fetchers = "4"
-    [fastsync]
+    [blocksync]
       version = "v0"
     [consensus]
       wal_file = "data/cs.wal/wal"
@@ -192,7 +182,7 @@ data:
       timeout_prevote_delta = "500ms"
       timeout_precommit = "1s"
       timeout_precommit_delta = "500ms"
-      timeout_commit = "5s"
+      timeout_commit = "3s"
       double_sign_check_height = 0
       skip_timeout_commit = false
       create_empty_blocks = true
@@ -209,4 +199,4 @@ data:
       prometheus_listen_addr = ":26660"
       max_open_connections = 3
       namespace = "cometbft"
-
+      

--- a/scripts/public-testnet.sh
+++ b/scripts/public-testnet.sh
@@ -115,7 +115,7 @@ TMP_GENESIS=$GLOBAL_GENESIS_HOMEDIR/config/tmp_genesis.json
 # [Modification 1]: Set abtc as the token denomination for relevant Cosmos SDK modules.
 jq '.app_state["crisis"]["constant_fee"]["denom"]="abtc"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 # [Modification 2]: Set non-zero gas limit in genesis
-jq '.consensus_params["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.consensus["params"]["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 # [Modification 3]: Set the first node's address as the initial PoA owner.
 POA_OWNER=${NODE_ADDRESSES[0]}
 jq '.app_state["poa"]["owner"]="'"$POA_OWNER"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"


### PR DESCRIPTION
Here we adjust testnet deployment artifacts to the recent changes and upgraded version of Cosmos SDK. The Kubernetes manifests were updated based on a new run of the `scripts/public-testnet.sh` generator script.