### PR TITLE
Allocate more resources for the block explorer and set missing URLs

### DIFF
--- a/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
+++ b/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
@@ -39,7 +39,10 @@ blockscout:
     ETHEREUM_JSONRPC_VARIANT: geth
     ETHEREUM_JSONRPC_HTTP_URL: http://mezo-node-0.default.svc.cluster.local:8545
     ETHEREUM_JSONRPC_WS_URL: ws://mezo-node-0.default.svc.cluster.local:8546
+    ETHEREUM_JSONRPC_TRACE_URL: http://mezo-node-0.default.svc.cluster.local:8545
     ETHEREUM_JSONRPC_FALLBACK_HTTP_URL: http://mezo-node-1.default.svc.cluster.local:8545
+    ETHEREUM_JSONRPC_FALLBACK_WS_URL: ws://mezo-node-1.default.svc.cluster.local:8546
+    ETHEREUM_JSONRPC_FALLBACK_TRACE_URL: http://mezo-node-1.default.svc.cluster.local:8545
     NETWORK: Mezo
     SUBNETWORK: Testnet
     BLOCKSCOUT_PROTOCOL: https


### PR DESCRIPTION
### Introduction

So far, BlockScout API requested 0.5 CPU and 1GiB of memory with a hard limit of 1 CPU and 2GiB. Those allocations turned out to be not enough for increased load after matsnet launch. Moreover we realized some errors thrown by the indexer due to the missing trace API URL. This PR fixes all those problems.

### Changes

#### More juice assigned to the BlockScout API

We set 2 CPUs and 4GiB as requested resources and 4 CPUs and 8GiB as hard limit.

#### Trace URLs 

We set `ETHEREUM_JSONRPC_TRACE_URL` and `ETHEREUM_JSONRPC_FALLBACK_TRACE_URL` envs to point the BlockScout API to the trace API. Turns out the trace API must be set separately and without that, the indexer throws errors in the logs (failed to fetch contract codes: "URL is nil").

#### Set fallback URL for WebSocket endpoint

We take an opportunity and set `ETHEREUM_JSONRPC_FALLBACK_WS_URL` that configures a fallback JSON-RPC WebSocket URL in case the main URL is not available.

### Testing

No particular testing. Changes were deployed on the testnet cluster. No more errors are logged by the BlockScout API.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
