### PR TITLE
Improvements to system tests

### DIFF
--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -2,19 +2,15 @@
 
 This project demonstrates system tests for the Mezo chain.
 
-## Run Mezo localnet
+## Run Mezo single-node localnet
 
-Clean and init localnet binaries
-
-```shell
-make localnet-bin-clean && make localnet-bin-init
-```
-
-Start 3 or 4 nodes
+Start the node using the following command:
 
 ```shell
-make localnet-bin-start
+make localnode-bin-start
 ```
+
+Wait a bit until the node's JSON-RPC server is up and running.
 
 ## Run hardhat system tests against localnet
 

--- a/tests/system/hardhat.config.ts
+++ b/tests/system/hardhat.config.ts
@@ -5,14 +5,18 @@ import { ethers } from 'ethers'
 import fs from 'fs'
 import path from 'path'
 
-// TODO: make it work with a single node
-const BUILD_DIR = '../../.localnet/'
-const COUNT = 4
+const localnodeKeySeed = (index: number) => `../../.localnode/dev${index}_key_seed.json`
+
+const KEY_SEEDS = [
+  localnodeKeySeed(0),
+  localnodeKeySeed(1),
+  localnodeKeySeed(2),
+]
 
 function getPrivKeys (): string[] {
   const keys: string[] = []
-  for (let i = 0; i < COUNT; i++) {
-    const filePath = path.resolve(`${BUILD_DIR}node${i}/mezod/key_seed.json`)
+  for (let i = 0; i < KEY_SEEDS.length; i++) {
+    const filePath = path.resolve(KEY_SEEDS[i])
     const seed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
     const pk: string = ethers.Wallet.fromPhrase(seed.secret).privateKey
     keys.push(pk)
@@ -32,7 +36,7 @@ const config: HardhatUserConfig = {
 
   networks: {
     localhost: {
-      url: 'http://localhost:8545',
+      url: 'http://127.0.0.1:8545', // localnode listens on this specific interface
       chainId: 31611,
       accounts: getPrivKeys(),
       gas: 'auto'

--- a/tests/system/test/MezoTransfers.test.ts
+++ b/tests/system/test/MezoTransfers.test.ts
@@ -12,15 +12,17 @@ describe("MezoTransfers", function () {
   let btcErc20Token: any;
   let mezoTransfers: MezoTransfers;
   let signers: any;
+  let senderSigner: any;
   let senderAddress: string;
   let recipientAddress: string;
 
-  beforeEach(async function () {
+  const fixture = (async function () {
     await deployments.fixture();
     btcErc20Token = new hre.ethers.Contract(precompileAddress, abi, ethers.provider);
     mezoTransfers = await getDeployedContract("MezoTransfers");
     signers = await ethers.getSigners();
-    senderAddress = signers[0].address;
+    senderSigner = signers[0];
+    senderAddress = senderSigner.address;
     recipientAddress = ethers.Wallet.createRandom().address;
   });
 
@@ -30,19 +32,21 @@ describe("MezoTransfers", function () {
     let tokenAmount: any;
     let gasCost: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       tokenAmount = ethers.parseEther("8");
       const mezoTransfersAddress = await mezoTransfers.getAddress();
 
-      const transferTx = await btcErc20Token.connect(signers[0]).transfer(mezoTransfersAddress, tokenAmount);
+      const transferTx = await btcErc20Token.connect(senderSigner).transfer(mezoTransfersAddress, tokenAmount);
       await transferTx.wait();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).nativeThenERC20(recipientAddress);
+      const tx = await mezoTransfers.connect(senderSigner).nativeThenERC20(recipientAddress);
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance", async function () {
@@ -82,19 +86,21 @@ describe("MezoTransfers", function () {
     let tokenAmount: any;
     let gasCost: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       tokenAmount = ethers.parseEther("12");
       const mezoTransfersAddress = await mezoTransfers.getAddress();
 
-      const transferTx = await btcErc20Token.connect(signers[0]).transfer(mezoTransfersAddress, tokenAmount);
+      const transferTx = await btcErc20Token.connect(senderSigner).transfer(mezoTransfersAddress, tokenAmount);
       await transferTx.wait();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).erc20ThenNative(recipientAddress);
+      const tx = await mezoTransfers.connect(senderSigner).erc20ThenNative(recipientAddress);
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance", async function () {
@@ -124,15 +130,17 @@ describe("MezoTransfers", function () {
     let nativeAmount: any;
     let gasCost: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       nativeAmount = ethers.parseEther("10");
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendNative(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendNative(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance", async function () {
@@ -163,17 +171,19 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       nativeAmount = ethers.parseEther("11");
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendERC20(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendERC20(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
 
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance", async function () {
@@ -203,15 +213,17 @@ describe("MezoTransfers", function () {
     let mezoTransfersAddress: any;
     const nativeAmount = ethers.parseEther("3");
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendNativeThenERC20(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendNativeThenERC20(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -237,15 +249,17 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendERC20ThenNative(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendERC20ThenNative(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -271,15 +285,17 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendMultiple(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendMultiple(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -305,16 +321,18 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
       // Transfer
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendMultiple(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendMultiple(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -340,15 +358,17 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendMultiple(recipientAddress, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendMultiple(recipientAddress, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -373,7 +393,9 @@ describe("MezoTransfers", function () {
     const nativeAmount = 42;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
@@ -382,7 +404,7 @@ describe("MezoTransfers", function () {
       try {
         // Transfer
         await mezoTransfers
-          .connect(signers[0])
+          .connect(senderSigner)
           .receiveSendRevert(recipientAddress, { value: nativeAmount });
       } catch (error) {
         expect(error.message).to.include("revert");
@@ -413,18 +435,20 @@ describe("MezoTransfers", function () {
     const nativeAmount = ethers.parseEther("3");
     const tokenAmount = ethers.parseEther("1");
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
-      await btcErc20Token.connect(signers[0]).approve(mezoTransfersAddress, tokenAmount)
+      await btcErc20Token.connect(senderSigner).approve(mezoTransfersAddress, tokenAmount)
         .then(tx => tx.wait());
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receiveSendNativeThenPullERC20(recipientAddress, tokenAmount, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receiveSendNativeThenPullERC20(recipientAddress, tokenAmount, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -451,18 +475,20 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       mezoTransfersAddress = await mezoTransfers.getAddress();
 
-      await btcErc20Token.connect(signers[0]).approve(mezoTransfersAddress, tokenAmount)
+      await btcErc20Token.connect(senderSigner).approve(mezoTransfersAddress, tokenAmount)
         .then(tx => tx.wait());
 
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).receivePullERC20ThenNative(recipientAddress, tokenAmount, { value: nativeAmount });
+      const tx = await mezoTransfers.connect(senderSigner).receivePullERC20ThenNative(recipientAddress, tokenAmount, { value: nativeAmount });
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender native balance deduction", async function () {
@@ -489,20 +515,22 @@ describe("MezoTransfers", function () {
     let gasCost: any;
     let mezoTransfersAddress: any;
 
-    beforeEach(async function () {
+    before(async function () {
+      await fixture();
+
       amount = ethers.parseEther("2");
       mezoTransfersAddress = await mezoTransfers.getAddress();
       
-      await btcErc20Token.connect(signers[0]).approve(mezoTransfersAddress, amount)
+      await btcErc20Token.connect(senderSigner).approve(mezoTransfersAddress, amount)
         .then(tx => tx.wait());
 
       initialContractBalance = await ethers.provider.getBalance(mezoTransfersAddress);
       initialSenderBalance = await ethers.provider.getBalance(senderAddress);
       initialRecipientBalance = await ethers.provider.getBalance(recipientAddress);
 
-      const tx = await mezoTransfers.connect(signers[0]).storageStateTransition(recipientAddress, amount);
+      const tx = await mezoTransfers.connect(senderSigner).storageStateTransition(recipientAddress, amount);
       const receipt = await tx.wait();
-      gasCost = receipt.gasUsed * tx.gasPrice;
+      gasCost = receipt.gasUsed * receipt.gasPrice;
     });
 
     it("should verify sender balance deduction", async function () {


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-260/test-suite-for-evm-state-db-security-vulnerabilities-fixes

### Introduction

We recently added a system test suite stressing BTC transfers. Unfortunately, it turned out those test are a bit flaky in terms of sender's balance checks. Moreover, execution was quite long.

### Changes

Here we add the following improvements:
1. We take the gasPrice from the receipt, not from the transaction object. Because of EIP-1559, the latter may contain inaccurate values in certain cases. It's safer to use the receipt that always holds the actual price. This gasPrice has a direct impact on the sender's balance assertions.
2. We are dropping the `beforeEach` hooks in favor of `before`. With `beforeEach` the contract under test is redeployed for every single assertion. This is the direct cause of long execution time and may introduce some hazard that negatively affects the sender's balance assertions. Using `before` ensures the contract under test is deployed and executed once, as part of the setup process. In this model, assertion execution does not affect the test state in any way. A nice side effect of this change is a much faster execution of the entire suite.
3. We are adjusting system tests to run with the single-node localnet (aka localnode). This way, the test setup is quicker and easier. Thanks to that, we can reset and invoke the test multiple times in a more comfortable way. Additionally, we are facilitating potential integration of the system tests with our CI pipeline.
4. We are extracting the sender signer to a constant ensuring all cases use the same sender and that the sender address we run our assertions against is always correct.

### Testing

See `tests/system/README.md`.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
