### PR TITLE
Enable EVM indexer on Mezo node powering the block explorer

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -5,6 +5,7 @@ env:
   NETWORK: testnet
   PUBLIC_IP: "34.134.59.27" # mezo-staging-node-0-external-ip
   MEZOD_MONIKER: "mezo-node-0"
+  MEZOD_JSON_RPC_ENABLE_INDEXER: true
 
 secrets:
   credentials: "mezo-node-0" # created manually


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/ENG-542/the-v040-matsnet-fork

### Introduction

Here we enable the optional EVM indexer for the `mezo-node-0` Mezo testnet node that feeds the BlockScout explorer with data. Thanks to that, we can trigger the EVM observability for the BTC bridge and see bridging actions as transactions against the `AssetsBridge` precompile ([`0x7B7C000000000000000000000000000000000012`](https://explorer.test.mezo.org/address/0x7B7C000000000000000000000000000000000012?tab=txs)).

### Changes

We are setting the `MEZOD_JSON_RPC_ENABLE_INDEXER: true` env variable in the `values.yaml` file for `mezo-node-0`. The underlying Vyper config framework translates this env to the `json-rpc.enable-indexer` config parameter defined in the `app.toml` file. The mentioned parameter enables the optional EVM indexer. A visual sign of that indexer working is a new `evmindexer.db` GoLevel database visible in the node's `data` directory.

### Testing

No particular local testing. This change was already deployed on our `mezo-staging` Kubernetes cluster. You can execute `helmfile diff` from within `infrastructure/kubernetes/mezo-staging` to double confirm that.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
