### PR TITLE
Add --keyring-dir flag to mezod start and mezod init

### DIFF
--- a/cmd/mezod/init.go
+++ b/cmd/mezod/init.go
@@ -204,6 +204,11 @@ func NewInitCmd(mbm module.BasicManager) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().String(
+		flags.FlagKeyringDir,
+		"",
+		"The client Keyring directory; if omitted, the default 'home' directory will be used",
+	)
 	cmd.Flags().Bool(
 		flagIgnorePredefined,
 		false,

--- a/server/start.go
+++ b/server/start.go
@@ -168,6 +168,7 @@ which accepts a path for the resulting pprof file.
 		},
 	}
 
+	cmd.Flags().String(flags.FlagKeyringDir, "", "The client Keyring directory; if omitted, the default 'home' directory will be used")
 	cmd.Flags().String(flags.FlagHome, opts.DefaultNodeHome, "The application home directory")
 	cmd.Flags().Bool(srvflags.WithTendermint, true, "Run abci app embedded in-process with tendermint")
 	cmd.Flags().String(srvflags.Address, "tcp://0.0.0.0:26658", "Listen address")


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/ENG-150/add-keyring-dir-flag-to-mezod-start-and-mezod-init

### Introduction

The --keyrind-dir flag was available only to the keys subcommand, this adds it also to the start and init subcommand of the monzod binarygi

### Changes

The persistent flags --keyring-dir havre been added to the init and start subcommand.

### Testing

Not sure this is relevant here. but code compiles and run locally.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
