### PR TITLE
Avoid memory aliasing when preparing bridging proposal

### DIFF
--- a/x/bridge/abci/proposal.go
+++ b/x/bridge/abci/proposal.go
@@ -550,8 +550,8 @@ func (ale *assetsLockedExtractor) CanonicalEvents(
 		// addVote assumes the given event is valid and does not perform
 		// any validation over it. We ensure validity by calling
 		// validateAssetsLockedEvents above.
-		for _, event := range voteExtension.AssetsLockedEvents {
-			voteCounter.addVote(&event, valVP, isBridgeVal)
+		for i := range voteExtension.AssetsLockedEvents {
+			voteCounter.addVote(&voteExtension.AssetsLockedEvents[i], valVP, isBridgeVal)
 		}
 	}
 


### PR DESCRIPTION
### Introduction

This change removes the potential issue with memory aliasing. The `event` is a loop variable so even though its value changes, the memory location does not. As a result, we've been passing the same memory location to the `addVote` function. This worked fine because we were not capturing this memory location anywhere and were just extracting values from the pointer but to make this code more future-proof we should pass the address of the actual element from the `AssetsLockedEvents` slice.

### Changes

This is a one-linter technical change in `proposal.go`.

### Testing

No testing is required beyond checking that all tests pass. You can also confirm `make lint` no longer complains.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
