### PR TITLE
Disable text ads in Blockscout

### DIFF
--- a/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
+++ b/infrastructure/helm/mezo-staging/blockscout-stack-values.yaml
@@ -79,7 +79,8 @@ frontend:
     NEXT_PUBLIC_APP_PROTOCOL: https
     NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL: wss
     NEXT_PUBLIC_API_SPEC_URL: https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
-    NEXT_PUBLIC_AD_BANNER_PROVIDER: none # Disable ads
+    NEXT_PUBLIC_AD_BANNER_PROVIDER: none # Disable banner ads
+    NEXT_PUBLIC_AD_TEXT_PROVIDER: none # Disable text ads
     NEXT_PUBLIC_NETWORK_CURRENCY_WEI_NAME: aBTC
 
 stats:


### PR DESCRIPTION
Previously only banner ads were off, leaving some text ads on e.g. transaction
detail pages. Example below.

https://explorer.test.mezo.org/tx/0x6ffd6d772ba77ee5a3dbc8f24a366d8aafe915e22849ac1060d1bcc3adc8609f

<img width="918" alt="PNG image" src="https://github.com/user-attachments/assets/292e767a-ab9e-405a-b0eb-91bf7148186a">

### Author's checklist

- [x] Provided the appropriate description of the pull request
- ~~Updated relevant unit and integration tests~~
- ~~Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)~~
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
