### PR TITLE
Setting p2p port as env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,8 @@ customize_configuration() {
   #
   mezod toml set "$CONFIG_FILE" \
     -v "moniker=${MEZOD_MONIKER}" \
-    -v "p2p.laddr=tcp://0.0.0.0:${MEZOD_P2P_PORT}" \
-    -v "p2p.external_address=${PUBLIC_IP}:${MEZOD_P2P_PORT}" \
+    -v "p2p.laddr=tcp://0.0.0.0:${MEZOD_PORT_P2P}" \
+    -v "p2p.external_address=${PUBLIC_IP}:${MEZOD_PORT_P2P}" \
     -v "rpc.laddr=tcp://0.0.0.0:26657" \
     -v "instrumentation.prometheus=true" \
     -v "instrumentation.prometheus_listen_addr=0.0.0.0:26660"


### PR DESCRIPTION
References https://linear.app/thesis-co/issue/ENG-415/support-custom-p2p-ports-in-the-validator-kit

### Introduction

Some of the validators might set a custom p2p port in their configs. We need to allow setting that port in the *.env file

### Changes

Setting `${P2P_PORT}` in `config.toml` for:
- p2p.laddr
- p2p.external_address

### Testing

Should be tested in the validator-kit

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [-] Updated relevant unit and integration tests / n/a
- [-] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) n/a
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
