### PR TITLE
Pre-commit configuration for Go and Markdown formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
         files: '\.go$'
         language: script
         description: "Format Go code"
+      - id: markdown-format
+        name: 'format markdown'
+        entry: /usr/bin/env bash -c 'make format-markdown'
+        files: '\.md'
+        language: script
+        description: "Format Markdown files"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,13 @@ repos:
     rev: 31903eabdb97f5a3375fb1ea419ff782de64d7e7
     hooks:
       - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: go-format
+        name: 'format go'
+        # gofumpt does not return error exit code now, so we need to workaround
+        # it with `test -z`. See https://github.com/mvdan/gofumpt/issues/114.
+        entry: /usr/bin/env bash -c 'test -z "$(make -s format)"'
+        files: '\.go$'
+        language: script
+        description: "Format Go code"

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,12 @@ format-fix:
 
 .PHONY: format format-fix
 
+format-markdown:
+	markdownlint '**/*.md' --config .markdownlint.yml
+
+format-markdown-fix:
+	markdownlint '**/*.md' --config .markdownlint.yml --fix
+
 ###############################################################################
 ###                                Protobuf                                 ###
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -216,10 +216,23 @@ lint-fix:
 
 .PHONY: lint lint-fix
 
-format:
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' | xargs gofumpt -w -l
+format: 
+	find . -name "*.go" -type f \
+	  -not -path "./vendor*" \
+	  -not -path "*.git*" \
+	  -not -path "./client/docs/statik/statik.go" \
+	  -not -name "*.pb.go" \
+	  -not -name "*.pb.gw.go" | xargs gofumpt -l
 
-.PHONY: format
+format-fix:
+	find . -name "*.go" -type f \
+	  -not -path "./vendor*" \
+	  -not -path "*.git*" \
+	  -not -path "./client/docs/statik/statik.go" \
+	  -not -name "*.pb.go" \
+	  -not -name "*.pb.gw.go" | xargs gofumpt -w -l
+
+.PHONY: format format-fix
 
 ###############################################################################
 ###                                Protobuf                                 ###

