### PR TITLE
Bump mezo-staging nodes to v0.3.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -10,7 +10,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 0.0.8
+    version: 0.0.9
     values:
       - ./values/mezo-node-common.yaml
       - ./values/mezo-node-0.yaml
@@ -19,7 +19,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 0.0.8
+    version: 0.0.9
     values:
       - ./values/mezo-node-common.yaml
       - ./values/mezo-node-1.yaml
@@ -28,7 +28,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 0.0.8
+    version: 0.0.9
     values:
       - ./values/mezo-node-common.yaml
       - ./values/mezo-node-2.yaml
@@ -37,7 +37,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 0.0.8
+    version: 0.0.9
     values:
       - ./values/mezo-node-common.yaml
       - ./values/mezo-node-3.yaml
@@ -46,7 +46,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 0.0.8
+    version: 0.0.9
     values:
       - ./values/mezo-node-common.yaml
       - ./values/mezo-node-4.yaml


### PR DESCRIPTION
>[!CAUTION]
> DO NOT MERGE NOR APPLY THESE CHANGES BEFORE THE [HARD FORK BLOCK](https://explorer.test.mezo.org/block/countdown/1093500)

Closes: https://linear.app/thesis-co/issue/ENG-410/execute-connect-oracle-rollout-on-matsnet

### Introduction

Here we upgrade our Mezo testnet validators running on the `mezo-staging` cluster to `v0.3.0-rc0`. This version is supposed to run after the planned hard fork that will roll out the Connect price oracle on Mezo testnet.

### Changes

We change the `mezo-org/mezod` chart version from `0.0.8` (`mezod v0.2.0-rc3`) to `0.0.9` (`mezod v0.3.0-rc`) for all 5 Mezo validator nodes running on the `mezo-staging` cluster.

### Testing

Check the diff using `helmfile diff`. Roll out using `helmfile apply`.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
