### PR TITLE
Go version update in Docker-based localnet

### DIFF
--- a/networks/local/mezo/Dockerfile
+++ b/networks/local/mezo/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as build-env
+FROM golang:1.22.6-bullseye AS build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-linux
 
 # Final image
-FROM golang:1.20-bullseye as final
+FROM golang:1.22.6-bullseye as final
 
 WORKDIR /
 


### PR DESCRIPTION
### Introduction

The Docker-based localnet stopped working some time ago.
The version used in the dockerfile was too old.

### Changes
- Updated the version of Go

### Testing
- Run Docker-based localnet:
```
localnet-docker-build
localnet-docker-start
localnet-docker-show-logstream
localnet-docker-stop
```

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
