### PR TITLE
Bump Mezo testnet nodes to v0.6.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.2.0
+    version: 1.3.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.2.0
+    version: 1.3.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.2.0
+    version: 1.3.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.2.0
+    version: 1.3.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.2.0
+    version: 1.3.0
     labels:
       type: validator
     values:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-258/the-v060-matsnet-fork

### Introduction

Here we bump the Mezo testnet nodes we host to the new `mezod` version `v0.6.0-rc0`.

### Changes

We do the mentioned action by bumping the V-Kit Helm chart version to `v1.3.0`. Under the hood, this chart resolves to `mezod` `v0.6.0-rc0`.

### Testing

No local testing. Already deployed on our cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
