### PR TITLE
Fix for spendable amount error

### DIFF
--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -49,7 +49,7 @@ func (k *Keeper) GetAccount(ctx sdk.Context, addr common.Address) *statedb.Accou
 	balance := k.GetBalance(ctx, addr)
 
 	// Use conversion to bytes rather than uint64 to avoid an overflow error.
-	acct.Balance = uint256.NewInt(0).SetBytes(balance.Bytes())
+	acct.Balance = new(uint256.Int).SetBytes(balance.Bytes())
 
 	return acct
 }


### PR DESCRIPTION
Refs: https://github.com/mezo-org/mezod/issues/274

### Introduction

This PR contains a fix for the error that occurs when transferring funds between accounts.
The error would occur when a high amount of funds (close to `100000000000000000000000000`) was transferred from one account to another account.
The issue was the result of an overflow during a conversion between a standard big int from `math/big` and one from `github.com/holiman/uint256`.

Other, similar conversions were checked, but they seem to be correct.

### Changes
- Replaced creation of an int via the `uint64` conversion with `byte` conversion.

### Testing

- Set up a local net of 4 nodes
```
make localnet-bin-clean
make localnet-bin-init
make localnet-bin-start // 4 times
```

- Set up local test accounts in `mezod/precompile/hardhat`:
```
./copy-interfaces.sh
npx hardhat run scripts/localhost-keys.ts | npx hardhat vars set MEZO_ACCOUNTS
```

- List the accounts and transfer almost the entire balance of one account to another account.
The transferred amount should be high (higher than max `uint64` to cause an overflow), but less than the entire balance of the account as we need to pay for gas.
For example, `99999999999999000000000000` when the account balance is `100000000000000000000000000`.
```
npx hardhat --network localhost run scripts/accounts.ts
npx hardhat btcToken:balanceOf --account 0xeffa74b83d28D2dD3F9173321BbB7b257fc89fF0
npx hardhat btcToken:transfer --signer 0xeffa74b83d28D2dD3F9173321BbB7b257fc89fF0 --to 0xb47Ce51DB2A3A1D23E7C7F62906b3e64Dd0877FD --value 99999999999999000000000000
```

Notice that if the transferred amount is very close to the the account's balance we still may get the "spendable balance ... is smaller than ..." error, but the spendable amount listed should always be correct. If such error occurs, a smaller amount must be transferred.

- Check the balances of accounts again to see if the transfer was successful.
```
npx hardhat btcToken:balanceOf --account 0xeffa74b83d28D2dD3F9173321BbB7b257fc89fF0
```

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [X] Updated relevant unit and integration tests
- [X] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
