### PR TITLE
Subcommand for toml values manipulation

### DIFF
--- a/cmd/mezod/root.go
+++ b/cmd/mezod/root.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/mezo-org/mezod/cmd/mezod/genesis"
+	"github.com/mezo-org/mezod/cmd/mezod/toml"
 
 	storetypes "cosmossdk.io/store/types"
 
@@ -132,6 +133,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	a := appCreator{encodingConfig}
 	rootCmd.AddCommand(
 		genesis.NewCmd(),
+		toml.NewCmd(),
 		NewInitCmd(app.ModuleBasics),
 		escli.NewEthereumSidecarCmd(),
 		tmcli.NewCompletionCmd(rootCmd, true),

--- a/cmd/mezod/toml/get.go
+++ b/cmd/mezod/toml/get.go
@@ -1,0 +1,136 @@
+package toml
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"cosmossdk.io/tools/confix"
+	"github.com/creachadair/tomledit"
+	"github.com/creachadair/tomledit/parser"
+	"github.com/spf13/cobra"
+)
+
+const GetTOMLCmdLong = `Get a specific part of toml configuration. You should specify path of the config file to be edited, ` +
+	`section for the attribute and an attribute name.`
+
+const GetTOMLCmdExample = "toml get <path_to_config_file> -v section.test=<desired_value>"
+
+func NewGetCmd() *cobra.Command {
+	var tomlInputKeys []string
+	cmd := &cobra.Command{
+		Use:     "get",
+		Short:   "Display TOML configuration",
+		Long:    GetTOMLCmdLong,
+		Example: GetTOMLCmdExample,
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// read config file path from args
+			configFile := args[0]
+			isFile, err := isFile(configFile)
+			if args[0] == "" || !isFile || err != nil {
+				return errors.New("no valid path to file specified")
+			}
+			// load toml document using confix
+			doc, err := confix.LoadConfig(configFile)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			// parse flag for verbose toml key printing
+			printKeyFlag, err := cmd.Flags().GetBool("print-key")
+			if err != nil {
+				return err
+			}
+
+			// parse flag for printing all toml key-values
+			isAll, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
+
+			if isAll {
+				return printFullConfig(doc, printKeyFlag)
+			}
+
+			// parse toml keys to keyValueTOML data structure
+			// we use TOMLKeyValue, but all values are empty strings
+			tomlKeys := parseTOMLKeys(tomlInputKeys)
+			for _, keys := range tomlKeys {
+				results := doc.Find(keys.Key...)
+				if len(results) == 0 {
+					return fmt.Errorf("key %v not found", keys.Key)
+				} else if len(results) > 1 {
+					return fmt.Errorf("key %v is ambiguous", keys.Key)
+				}
+
+				if printKeyFlag {
+					fmt.Printf("%s\n", results[0].KeyValue)
+				} else {
+					fmt.Printf("%s\n", results[0].KeyValue.Value)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP("all", "a", false, "View all values in the configuration")
+	cmd.Flags().BoolP("print-key", "p", false, "Print keys of given values instead of raw value")
+	cmd.Flags().StringArrayVarP(&tomlInputKeys, "value", "v", []string{}, "View given values")
+
+	return cmd
+}
+
+func parseTOMLKeys(tomlValues []string) []keyValueTOML {
+	parsedTOML := []keyValueTOML{}
+
+	for _, val := range tomlValues {
+		var newTOMLEntry keyValueTOML
+
+		splitKeyStructure := strings.Split(val, ".")
+		if len(splitKeyStructure) < 1 {
+			fmt.Println("no value for reading specified")
+			return nil
+		}
+
+		// we don't need the value here
+		newTOMLEntry.Key = splitKeyStructure
+		newTOMLEntry.Value = ""
+
+		parsedTOML = append(parsedTOML, newTOMLEntry)
+	}
+
+	return parsedTOML
+}
+
+// i know passing boolean into a function isn't the best practice but now i think it's justified
+func printFullConfig(doc *tomledit.Document, printKeyFlag bool) error {
+	// Print global key-value pairs (if any) at the root level
+	if doc.Global != nil {
+		for _, item := range doc.Global.Items {
+			if keyValueItem, ok := item.(*parser.KeyValue); ok {
+				if printKeyFlag {
+					fmt.Println(keyValueItem.String())
+				} else {
+					fmt.Println(keyValueItem.Value)
+				}
+			}
+		}
+	}
+
+	// Print sectioned key-value pairs
+	for _, s := range doc.Sections {
+		fmt.Println(s.String())
+		for _, item := range s.Items {
+			if keyValueItem, ok := item.(*parser.KeyValue); ok {
+				if printKeyFlag {
+					fmt.Println(keyValueItem.String())
+				} else {
+					fmt.Println(keyValueItem.Value)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/mezod/toml/set.go
+++ b/cmd/mezod/toml/set.go
@@ -1,0 +1,189 @@
+package toml
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"cosmossdk.io/tools/confix"
+	"github.com/creachadair/tomledit"
+	"github.com/creachadair/tomledit/parser"
+	"github.com/creachadair/tomledit/transform"
+	"github.com/spf13/cobra"
+)
+
+// Pattern for detecting a valid TOML array
+//
+// Good luck with understanding this ;)
+//
+// https://regex101.com/r/45Wetr/1
+// This regex detects TOML array syntax.
+//
+// It supports depth 1 nested arrays and simple arrays:
+// [["apple","banana"],["orange"]]
+// ["apple","banana"]
+// ["apple","banana",["orange","cherry"]]
+//
+// This is not supported for example (depth 2 nested array):
+// ["apple","banana",["orange","cherry",["apple","banana"]]]
+const tomlArrayPattern = `^\[\s*(?:(?:\[(?:[^\[\]]*)\])|(?:[^\[\],]+))\s*(?:,\s*(?:(?:\[(?:[^\[\]]*)\])|(?:[^\[\],]+))\s*)*\]$`
+
+const SetTOMLCmdLong = `Set a specific part of toml configuration. You should specify path of the config file to be edited, ` +
+	`section for the attribute, attribute name and desired value`
+
+const SetTOMLCmdExample = "toml set <path_to_config_file> -v section.test=<desired_value> -v section.test2='[\"example\",\"array\"]'"
+
+func NewSetCmd() *cobra.Command {
+	var tomlValues []string
+	var FlagStdOut bool
+
+	cmd := &cobra.Command{
+		Use:     "set",
+		Short:   "Edit TOML configuration",
+		Long:    SetTOMLCmdLong,
+		Example: SetTOMLCmdExample,
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			// read config file path from args
+			configFile := args[0]
+			isFile, err := isFile(configFile)
+			if args[0] == "" || !isFile || err != nil {
+				return errors.New("no valid path to file specified")
+			}
+
+			// map []string arguments from command line to custom TOMLKeyValue struct
+			parsedTomlFromUser := parseTOMLKeyValues(tomlValues)
+
+			// generate a transform plan for each value from config we want to change
+			transformPlans := generateTransformPlans(parsedTomlFromUser, configFile)
+
+			// if output path is set to empty string, the expected change will only be printed to stdout
+			outputPath := configFile
+			if FlagStdOut {
+				outputPath = ""
+			}
+
+			// for our use case set skipValidate arg to true, otherwise some config files could not be edited (cometbft config)
+			resultOfTransform := transformValues(context.Background(), transformPlans, configFile, outputPath, true)
+
+			return resultOfTransform
+		},
+	}
+
+	cmd.Flags().StringArrayVarP(&tomlValues, "value", "v", []string{}, "Define values to display/edit their values.")
+	cmd.Flags().BoolVar(&FlagStdOut, "stdout", false, "print the updated config to stdout")
+
+	return cmd
+}
+
+// wrapper function for confix.Upgrade that edits config file in-place
+func transformValues(ctx context.Context, plans []transform.Plan, configPath string, outputPath string, skipValidate bool) error {
+	var result error
+	for _, plan := range plans {
+		fmt.Println(plan[0].Desc)
+		result = confix.Upgrade(ctx, plan, configPath, outputPath, skipValidate)
+		if result != nil {
+			fmt.Println("result contains errors: ", result)
+			return result
+		}
+		fmt.Println("plan successfully applied")
+	}
+
+	return result
+}
+
+// function for checking if string has TOML array-like format (using regex)
+func isValidTOMLArray(input string) bool {
+	// Compile the regex pattern
+	re := regexp.MustCompile(tomlArrayPattern)
+	// Use MatchString to check if the input matches the pattern
+	return re.MatchString(input)
+}
+
+// generate array of plans ([]transform.Plan) that define TOML variable change logic
+func generateTransformPlans(tomlKeyValues []keyValueTOML, filename string) []transform.Plan {
+	transformPlans := []transform.Plan{}
+
+	for _, keyvalue := range tomlKeyValues {
+		key, value := keyvalue.Key, keyvalue.Value
+		plan := transform.Plan{
+			{
+				Desc: fmt.Sprintf("update %s = %s in %s", strings.Join(key, "."), value, filename),
+				T: transform.Func(func(_ context.Context, doc *tomledit.Document) error {
+					// depending on the value, we try to convert it to various formats, default is string
+					var convertedValue string
+					if isValidTOMLArray(value) {
+						convertedValue = strings.ReplaceAll(value, "\\", "")
+					} else if intVal, err := strconv.Atoi(value); err == nil {
+						convertedValue = fmt.Sprintf("%d", intVal)
+					} else if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
+						convertedValue = strconv.FormatFloat(floatVal, 'f', -1, 64)
+					} else if boolVal, err := strconv.ParseBool(value); err == nil {
+						convertedValue = fmt.Sprintf("%t", boolVal)
+					} else {
+						convertedValue = fmt.Sprintf("%q", value)
+					}
+
+					// finding the section containing entries []*tomledit.Entry
+					found := doc.Find(key...)
+					switch {
+					case len(found) == 0:
+						return fmt.Errorf("key %q not found", key)
+					case len(found) > 1:
+						return fmt.Errorf("found %d definitions of key %q", len(found), key)
+					case !found[0].IsMapping():
+						return fmt.Errorf("%q is not a key-value mapping", key)
+					}
+
+					// convert value to parser.Value type - transform.InsertMapping requires it
+					parserValue, err := parser.ParseValue(convertedValue)
+					if err != nil {
+						return err
+					}
+
+					// validate transform
+					if ok := transform.InsertMapping(found[0].Section, &parser.KeyValue{
+						Block: found[0].Block,
+						Name:  found[0].Name,
+						Value: parserValue,
+					}, true); !ok {
+						return errors.New("failed to set value")
+					}
+					return nil
+				}),
+			},
+		}
+
+		transformPlans = append(transformPlans, plan)
+	}
+
+	return transformPlans
+}
+
+func parseTOMLKeyValues(tomlValues []string) []keyValueTOML {
+	parsedTOML := []keyValueTOML{}
+
+	for _, val := range tomlValues {
+		var newTOMLEntry keyValueTOML
+
+		splitKVString := strings.SplitN(val, "=", 2)
+		if len(splitKVString) != 2 {
+			fmt.Printf("Skipping invalid key-value pair: %s\n", val)
+			continue
+		}
+
+		inputKey := strings.TrimSpace(splitKVString[0])
+		inputValue := strings.TrimSpace(splitKVString[1])
+		inputKeySections := strings.Split(inputKey, ".")
+
+		newTOMLEntry.Key = inputKeySections
+		newTOMLEntry.Value = inputValue
+
+		parsedTOML = append(parsedTOML, newTOMLEntry)
+	}
+
+	return parsedTOML
+}

--- a/cmd/mezod/toml/toml.go
+++ b/cmd/mezod/toml/toml.go
@@ -1,0 +1,34 @@
+package toml
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "toml",
+		Short: "Utilities for setting/getting values in TOML configuration files",
+	}
+
+	cmd.AddCommand(
+		NewSetCmd(),
+		NewGetCmd(),
+	)
+
+	return cmd
+}
+
+type keyValueTOML struct {
+	Key   []string
+	Value string
+}
+
+func isFile(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return !info.IsDir(), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/cosmos/gogoproto v1.5.0
 	github.com/cosmos/rosetta v0.50.8
 	github.com/cpuguy83/go-md2man/v2 v2.0.3
+	github.com/creachadair/tomledit v0.0.24
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/go-kit/log v0.2.1
@@ -121,7 +122,6 @@ require (
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.0.0 // indirect
 	github.com/creachadair/atomicfile v0.3.1 // indirect
-	github.com/creachadair/tomledit v0.0.24 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect


### PR DESCRIPTION
<!-- 
Pin the issue this PR references to. Use 'Closes' instead of 'Refs' if this PR 
should close the issue when merged.
-->
Refs: #<issue_number>

<!--
Add 'Depends on' if this PR depends on another PR. Remember about setting this 
PR's base branch to the branch of the PR it depends on. Keep this PR as draft
until the PR it depends on is merged.
-->

<!--
If this PR is a work in progress, mark it as a draft. In such a case, 
the minimum is filling out the 'Introduction' section. If possible, placing a 
TODO list with planned changes and current progress in the 'Changes' section
is strongly recommended.
-->

### Introduction
> [!NOTE]
> This PR is work in progress, most of the features described are not implemented.

After some discussions with @thevops and @lukasz-zimnoch we decided to take on other mezo configuration approach which is based on declaratively overwriting mezod parameters **after mezod init** and **before mezod start**. This means: first we generate vanilla config files and then we introduce changes to them using new `mezod toml` subcommand.

<!-- 
Add a short introduction describing the context and the goal of this PR.
-->

### Changes
This PR adds a new sub-command for mezod CLI `toml` that lets users manipulate given one (or more) TOML parameters and display them.

#### Changes in `cmd` component (`cmd/mezod/toml` directory)
Added a sub-command that will take care of described changes. Subcommand will contain the following capabilities:
- [x] Specify configuration file path which is chosen for edition/viewing (adjusted for `app.toml`, `config.toml` and `client.toml`)
- [x] View chosen parts of the configuration
- [x] Edit chosen parts of the configuration

<!--
Describe specific changes made in this PR. Use level-4 headings to separate
different sections of changes. For example:

#### The new XXX component
(...)

#### Changes in the YYY module
(...)
-->


### Testing
Try to test new mezod features the commands below. Try to create different edge case scenarios for the `set` and `get` functionalities to test if the code works as intended.

#### Setting variables
```
mezod toml set /var/mezod/config/client.toml -v chain-id="test" -v keyring-backend="test"
```
Check the `/var/mezod/config/client.toml` for any updates in TOML file, if changes were applied, then the command works.

#### Getting variables
```
mezod toml get /var/mezod/config/client.toml -v chain-id -v keyring-backend
```
To test, check if the output matches current configuration.

<!--
Describe how the presented changes can be tested. Execute some basic tests
on your own and provide a short summary of the results in this section.
-->

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
