### PR TITLE
Bump `mezo-staging` nodes to V-Kit Helm chart 1.0.1

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.0
+    version: 1.0.1
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.0
+    version: 1.0.1
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.0
+    version: 1.0.1
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.0
+    version: 1.0.1
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.0
+    version: 1.0.1
     labels:
       type: validator
     values:


### PR DESCRIPTION
### Introduction

We released a new Helm chart 1.0.1 that bumps the `mezod` image to `v0.3.0-rc2` for the client and for Ethereum sidecar. This release contains some improvements we want to pull in.

### Changes

We changed the V-Kit chart version in the `helmfile.yaml`. That bumps up our 5 testnet nodes.

### Testing

No local testing. Already deployed on testnet.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
