### PR TITLE
Run clean before the build in make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ endif
 
 BUILD_TARGETS := build install
 
-build: BUILD_ARGS=-o $(BUILDDIR)/
+build: clean
+  BUILD_ARGS=-o $(BUILDDIR)/
+
 build-linux:
 	GOOS=linux GOARCH=amd64 LEDGER_ENABLED=false $(MAKE) build
 


### PR DESCRIPTION
### Introduction

When I `make build`, I know I want to build. Probably the code changed or I want to make sure the client version I am running locally is the one I want to run.

### Changes

Before this change, `make build` was not building the client if it was already built even if there were changes to the code. Now we do a `clean` as a part of the `make build`.

### Testing

Just run `make build` and see you are always... building! ✨ 

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
