### PR TITLE
Echoing Moniker in get_validator_info

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,6 +182,8 @@ get_validator_info() {
 
   validator_consensus_addr="$(jq -r '.address' "${MEZOD_HOME}"/config/priv_validator_key.json | awk '{print "0x"$1}')"
   echo "Validator consensus address: ${validator_consensus_addr}"
+
+  echo "Moniker: $MEZOD_MONIKER" 
 }
 
 #


### PR DESCRIPTION
This Moniker will be needed for application submission. This way 'validator-info' flag will display all the necessary data for application submission instead of fetching it from multiple places.

### Changes

Added `echo "Moniker: $MEZOD_MONIKER"` to display in `validator-info` flag

### Testing

`./v-kit.sh validator-info`

You should see Moniker name

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [-] Updated relevant unit and integration tests
- [-] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
