### PR TITLE
Bump Mezo testnet nodes to v0.4.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.1
+    version: 1.1.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.1
+    version: 1.1.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.1
+    version: 1.1.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.1
+    version: 1.1.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.0.1
+    version: 1.1.0
     labels:
       type: validator
     values:

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -6,7 +6,8 @@ env:
   PUBLIC_IP: "34.134.59.27" # mezo-staging-node-0-external-ip
   MEZOD_MONIKER: "mezo-node-0"
 
-secret: "mezo-node-0" # created manually
+secrets:
+  credentials: "mezo-node-0" # created manually
 
 storage:
   className: "premium-rwo"

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -6,7 +6,8 @@ env:
   PUBLIC_IP: "104.198.64.215" # mezo-staging-node-1-external-ip
   MEZOD_MONIKER: "mezo-node-1"
 
-secret: "mezo-node-1" # created manually
+secrets:
+  credentials: "mezo-node-1" # created manually
 
 storage:
   className: "premium-rwo"

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -6,7 +6,8 @@ env:
   PUBLIC_IP: "104.197.235.84" # mezo-staging-node-2-external-ip
   MEZOD_MONIKER: "mezo-node-2"
 
-secret: "mezo-node-2" # created manually
+secrets:
+  credentials: "mezo-node-2" # created manually
 
 storage:
   className: "premium-rwo"

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -6,7 +6,8 @@ env:
   PUBLIC_IP: "34.170.77.124" # mezo-staging-node-3-external-ip
   MEZOD_MONIKER: "mezo-node-3"
 
-secret: "mezo-node-3" # created manually
+secrets:
+  credentials: "mezo-node-3" # created manually
 
 storage:
   className: "premium-rwo"

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -6,7 +6,8 @@ env:
   PUBLIC_IP: "34.70.22.86" # mezo-staging-node-4-external-ip
   MEZOD_MONIKER: "mezo-node-4"
 
-secret: "mezo-node-4" # created manually
+secrets:
+  credentials: "mezo-node-4" # created manually
 
 storage:
   className: "premium-rwo"


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/ENG-542/the-v040-matsnet-fork

### Introduction

Here we bump the Mezo testnet nodes we host to the new `mezod` version `v0.4.0-rc0`.

### Changes

We do the mentioned action by bumping the V-Kit Helm chart version to `v1.1.0`. Under the hood, this chart resolves to `mezod` `v0.4.0-rc0`. We are also adjusting `values.yaml` to the changes made in the chart itself. Specifically the key `secret` became `secrets.credentials`.

### Testing

No local testing. Already deployed on our cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
