### PR TITLE
Set `aBTC` as base sub-denom of the block explorer

### DIFF
--- a/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
+++ b/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
@@ -70,6 +70,7 @@ frontend:
     NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL: wss
     NEXT_PUBLIC_API_SPEC_URL: https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
     NEXT_PUBLIC_AD_BANNER_PROVIDER: none # Disable ads
+    NEXT_PUBLIC_NETWORK_CURRENCY_WEI_NAME: aBTC
 
 stats:
   enabled: false # This won't be needed for now.


### PR DESCRIPTION
## Introduction

The BlockScout explorer uses `wei` as the default sub-denom which does not match what we have on Mezo. The base sub-denom for Mezo is aBTC (atto-BTC). 

### Changes

We set the `NEXT_PUBLIC_NETWORK_CURRENCY_WEI_NAME` env responsible for that value.

### Testing

Deployed on testnet explorer. See example transaction: https://explorer.test.mezo.org/tx/0xdea58f4b1db7e8c315f0dd1496c773b11fbded88299a000c28fbecbcc63ec348 (refresh your cache if you still see `Gwei`)

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
