### PR TITLE
Deploy Ethereum sidecar on `mezo-staging`

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/README.md
+++ b/infrastructure/kubernetes/mezo-staging/README.md
@@ -50,7 +50,7 @@ cluster as secrets:
   Custom `generate-mezo-node-keystore.sh` script is used to inject those secrets 
   directly into the Kubernetes cluster.
 
-### Stateful sets and services
+### Stateful sets
 
 Initial Mezo validators were defined as Kubernetes `mezo-node-<index>` stateful sets. 
 They mount the aforementioned config maps and secrets as volumes and map their 
@@ -68,3 +68,13 @@ Use `kubectl` to create the stateful sets (and services) or apply changes:
 ```shell
 kubectl apply -f mezo-node-<index>.yaml
 ```
+
+### Stateless deployments
+
+In addition to the Mezo validators, the `mezo-staging` cluster hosts the following 
+stateless deployments:
+- `ethereum-sidecar`: A sidecar process being the BTC bridge's pillar on Ethereum. 
+  It listens to `AssetsLocked` events emitted by the `BitcoinBridge` contract
+  and exposes them to the Mezo validators via a gRPC API. It uses the same
+  Docker image as the validators but is started with a different CLI command.
+  It is exposed through a ClusterIP service so, only cluster resources can access it.

--- a/infrastructure/kubernetes/mezo-staging/ethereum-sidecar.yaml
+++ b/infrastructure/kubernetes/mezo-staging/ethereum-sidecar.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ethereum-sidecar
+  namespace: default
+  labels:
+    app: mezo
+    type: ethereum-sidecar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mezo
+      type: ethereum-sidecar
+  template:
+    metadata:
+      labels:
+        app: mezo
+        type: ethereum-sidecar
+    spec:
+      containers:
+        - name: ethereum-sidecar
+          image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-internal/mezo-node:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 250m
+              memory: 128Mi
+          ports:
+            - name: server
+              containerPort: 7500
+          command:
+            - mezod
+            - ethereum-sidecar
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ethereum-sidecar
+  namespace: default
+  labels:
+    app: mezo
+    type: ethereum-sidecar
+spec:
+  type: ClusterIP
+  ports:
+    - name: server
+      port: 7500
+      targetPort: server
+  selector:
+    app: mezo
+    type: ethereum-sidecar

--- a/infrastructure/kubernetes/mezo-staging/mezo-node-config.yaml
+++ b/infrastructure/kubernetes/mezo-staging/mezo-node-config.yaml
@@ -82,6 +82,9 @@ data:
     [tls]
       certificate-path = ""
       key-path = ""
+    [ethereum-sidecar.client]
+      server-address = "ethereum-sidecar.default.svc.cluster.local:7500"
+      request-timeout = "1s"  
 
   client.toml: |
     chain-id = "mezo_31611-1"


### PR DESCRIPTION
### Introduction

Here we add the Ethereum sidecar server to the `mezo-staging` Kubernetes cluster.

### Changes

- Added `ethereum-sidecar` Kubernetes deployment of the Ethereum sidecar server along with its service
- Changed the `mezo-node-config` config map so Mezo validators can connect to the Ethereum sidecar server
- Updated `README.md` to describe the new Ethereum sidecar component

### Testing

No local testing. This will be deployed and checked directly on the `mezo-staging` Kubernetes cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
