### PR TITLE
Bump Mezo testnet nodes to v0.5.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.1.0
+    version: 1.2.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.1.0
+    version: 1.2.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.1.0
+    version: 1.2.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.1.0
+    version: 1.2.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.1.0
+    version: 1.2.0
     labels:
       type: validator
     values:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-28/the-v050-matsnet-fork

### Introduction

Here we bump the Mezo testnet nodes we host to the new `mezod` version `v0.5.0-rc0`.

### Changes

We do the mentioned action by bumping the V-Kit Helm chart version to `v1.2.0`. Under the hood, this chart resolves to `mezod` `v0.5.0-rc0`.

### Testing

No local testing. Already deployed on our cluster.

<!--
Describe how the presented changes can be tested. Execute some basic tests
on your own and provide a short summary of the results in this section.
-->

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
