### PR TITLE
Remove genesis validation from the entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,12 +45,6 @@ init_configuration() {
   echo "Configuration initialized!"
 }
 
-validate_genesis() {
-  echo "Validate genesis..."
-  mezod genesis validate --home="${MEZOD_HOME}"
-  echo "Genesis validated!"
-}
-
 customize_configuration() {
   echo "Backup original configuration..."
   test -f "${CLIENT_CONFIG_FILE}.bak" || cat "$CLIENT_CONFIG_FILE" > "${CLIENT_CONFIG_FILE}.bak"
@@ -182,14 +176,12 @@ case "$1" in
     ;;
   config)
     init_configuration
-    validate_genesis
     customize_configuration
     exit 0
     ;;
   *)
     init_keyring
     init_configuration
-    validate_genesis
     customize_configuration
     init_genval
     get_validator_info


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/ENG-410/execute-connect-oracle-rollout-on-matsnet

### Introduction

Genesis validation causes problems on v0.3.0-rc0. This is because v0.3.0-rc0 contains Connect modules that are not available in the initial genesis file. Moreover, this validation is not strictly needed for a running chain. That said, we are removing it.

### Changes

We removed the `validate_genesis` function from the `entrypoint.sh` file. This change affects the Docker and Helm variants of the V-Kit.

### Testing

No particular local testing. Changes already rolled out on testnet.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
