### PR TITLE
Change websocket error to debug

### DIFF
--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -200,7 +200,7 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 		_, mb, err := wsConn.ReadMessage()
 		if err != nil {
 			_ = wsConn.Close() // #nosec G703
-			s.logger.Error("read message error, breaking read loop", "error", err.Error())
+			s.logger.Debug("read message error, breaking read loop", "error", err.Error())
 			return
 		}
 


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-270/abnormal-ws-closure-on-our-mezo-testnet-nodes

### Introduction

The error is due to peers disconnecting without properly closing (e.g a timeout), there's no need to log this as an error to node operators. This PR changes to `Debug` to clean up logs.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests - NA
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) - NA
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
