### PR TITLE
Removed printing of ETH client URL

### DIFF
--- a/ethereum/ethereum.go
+++ b/ethereum/ethereum.go
@@ -41,35 +41,27 @@ func Connect(
 ) {
 	parsedURL, err := url.Parse(config.URL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL provided: [%s]", config.URL)
+		return nil, fmt.Errorf("invalid URL provided for ETH client")
 	}
 
 	// Enforce the connection via WebSockets as other protocols may not support
 	// subscriptions.
 	if parsedURL.Scheme != "wss" && parsedURL.Scheme != "ws" {
 		return nil, fmt.Errorf(
-			"ETH client requires a WebSocket URL starting with wss:// "+
-				"(recommended) or ws://. Provided: [%s]",
-			config.URL,
+			"ETH client requires a WebSocket URL starting with wss:// " +
+				"(recommended) or ws://",
 		)
 	}
 
 	client, err := ethclient.Dial(config.URL)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"error connecting to Ethereum Server: %s [%v]",
-			config.URL,
-			err,
-		)
+		return nil, fmt.Errorf("error connecting to ETH Server: [%v]", err)
 	}
 
 	// Double-check if subscriptions are supported.
 	if !client.Client().SupportsSubscriptions() {
 		client.Close()
-		return nil, fmt.Errorf(
-			"ETH client for URL [%s] does not support subscriptions",
-			config.URL,
-		)
+		return nil, fmt.Errorf("ETH client does not support subscriptions")
 	}
 
 	baseChain, err := newBaseChain(ctx, config, client)


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-17/enforce-websocket-rpc-in-the-ethereum-sidecar

### Introduction
This is a follow-up to: https://github.com/mezo-org/mezod/pull/390.
When an invalid URL was provided for ETH client, we would include the URL in the error log.
This could result in accidental reveal of sensitive user information - the key embedded in the URL.
This PR removes printing of the URL provided by the user. 

### Changes
Removed printing of the provided URL.

### Testing
The same as in https://github.com/mezo-org/mezod/pull/390: start the Ethereum sidecar with a valid and invalid ETH client URL. 

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
