### PR TITLE
Implement batched events fetch in the Ethereum sidecar

### DIFF
--- a/ethereum/sidecar/cli/ethereum_sidecar.go
+++ b/ethereum/sidecar/cli/ethereum_sidecar.go
@@ -16,6 +16,7 @@ func NewEthereumSidecarCmd() *cobra.Command {
 	defaultServerAddress := "0.0.0.0:7500"
 	defaultServerEthereumNodeAddress := "ws://127.0.0.1:8546"
 	defaultServerEthereumNetwork := ethconfig.Sepolia
+	defaultServerBatchSize := uint64(1000)
 
 	cmd := &cobra.Command{
 		Use:   "ethereum-sidecar",
@@ -30,6 +31,7 @@ func NewEthereumSidecarCmd() *cobra.Command {
 			defaultServerAddress,
 			defaultServerEthereumNodeAddress,
 			defaultServerEthereumNetwork.String(),
+			defaultServerBatchSize,
 		))
 
 	return cmd
@@ -44,6 +46,7 @@ func runEthereumSidecar(cmd *cobra.Command, _ []string) error {
 	grpcAddress, _ := cmd.Flags().GetString(FlagServerAddress)
 	ethNodeAddress, _ := cmd.Flags().GetString(FlagServerEthereumNodeAddress)
 	network, _ := cmd.Flags().GetString(FlagServerNetwork)
+	batchSize, _ := cmd.Flags().GetUint64(FlagServerBatchSize)
 
 	clientCtx, err := client.GetClientQueryContext(cmd)
 	if err != nil {
@@ -56,7 +59,7 @@ func runEthereumSidecar(cmd *cobra.Command, _ []string) error {
 		codec.NewProtoCodec(clientCtx.InterfaceRegistry).GRPCCodec(),
 	)
 
-	sidecar.RunServer(grpcAddress, ethNodeAddress, network, logger)
+	sidecar.RunServer(logger, grpcAddress, ethNodeAddress, network, batchSize)
 
 	return nil
 }

--- a/ethereum/sidecar/cli/flags.go
+++ b/ethereum/sidecar/cli/flags.go
@@ -10,12 +10,14 @@ const (
 	FlagServerAddress             = "ethereum-sidecar.server.address"
 	FlagServerEthereumNodeAddress = "ethereum-sidecar.server.ethereum-node-address"
 	FlagServerNetwork             = "ethereum-sidecar.server.network"
+	FlagServerBatchSize           = "ethereum-sidecar.server.batch-size"
 )
 
 func NewFlagSetEthereumSidecar(
 	defaultServerAddress,
 	defaultServerEthereumNodeAddress,
 	defaultServerNetwork string,
+	defaultServerBatchSize uint64,
 ) *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
@@ -43,6 +45,12 @@ func NewFlagSetEthereumSidecar(
 				"Possible values: mainnet | sepolia | developer "+
 				"If not set, sepolia is used by default",
 		),
+	)
+
+	fs.Uint64(
+		FlagServerBatchSize,
+		defaultServerBatchSize,
+		"Size of the block batch for fallback AssetsLocked events lookup",
 	)
 
 	return fs


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/ENG-480/add-pagination-to-events-observation-in-the-ethereum-sidecar

### Introduction

More than 10k `AssetsLocked` events were produced on Mezo testnet in the last 30 days. Ethereum sidecars scan the last 30-day window at startup to load past events. However, instances attached to popular providers like Alchemy/Infura stumble upon `eth_getLogs` response size limits imposed by these providers. As a result, those sidecar instances are not able to start.

To overcome that problem, we add a fallback logic that fetches events in batches. The batch size is configurable using the
`--ethereum-sidecar.server.batch-size` flag whose default value is 1000.

### Changes

#### The new `fetchABIEvents` private method

The mentioned method was added to the Ethereum sidecar server implementation. Its job is to attempt to fetch `AssetsLocked` from the desired block range in one shot and fall back to the batched fetch in case of an error. Batched fetch tries to split the desired block range to `N` batches of size `S`. The size `S` is 1000 by default but is configurable using the new `--ethereum-sidecar.server.batch-size` flag.

### Testing

Do `make bindings && make build` to build the `mezod` binary. Run the sidecar against Sepolia with Alchemy/Infura as provider and confirm that the displayed logs are correct.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