--- a/ethereum/bindings/portal/gen/abi/MezoBridge.go
+++ b/ethereum/bindings/portal/gen/abi/MezoBridge.go
@@ -204,7 +204,6 @@ func (_MezoBridge *MezoBridgeTransactorRaw) Transact(opts *bind.TransactOpts, me
 func (_MezoBridge *MezoBridgeCaller) ERC20Tokens(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "ERC20Tokens", arg0)
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -212,7 +211,6 @@ func (_MezoBridge *MezoBridgeCaller) ERC20Tokens(opts *bind.CallOpts, arg0 commo
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // ERC20Tokens is a free data retrieval call binding the contract method 0xd80687ef.
@@ -235,7 +233,6 @@ func (_MezoBridge *MezoBridgeCallerSession) ERC20Tokens(arg0 common.Address) (*b
 func (_MezoBridge *MezoBridgeCaller) ERC20TokensCount(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "ERC20TokensCount")
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -243,7 +240,6 @@ func (_MezoBridge *MezoBridgeCaller) ERC20TokensCount(opts *bind.CallOpts) (*big
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // ERC20TokensCount is a free data retrieval call binding the contract method 0xd252bb2c.
@@ -266,7 +262,6 @@ func (_MezoBridge *MezoBridgeCallerSession) ERC20TokensCount() (*big.Int, error)
 func (_MezoBridge *MezoBridgeCaller) MAXERC20TOKENS(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "MAX_ERC20_TOKENS")
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -274,7 +269,6 @@ func (_MezoBridge *MezoBridgeCaller) MAXERC20TOKENS(opts *bind.CallOpts) (*big.I
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // MAXERC20TOKENS is a free data retrieval call binding the contract method 0x5febd8eb.
@@ -297,7 +291,6 @@ func (_MezoBridge *MezoBridgeCallerSession) MAXERC20TOKENS() (*big.Int, error) {
 func (_MezoBridge *MezoBridgeCaller) SATOSHIMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "SATOSHI_MULTIPLIER")
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -305,7 +298,6 @@ func (_MezoBridge *MezoBridgeCaller) SATOSHIMULTIPLIER(opts *bind.CallOpts) (*bi
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // SATOSHIMULTIPLIER is a free data retrieval call binding the contract method 0xc7ba0347.
@@ -328,7 +320,6 @@ func (_MezoBridge *MezoBridgeCallerSession) SATOSHIMULTIPLIER() (*big.Int, error
 func (_MezoBridge *MezoBridgeCaller) Bridge(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "bridge")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -336,7 +327,6 @@ func (_MezoBridge *MezoBridgeCaller) Bridge(opts *bind.CallOpts) (common.Address
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // Bridge is a free data retrieval call binding the contract method 0xe78cea92.
@@ -359,7 +349,6 @@ func (_MezoBridge *MezoBridgeCallerSession) Bridge() (common.Address, error) {
 func (_MezoBridge *MezoBridgeCaller) BtcDeposits(opts *bind.CallOpts, arg0 *big.Int) (uint8, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "btcDeposits", arg0)
-
 	if err != nil {
 		return *new(uint8), err
 	}
@@ -367,7 +356,6 @@ func (_MezoBridge *MezoBridgeCaller) BtcDeposits(opts *bind.CallOpts, arg0 *big.
 	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
 
 	return out0, err
-
 }
 
 // BtcDeposits is a free data retrieval call binding the contract method 0x941b1f94.
@@ -390,7 +378,6 @@ func (_MezoBridge *MezoBridgeCallerSession) BtcDeposits(arg0 *big.Int) (uint8, e
 func (_MezoBridge *MezoBridgeCaller) MinTBTCAmount(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "minTBTCAmount")
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -398,7 +385,6 @@ func (_MezoBridge *MezoBridgeCaller) MinTBTCAmount(opts *bind.CallOpts) (*big.In
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // MinTBTCAmount is a free data retrieval call binding the contract method 0xdab1b4bd.
@@ -421,7 +407,6 @@ func (_MezoBridge *MezoBridgeCallerSession) MinTBTCAmount() (*big.Int, error) {
 func (_MezoBridge *MezoBridgeCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "owner")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -429,7 +414,6 @@ func (_MezoBridge *MezoBridgeCaller) Owner(opts *bind.CallOpts) (common.Address,
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
@@ -452,7 +436,6 @@ func (_MezoBridge *MezoBridgeCallerSession) Owner() (common.Address, error) {
 func (_MezoBridge *MezoBridgeCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "pendingOwner")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -460,7 +443,6 @@ func (_MezoBridge *MezoBridgeCaller) PendingOwner(opts *bind.CallOpts) (common.A
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
@@ -483,7 +465,6 @@ func (_MezoBridge *MezoBridgeCallerSession) PendingOwner() (common.Address, erro
 func (_MezoBridge *MezoBridgeCaller) Sequence(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "sequence")
-
 	if err != nil {
 		return *new(*big.Int), err
 	}
@@ -491,7 +472,6 @@ func (_MezoBridge *MezoBridgeCaller) Sequence(opts *bind.CallOpts) (*big.Int, er
 	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
-
 }
 
 // Sequence is a free data retrieval call binding the contract method 0x529d15cc.
@@ -514,7 +494,6 @@ func (_MezoBridge *MezoBridgeCallerSession) Sequence() (*big.Int, error) {
 func (_MezoBridge *MezoBridgeCaller) TbtcToken(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "tbtcToken")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -522,7 +501,6 @@ func (_MezoBridge *MezoBridgeCaller) TbtcToken(opts *bind.CallOpts) (common.Addr
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // TbtcToken is a free data retrieval call binding the contract method 0xe5d3d714.
@@ -545,7 +523,6 @@ func (_MezoBridge *MezoBridgeCallerSession) TbtcToken() (common.Address, error) 
 func (_MezoBridge *MezoBridgeCaller) TbtcVault(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _MezoBridge.contract.Call(opts, &out, "tbtcVault")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -553,7 +530,6 @@ func (_MezoBridge *MezoBridgeCaller) TbtcVault(opts *bind.CallOpts) (common.Addr
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // TbtcVault is a free data retrieval call binding the contract method 0x0f36403a.
@@ -923,7 +899,6 @@ type MezoBridgeAssetsLocked struct {
 //
 // Solidity: event AssetsLocked(uint256 indexed sequenceNumber, address indexed recipient, address indexed token, uint256 amount)
 func (_MezoBridge *MezoBridgeFilterer) FilterAssetsLocked(opts *bind.FilterOpts, sequenceNumber []*big.Int, recipient []common.Address, token []common.Address) (*MezoBridgeAssetsLockedIterator, error) {
-
 	var sequenceNumberRule []interface{}
 	for _, sequenceNumberItem := range sequenceNumber {
 		sequenceNumberRule = append(sequenceNumberRule, sequenceNumberItem)
@@ -948,7 +923,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterAssetsLocked(opts *bind.FilterOpts,
 //
 // Solidity: event AssetsLocked(uint256 indexed sequenceNumber, address indexed recipient, address indexed token, uint256 amount)
 func (_MezoBridge *MezoBridgeFilterer) WatchAssetsLocked(opts *bind.WatchOpts, sink chan<- *MezoBridgeAssetsLocked, sequenceNumber []*big.Int, recipient []common.Address, token []common.Address) (event.Subscription, error) {
-
 	var sequenceNumberRule []interface{}
 	for _, sequenceNumberItem := range sequenceNumber {
 		sequenceNumberRule = append(sequenceNumberRule, sequenceNumberItem)
@@ -1085,7 +1059,6 @@ type MezoBridgeBTCDepositFinalized struct {
 //
 // Solidity: event BTCDepositFinalized(uint256 indexed btcDepositKey, uint256 initialAmount, uint256 tbtcAmount)
 func (_MezoBridge *MezoBridgeFilterer) FilterBTCDepositFinalized(opts *bind.FilterOpts, btcDepositKey []*big.Int) (*MezoBridgeBTCDepositFinalizedIterator, error) {
-
 	var btcDepositKeyRule []interface{}
 	for _, btcDepositKeyItem := range btcDepositKey {
 		btcDepositKeyRule = append(btcDepositKeyRule, btcDepositKeyItem)
@@ -1102,7 +1075,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterBTCDepositFinalized(opts *bind.Filt
 //
 // Solidity: event BTCDepositFinalized(uint256 indexed btcDepositKey, uint256 initialAmount, uint256 tbtcAmount)
 func (_MezoBridge *MezoBridgeFilterer) WatchBTCDepositFinalized(opts *bind.WatchOpts, sink chan<- *MezoBridgeBTCDepositFinalized, btcDepositKey []*big.Int) (event.Subscription, error) {
-
 	var btcDepositKeyRule []interface{}
 	for _, btcDepositKeyItem := range btcDepositKey {
 		btcDepositKeyRule = append(btcDepositKeyRule, btcDepositKeyItem)
@@ -1230,7 +1202,6 @@ type MezoBridgeBTCDepositInitialized struct {
 //
 // Solidity: event BTCDepositInitialized(uint256 indexed btcDepositKey, address indexed recipient)
 func (_MezoBridge *MezoBridgeFilterer) FilterBTCDepositInitialized(opts *bind.FilterOpts, btcDepositKey []*big.Int, recipient []common.Address) (*MezoBridgeBTCDepositInitializedIterator, error) {
-
 	var btcDepositKeyRule []interface{}
 	for _, btcDepositKeyItem := range btcDepositKey {
 		btcDepositKeyRule = append(btcDepositKeyRule, btcDepositKeyItem)
@@ -1251,7 +1222,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterBTCDepositInitialized(opts *bind.Fi
 //
 // Solidity: event BTCDepositInitialized(uint256 indexed btcDepositKey, address indexed recipient)
 func (_MezoBridge *MezoBridgeFilterer) WatchBTCDepositInitialized(opts *bind.WatchOpts, sink chan<- *MezoBridgeBTCDepositInitialized, btcDepositKey []*big.Int, recipient []common.Address) (event.Subscription, error) {
-
 	var btcDepositKeyRule []interface{}
 	for _, btcDepositKeyItem := range btcDepositKey {
 		btcDepositKeyRule = append(btcDepositKeyRule, btcDepositKeyItem)
@@ -1382,7 +1352,6 @@ type MezoBridgeERC20TokenDisabled struct {
 //
 // Solidity: event ERC20TokenDisabled(address indexed ERC20Token)
 func (_MezoBridge *MezoBridgeFilterer) FilterERC20TokenDisabled(opts *bind.FilterOpts, ERC20Token []common.Address) (*MezoBridgeERC20TokenDisabledIterator, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1399,7 +1368,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterERC20TokenDisabled(opts *bind.Filte
 //
 // Solidity: event ERC20TokenDisabled(address indexed ERC20Token)
 func (_MezoBridge *MezoBridgeFilterer) WatchERC20TokenDisabled(opts *bind.WatchOpts, sink chan<- *MezoBridgeERC20TokenDisabled, ERC20Token []common.Address) (event.Subscription, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1527,7 +1495,6 @@ type MezoBridgeERC20TokenEnabled struct {
 //
 // Solidity: event ERC20TokenEnabled(address indexed ERC20Token, uint256 minERC20Amount)
 func (_MezoBridge *MezoBridgeFilterer) FilterERC20TokenEnabled(opts *bind.FilterOpts, ERC20Token []common.Address) (*MezoBridgeERC20TokenEnabledIterator, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1544,7 +1511,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterERC20TokenEnabled(opts *bind.Filter
 //
 // Solidity: event ERC20TokenEnabled(address indexed ERC20Token, uint256 minERC20Amount)
 func (_MezoBridge *MezoBridgeFilterer) WatchERC20TokenEnabled(opts *bind.WatchOpts, sink chan<- *MezoBridgeERC20TokenEnabled, ERC20Token []common.Address) (event.Subscription, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1671,7 +1637,6 @@ type MezoBridgeInitialized struct {
 //
 // Solidity: event Initialized(uint64 version)
 func (_MezoBridge *MezoBridgeFilterer) FilterInitialized(opts *bind.FilterOpts) (*MezoBridgeInitializedIterator, error) {
-
 	logs, sub, err := _MezoBridge.contract.FilterLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
@@ -1683,7 +1648,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterInitialized(opts *bind.FilterOpts) 
 //
 // Solidity: event Initialized(uint64 version)
 func (_MezoBridge *MezoBridgeFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *MezoBridgeInitialized) (event.Subscription, error) {
-
 	logs, sub, err := _MezoBridge.contract.WatchLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
@@ -1806,7 +1770,6 @@ type MezoBridgeMinERC20AmountUpdated struct {
 //
 // Solidity: event MinERC20AmountUpdated(address indexed ERC20Token, uint256 newMinERC20Amount)
 func (_MezoBridge *MezoBridgeFilterer) FilterMinERC20AmountUpdated(opts *bind.FilterOpts, ERC20Token []common.Address) (*MezoBridgeMinERC20AmountUpdatedIterator, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1823,7 +1786,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterMinERC20AmountUpdated(opts *bind.Fi
 //
 // Solidity: event MinERC20AmountUpdated(address indexed ERC20Token, uint256 newMinERC20Amount)
 func (_MezoBridge *MezoBridgeFilterer) WatchMinERC20AmountUpdated(opts *bind.WatchOpts, sink chan<- *MezoBridgeMinERC20AmountUpdated, ERC20Token []common.Address) (event.Subscription, error) {
-
 	var ERC20TokenRule []interface{}
 	for _, ERC20TokenItem := range ERC20Token {
 		ERC20TokenRule = append(ERC20TokenRule, ERC20TokenItem)
@@ -1950,7 +1912,6 @@ type MezoBridgeMinTBTCAmountUpdated struct {
 //
 // Solidity: event MinTBTCAmountUpdated(uint256 minTBTCAmount)
 func (_MezoBridge *MezoBridgeFilterer) FilterMinTBTCAmountUpdated(opts *bind.FilterOpts) (*MezoBridgeMinTBTCAmountUpdatedIterator, error) {
-
 	logs, sub, err := _MezoBridge.contract.FilterLogs(opts, "MinTBTCAmountUpdated")
 	if err != nil {
 		return nil, err
@@ -1962,7 +1923,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterMinTBTCAmountUpdated(opts *bind.Fil
 //
 // Solidity: event MinTBTCAmountUpdated(uint256 minTBTCAmount)
 func (_MezoBridge *MezoBridgeFilterer) WatchMinTBTCAmountUpdated(opts *bind.WatchOpts, sink chan<- *MezoBridgeMinTBTCAmountUpdated) (event.Subscription, error) {
-
 	logs, sub, err := _MezoBridge.contract.WatchLogs(opts, "MinTBTCAmountUpdated")
 	if err != nil {
 		return nil, err
@@ -2085,7 +2045,6 @@ type MezoBridgeOwnershipTransferStarted struct {
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
 func (_MezoBridge *MezoBridgeFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*MezoBridgeOwnershipTransferStartedIterator, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -2106,7 +2065,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterOwnershipTransferStarted(opts *bind
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
 func (_MezoBridge *MezoBridgeFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *MezoBridgeOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -2238,7 +2196,6 @@ type MezoBridgeOwnershipTransferred struct {
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_MezoBridge *MezoBridgeFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*MezoBridgeOwnershipTransferredIterator, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -2259,7 +2216,6 @@ func (_MezoBridge *MezoBridgeFilterer) FilterOwnershipTransferred(opts *bind.Fil
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_MezoBridge *MezoBridgeFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *MezoBridgeOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)

--- a/ethereum/bindings/portal/gen/contract/MezoBridge.go
+++ b/ethereum/bindings/portal/gen/contract/MezoBridge.go
@@ -106,7 +106,6 @@ func NewMezoBridge(
 
 // Transaction submission.
 func (mb *MezoBridge) AcceptOwnership(
-
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	mbLogger.Debug(
@@ -1484,7 +1483,6 @@ func (mb *MezoBridge) InitializeBTCBridgingGasEstimate(
 
 // Transaction submission.
 func (mb *MezoBridge) RenounceOwnership(
-
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	mbLogger.Debug(
@@ -2036,7 +2034,6 @@ func (mb *MezoBridge) Bridge() (common.Address, error) {
 	result, err := mb.contract.Bridge(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2076,7 +2073,6 @@ func (mb *MezoBridge) BtcDeposits(
 		mb.callerOptions,
 		arg0,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2119,7 +2115,6 @@ func (mb *MezoBridge) ERC20Tokens(
 		mb.callerOptions,
 		arg0,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2159,7 +2154,6 @@ func (mb *MezoBridge) ERC20TokensCount() (*big.Int, error) {
 	result, err := mb.contract.ERC20TokensCount(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2196,7 +2190,6 @@ func (mb *MezoBridge) MAXERC20TOKENS() (*big.Int, error) {
 	result, err := mb.contract.MAXERC20TOKENS(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2233,7 +2226,6 @@ func (mb *MezoBridge) MinTBTCAmount() (*big.Int, error) {
 	result, err := mb.contract.MinTBTCAmount(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2270,7 +2262,6 @@ func (mb *MezoBridge) Owner() (common.Address, error) {
 	result, err := mb.contract.Owner(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2307,7 +2298,6 @@ func (mb *MezoBridge) PendingOwner() (common.Address, error) {
 	result, err := mb.contract.PendingOwner(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2344,7 +2334,6 @@ func (mb *MezoBridge) SATOSHIMULTIPLIER() (*big.Int, error) {
 	result, err := mb.contract.SATOSHIMULTIPLIER(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2381,7 +2370,6 @@ func (mb *MezoBridge) Sequence() (*big.Int, error) {
 	result, err := mb.contract.Sequence(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2418,7 +2406,6 @@ func (mb *MezoBridge) TbtcToken() (common.Address, error) {
 	result, err := mb.contract.TbtcToken(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,
@@ -2455,7 +2442,6 @@ func (mb *MezoBridge) TbtcVault() (common.Address, error) {
 	result, err := mb.contract.TbtcVault(
 		mb.callerOptions,
 	)
-
 	if err != nil {
 		return result, mb.errorResolver.ResolveError(
 			err,

--- a/precompile/validatorpool/gen/validatorpool_binding.go
+++ b/precompile/validatorpool/gen/validatorpool_binding.go
@@ -200,7 +200,8 @@ func (_Validatorpool *ValidatorpoolTransactorRaw) Transact(opts *bind.TransactOp
 func (_Validatorpool *ValidatorpoolCaller) Application(opts *bind.CallOpts, operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "application", operator)
 
@@ -216,7 +217,6 @@ func (_Validatorpool *ValidatorpoolCaller) Application(opts *bind.CallOpts, oper
 	outstruct.Description = *abi.ConvertType(out[1], new(Description)).(*Description)
 
 	return *outstruct, err
-
 }
 
 // Application is a free data retrieval call binding the contract method 0x8bd2cc11.
@@ -225,7 +225,8 @@ func (_Validatorpool *ValidatorpoolCaller) Application(opts *bind.CallOpts, oper
 func (_Validatorpool *ValidatorpoolSession) Application(operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	return _Validatorpool.Contract.Application(&_Validatorpool.CallOpts, operator)
 }
 
@@ -235,7 +236,8 @@ func (_Validatorpool *ValidatorpoolSession) Application(operator common.Address)
 func (_Validatorpool *ValidatorpoolCallerSession) Application(operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	return _Validatorpool.Contract.Application(&_Validatorpool.CallOpts, operator)
 }
 
@@ -245,7 +247,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) Application(operator common.Ad
 func (_Validatorpool *ValidatorpoolCaller) Applications(opts *bind.CallOpts) ([]common.Address, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "applications")
-
 	if err != nil {
 		return *new([]common.Address), err
 	}
@@ -253,7 +254,6 @@ func (_Validatorpool *ValidatorpoolCaller) Applications(opts *bind.CallOpts) ([]
 	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
 
 	return out0, err
-
 }
 
 // Applications is a free data retrieval call binding the contract method 0x7ce5e82f.
@@ -276,7 +276,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) Applications() ([]common.Addre
 func (_Validatorpool *ValidatorpoolCaller) CandidateOwner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "candidateOwner")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -284,7 +283,6 @@ func (_Validatorpool *ValidatorpoolCaller) CandidateOwner(opts *bind.CallOpts) (
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // CandidateOwner is a free data retrieval call binding the contract method 0xc105ea2b.
@@ -307,7 +305,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) CandidateOwner() (common.Addre
 func (_Validatorpool *ValidatorpoolCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "owner")
-
 	if err != nil {
 		return *new(common.Address), err
 	}
@@ -315,7 +312,6 @@ func (_Validatorpool *ValidatorpoolCaller) Owner(opts *bind.CallOpts) (common.Ad
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
 
 	return out0, err
-
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
@@ -338,7 +334,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) Owner() (common.Address, error
 func (_Validatorpool *ValidatorpoolCaller) Privileges(opts *bind.CallOpts) ([]Privilege, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "privileges")
-
 	if err != nil {
 		return *new([]Privilege), err
 	}
@@ -346,7 +341,6 @@ func (_Validatorpool *ValidatorpoolCaller) Privileges(opts *bind.CallOpts) ([]Pr
 	out0 := *abi.ConvertType(out[0], new([]Privilege)).(*[]Privilege)
 
 	return out0, err
-
 }
 
 // Privileges is a free data retrieval call binding the contract method 0x2dea97ba.
@@ -369,7 +363,8 @@ func (_Validatorpool *ValidatorpoolCallerSession) Privileges() ([]Privilege, err
 func (_Validatorpool *ValidatorpoolCaller) Validator(opts *bind.CallOpts, operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "validator", operator)
 
@@ -385,7 +380,6 @@ func (_Validatorpool *ValidatorpoolCaller) Validator(opts *bind.CallOpts, operat
 	outstruct.Description = *abi.ConvertType(out[1], new(Description)).(*Description)
 
 	return *outstruct, err
-
 }
 
 // Validator is a free data retrieval call binding the contract method 0x223b3b7a.
@@ -394,7 +388,8 @@ func (_Validatorpool *ValidatorpoolCaller) Validator(opts *bind.CallOpts, operat
 func (_Validatorpool *ValidatorpoolSession) Validator(operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	return _Validatorpool.Contract.Validator(&_Validatorpool.CallOpts, operator)
 }
 
@@ -404,7 +399,8 @@ func (_Validatorpool *ValidatorpoolSession) Validator(operator common.Address) (
 func (_Validatorpool *ValidatorpoolCallerSession) Validator(operator common.Address) (struct {
 	ConsPubKey  [32]byte
 	Description Description
-}, error) {
+}, error,
+) {
 	return _Validatorpool.Contract.Validator(&_Validatorpool.CallOpts, operator)
 }
 
@@ -414,7 +410,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) Validator(operator common.Addr
 func (_Validatorpool *ValidatorpoolCaller) Validators(opts *bind.CallOpts) ([]common.Address, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "validators")
-
 	if err != nil {
 		return *new([]common.Address), err
 	}
@@ -422,7 +417,6 @@ func (_Validatorpool *ValidatorpoolCaller) Validators(opts *bind.CallOpts) ([]co
 	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
 
 	return out0, err
-
 }
 
 // Validators is a free data retrieval call binding the contract method 0xca1e7819.
@@ -445,7 +439,6 @@ func (_Validatorpool *ValidatorpoolCallerSession) Validators() ([]common.Address
 func (_Validatorpool *ValidatorpoolCaller) ValidatorsByPrivilege(opts *bind.CallOpts, privilegeId uint8) ([]common.Address, error) {
 	var out []interface{}
 	err := _Validatorpool.contract.Call(opts, &out, "validatorsByPrivilege", privilegeId)
-
 	if err != nil {
 		return *new([]common.Address), err
 	}
@@ -453,7 +446,6 @@ func (_Validatorpool *ValidatorpoolCaller) ValidatorsByPrivilege(opts *bind.Call
 	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
 
 	return out0, err
-
 }
 
 // ValidatorsByPrivilege is a free data retrieval call binding the contract method 0x617177f5.
@@ -736,7 +728,6 @@ type ValidatorpoolApplicationApproved struct {
 //
 // Solidity: event ApplicationApproved(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationApproved(opts *bind.FilterOpts, operator []common.Address) (*ValidatorpoolApplicationApprovedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -753,7 +744,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationApproved(opts *bin
 //
 // Solidity: event ApplicationApproved(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) WatchApplicationApproved(opts *bind.WatchOpts, sink chan<- *ValidatorpoolApplicationApproved, operator []common.Address) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -882,7 +872,6 @@ type ValidatorpoolApplicationSubmitted struct {
 //
 // Solidity: event ApplicationSubmitted(address indexed operator, bytes32 indexed consPubKey, (string,string,string,string,string) description)
 func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationSubmitted(opts *bind.FilterOpts, operator []common.Address, consPubKey [][32]byte) (*ValidatorpoolApplicationSubmittedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -903,7 +892,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationSubmitted(opts *bi
 //
 // Solidity: event ApplicationSubmitted(address indexed operator, bytes32 indexed consPubKey, (string,string,string,string,string) description)
 func (_Validatorpool *ValidatorpoolFilterer) WatchApplicationSubmitted(opts *bind.WatchOpts, sink chan<- *ValidatorpoolApplicationSubmitted, operator []common.Address, consPubKey [][32]byte) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1033,7 +1021,6 @@ type ValidatorpoolApplicationsCleaned struct {
 //
 // Solidity: event ApplicationsCleaned()
 func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationsCleaned(opts *bind.FilterOpts) (*ValidatorpoolApplicationsCleanedIterator, error) {
-
 	logs, sub, err := _Validatorpool.contract.FilterLogs(opts, "ApplicationsCleaned")
 	if err != nil {
 		return nil, err
@@ -1045,7 +1032,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterApplicationsCleaned(opts *bin
 //
 // Solidity: event ApplicationsCleaned()
 func (_Validatorpool *ValidatorpoolFilterer) WatchApplicationsCleaned(opts *bind.WatchOpts, sink chan<- *ValidatorpoolApplicationsCleaned) (event.Subscription, error) {
-
 	logs, sub, err := _Validatorpool.contract.WatchLogs(opts, "ApplicationsCleaned")
 	if err != nil {
 		return nil, err
@@ -1168,7 +1154,6 @@ type ValidatorpoolOwnershipTransferStarted struct {
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
 func (_Validatorpool *ValidatorpoolFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ValidatorpoolOwnershipTransferStartedIterator, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -1189,7 +1174,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterOwnershipTransferStarted(opts
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
 func (_Validatorpool *ValidatorpoolFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *ValidatorpoolOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -1321,7 +1305,6 @@ type ValidatorpoolOwnershipTransferred struct {
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_Validatorpool *ValidatorpoolFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ValidatorpoolOwnershipTransferredIterator, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -1342,7 +1325,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterOwnershipTransferred(opts *bi
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_Validatorpool *ValidatorpoolFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ValidatorpoolOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
-
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
@@ -1474,7 +1456,6 @@ type ValidatorpoolPrivilegeAdded struct {
 //
 // Solidity: event PrivilegeAdded(address indexed operator, uint8 indexed privilegeId)
 func (_Validatorpool *ValidatorpoolFilterer) FilterPrivilegeAdded(opts *bind.FilterOpts, operator []common.Address, privilegeId []uint8) (*ValidatorpoolPrivilegeAddedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1495,7 +1476,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterPrivilegeAdded(opts *bind.Fil
 //
 // Solidity: event PrivilegeAdded(address indexed operator, uint8 indexed privilegeId)
 func (_Validatorpool *ValidatorpoolFilterer) WatchPrivilegeAdded(opts *bind.WatchOpts, sink chan<- *ValidatorpoolPrivilegeAdded, operator []common.Address, privilegeId []uint8) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1627,7 +1607,6 @@ type ValidatorpoolPrivilegeRemoved struct {
 //
 // Solidity: event PrivilegeRemoved(address indexed operator, uint8 indexed privilegeId)
 func (_Validatorpool *ValidatorpoolFilterer) FilterPrivilegeRemoved(opts *bind.FilterOpts, operator []common.Address, privilegeId []uint8) (*ValidatorpoolPrivilegeRemovedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1648,7 +1627,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterPrivilegeRemoved(opts *bind.F
 //
 // Solidity: event PrivilegeRemoved(address indexed operator, uint8 indexed privilegeId)
 func (_Validatorpool *ValidatorpoolFilterer) WatchPrivilegeRemoved(opts *bind.WatchOpts, sink chan<- *ValidatorpoolPrivilegeRemoved, operator []common.Address, privilegeId []uint8) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1779,7 +1757,6 @@ type ValidatorpoolValidatorJoined struct {
 //
 // Solidity: event ValidatorJoined(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorJoined(opts *bind.FilterOpts, operator []common.Address) (*ValidatorpoolValidatorJoinedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1796,7 +1773,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorJoined(opts *bind.Fi
 //
 // Solidity: event ValidatorJoined(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) WatchValidatorJoined(opts *bind.WatchOpts, sink chan<- *ValidatorpoolValidatorJoined, operator []common.Address) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1923,7 +1899,6 @@ type ValidatorpoolValidatorKicked struct {
 //
 // Solidity: event ValidatorKicked(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorKicked(opts *bind.FilterOpts, operator []common.Address) (*ValidatorpoolValidatorKickedIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -1940,7 +1915,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorKicked(opts *bind.Fi
 //
 // Solidity: event ValidatorKicked(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) WatchValidatorKicked(opts *bind.WatchOpts, sink chan<- *ValidatorpoolValidatorKicked, operator []common.Address) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -2067,7 +2041,6 @@ type ValidatorpoolValidatorLeft struct {
 //
 // Solidity: event ValidatorLeft(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorLeft(opts *bind.FilterOpts, operator []common.Address) (*ValidatorpoolValidatorLeftIterator, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)
@@ -2084,7 +2057,6 @@ func (_Validatorpool *ValidatorpoolFilterer) FilterValidatorLeft(opts *bind.Filt
 //
 // Solidity: event ValidatorLeft(address indexed operator)
 func (_Validatorpool *ValidatorpoolFilterer) WatchValidatorLeft(opts *bind.WatchOpts, sink chan<- *ValidatorpoolValidatorLeft, operator []common.Address) (event.Subscription, error) {
-
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
 		operatorRule = append(operatorRule, operatorItem)


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-87/contributing-policy-contributingmd

### Introduction

As a part of the work on the contributing policy, I realized we do not have a pre-commit configuration in the repository. This pull request adds pre-commit configuration for Go and Markdown file formatting.

### Changes

I wanted to "fix everything" (TM) in this PR but quickly realized there is a disconnect between what GitHub Actions expect, what we have in the Makefile, and what we have in the code.

For example, if you run `make lint`, you will see the linter reports an error in one of the files. This error was not caught by GitHub actions when this code was pushed. Another example is the use of `cosmos/gosec` scanner in GitHub actions - this scanner is no longer maintained, and it is unclear whether we can have it supported from pre-commit. Similar story about the superlinter config from GitHub actions

Thus, baby-steps. Let's fix the formatting for the files we edit most often and then go after the rest.

### Testing

Insert some changes in one of the Go files the formatters is not going to like. Add this file to the index and run `git commit`. The pre-commit rules should block you. Then run `make lint-fix` and add the updated file to the index. Now, `git commit` should work. Try the same with a Markdown file and `make format-markdown-fix`.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
