### PR TITLE
v0.7.0 Matsnet fork preparation

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -11,11 +11,12 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_4"
 	"github.com/mezo-org/mezod/app/upgrades/v0_5"
 	"github.com/mezo-org/mezod/app/upgrades/v0_6"
+	"github.com/mezo-org/mezod/app/upgrades/v0_7"
 )
 
 var (
 	Upgrades = []upgrades.Upgrade{v0_3.Upgrade}
-	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork}
+	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )
 
 // BeginBlockForks is intended to be run in a chain upgrade.

--- a/app/upgrades/v0_7/constants.go
+++ b/app/upgrades/v0_7/constants.go
@@ -1,0 +1,30 @@
+//nolint:revive,stylecheck
+package v0_7
+
+import (
+	"github.com/mezo-org/mezod/app/upgrades"
+	"github.com/mezo-org/mezod/utils"
+)
+
+const (
+	// UpgradeName defines the name of the upgrade.
+	UpgradeName = "v0.7.0"
+	// TestnetUpgradeHeight defines the block height at which the upgrade is
+	// triggered on testnet. No expected date as we are executing this fork on halted chain.
+	// https://explorer.test.mezo.org/block/countdown/3078794
+	TestnetUpgradeHeight = 3_078_794
+)
+
+var upgradeHeight = func(chainID string) int64 {
+	if utils.IsTestnet(chainID) {
+		return TestnetUpgradeHeight
+	}
+
+	return -1
+}
+
+var Fork = upgrades.Fork{
+	UpgradeName:    UpgradeName,
+	UpgradeHeight:  upgradeHeight,
+	BeginForkLogic: RunForkLogic,
+}

--- a/app/upgrades/v0_7/forks.go
+++ b/app/upgrades/v0_7/forks.go
@@ -1,0 +1,97 @@
+//nolint:revive,stylecheck
+package v0_7
+
+import (
+	"bytes"
+	"slices"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+	"github.com/mezo-org/mezod/x/evm/keeper"
+	evmtypes "github.com/mezo-org/mezod/x/evm/types"
+)
+
+func RunForkLogic(ctx sdk.Context, keepers *upgrades.Keepers) {
+	ctx.Logger().Info("running v0.7.0 fork logic")
+
+	updateMaintenancePrecompileVersion(ctx, keepers.EvmKeeper)
+	setMaxPrecompilesCallsPerExecution(ctx, keepers.EvmKeeper)
+
+	ctx.Logger().Info("v0.7.0 fork logic applied successfully")
+}
+
+func updateMaintenancePrecompileVersion(ctx sdk.Context, evmKeeper *keeper.Keeper) {
+	params := evmKeeper.GetParams(ctx)
+
+	ctx.Logger().Info(
+		"begin maintenance precompile version update",
+		"precompilesVersions",
+		params.PrecompilesVersions,
+	)
+
+	maintenanceVersionInfoIndex := slices.IndexFunc(
+		params.PrecompilesVersions,
+		func(versionInfo *evmtypes.PrecompileVersionInfo) bool {
+			// Compare bytes just in case to avoid any potential issues
+			// with string comparison.
+			return bytes.Equal(
+				evmtypes.HexAddressToBytes(versionInfo.PrecompileAddress),
+				evmtypes.HexAddressToBytes(evmtypes.MaintenancePrecompileAddress),
+			)
+		},
+	)
+
+	// 3 is the value of evmtypes.MaintenancePrecompileLatestVersion at
+	// the time of this upgrade. We avoid using the constant directly
+	// as it will change in the future so the actual value of the version
+	// used during this upgrade would perish over time.
+	params.PrecompilesVersions[maintenanceVersionInfoIndex].Version = 3
+
+	err := evmKeeper.SetParams(ctx, params)
+	if err != nil {
+		// Do not halt consensus in case of failure.
+		// Just live without the Maintenance precompile version update.
+		ctx.Logger().Error(
+			"failed to set maintenance precompile version; abandoning",
+			"error",
+			err,
+		)
+		return
+	}
+
+	ctx.Logger().Info(
+		"maintenance precompile version updated",
+		"precompilesVersions",
+		evmKeeper.GetParams(ctx).PrecompilesVersions,
+	)
+}
+
+func setMaxPrecompilesCallsPerExecution(ctx sdk.Context, evmKeeper *keeper.Keeper) {
+	params := evmKeeper.GetParams(ctx)
+
+	ctx.Logger().Info(
+		"begin setting max precompile calls per execution",
+		"maxPrecompileCallsPerExecution",
+		params.MaxPrecompilesCallsPerExecution,
+	)
+
+	params.MaxPrecompilesCallsPerExecution = uint32(evmtypes.DefaultMaxPrecompilesCallsPerExecution)
+
+	err := evmKeeper.SetParams(ctx, params)
+	if err != nil {
+		// Do not halt consensus in case of failure.
+		// Just live without the max precompile calls per execution update.
+		ctx.Logger().Error(
+			"failed to set max precompile calls per execution; abandoning",
+			"error",
+			err,
+		)
+		return
+	}
+
+	ctx.Logger().Info(
+		"max precompile calls per execution updated",
+		"maxPrecompileCallsPerExecution",
+		evmKeeper.GetParams(ctx).MaxPrecompilesCallsPerExecution,
+	)
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -174,6 +174,7 @@ for full version information.
 | `v0.4.0` | 1745000 | Hard fork upgrade without state migrations | Update EVM storage root strategy (fix for Mezo Passport create2 problem) and introduce EVM observability for the BTC bridge.                                                            |
 | `v0.5.0` | 2213000 | Hard fork upgrade without state migrations | On-chain precompile versioning. New Upgrade and PriceOracle precompiles and upgrade of the existing Maintenance precompile.                                                             |
 | `v0.6.0` | 2563000 | Hard fork upgrade without state migrations | Introduce the ERC20 bridge and the BTC supply assertion.                                                                                                                                |
+| `v0.7.0` | 3078794 | Hard fork upgrade without state migrations | Fix security issues in the EVM state DB. Introduce proper reverts for precompiles. Add chain fee splitter support. Disable Cosmos transactions.                                                                                                                                 |
 
 ### Mainnet
 

--- a/precompile/maintenance/maintenance.go
+++ b/precompile/maintenance/maintenance.go
@@ -26,8 +26,9 @@ func NewPrecompileVersionMap(
 ) (*precompile.VersionMap, error) {
 	// v1 is just the EVM settings.
 	contractV1, err := NewPrecompile(poaKeeper, evmKeeper, &Settings{
-		EVM:         true,
-		Precompiles: false,
+		EVM:              true,
+		Precompiles:      false,
+		ChainFeeSplitter: false,
 	})
 	if err != nil {
 		return nil, err
@@ -35,8 +36,19 @@ func NewPrecompileVersionMap(
 
 	// v2 is the EVM settings and the precompiles settings.
 	contractV2, err := NewPrecompile(poaKeeper, evmKeeper, &Settings{
-		EVM:         true,
-		Precompiles: true,
+		EVM:              true,
+		Precompiles:      true,
+		ChainFeeSplitter: false,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// v3 is the EVM settings, the precompiles settings and the chain fee splitter settings.
+	contractV3, err := NewPrecompile(poaKeeper, evmKeeper, &Settings{
+		EVM:              true,
+		Precompiles:      true,
+		ChainFeeSplitter: true,
 	})
 	if err != nil {
 		return nil, err
@@ -46,14 +58,16 @@ func NewPrecompileVersionMap(
 		map[int]*precompile.Contract{
 			0: contractV1, // returning v1 as v0 is legacy to support this precompile before versioning was introduced
 			1: contractV1,
-			evmtypes.MaintenancePrecompileLatestVersion: contractV2,
+			2: contractV2,
+			evmtypes.MaintenancePrecompileLatestVersion: contractV3,
 		},
 	), nil
 }
 
 type Settings struct {
-	EVM         bool // enable methods related to the evm
-	Precompiles bool // enable methods related to the precompiles
+	EVM              bool // enable methods related to the evm
+	Precompiles      bool // enable methods related to the precompiles
+	ChainFeeSplitter bool // enable methods related to the chain fee splitter
 }
 
 // NewPrecompile creates a new maintenance precompile.
@@ -97,8 +111,10 @@ func newPrecompileMethods(
 		methods = append(methods, newSetPrecompileByteCodeMethod(poaKeeper, evmKeeper))
 	}
 
-	methods = append(methods, newSetChainFeeSplitterAddressMethod(poaKeeper, evmKeeper))
-	methods = append(methods, newGetChainFeeSplitterAddressMethod(evmKeeper))
+	if settings.ChainFeeSplitter {
+		methods = append(methods, newSetChainFeeSplitterAddressMethod(poaKeeper, evmKeeper))
+		methods = append(methods, newGetChainFeeSplitterAddressMethod(evmKeeper))
+	}
 
 	return methods
 }

--- a/precompile/maintenance/setup_test.go
+++ b/precompile/maintenance/setup_test.go
@@ -117,8 +117,9 @@ func (s *PrecompileTestSuite) RunMethodTestCases(testcases []TestCase, methodNam
 				s.poaKeeper,
 				s.evmKeeper,
 				&maintenance.Settings{
-					EVM:         true,
-					Precompiles: true,
+					EVM:              true,
+					Precompiles:      true,
+					ChainFeeSplitter: true,
 				},
 			)
 			s.Require().NoError(err)

--- a/x/bridge/keeper/abci.go
+++ b/x/bridge/keeper/abci.go
@@ -51,7 +51,7 @@ func (k *Keeper) verifyBTCSupply(ctx context.Context) error {
 		)
 	}
 
-	k.Logger(sdkCtx).Debug("safe BTC supply state",
+	k.Logger(sdkCtx).Info("safe BTC supply state",
 		"totalSupply", totalSupply.String(),
 		"totalMinted", totalMinted.String(),
 		"totalBurnt", totalBurnt.String(),

--- a/x/evm/types/precompile.go
+++ b/x/evm/types/precompile.go
@@ -17,7 +17,7 @@ const (
 
 const (
 	MaintenancePrecompileAddress       = "0x7b7c000000000000000000000000000000000013"
-	MaintenancePrecompileLatestVersion = 2
+	MaintenancePrecompileLatestVersion = 3
 )
 
 const (


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-382/the-v070-matsnet-fork

### Introduction

Here we make the necessary preparations in order to execute the v0.7.0 fork on Mezo Matsnet. The mentioned fork will introduce the following things:
1. Disable Cosmos-native transactions
2. Fix the critical security vulns around EVM state DB
3. Add a proper revert mechanism for precompiles
4. Allow redirecting transaction fees to a chain fee splitter contract

### Changes

#### Schedule the v0.7.0 fork at block 3078794

We add the fork logic that will execute the v0.7.0 fork on Matnset, at block 3078794. The fork introduces things mentioned in the introduction by doing the following state changes:

- Bumping up the `Maintenance` precompile to version `3` which is currently the latest one. This enables redirecting fees to a chain fee splitter contract.
- Setting the limit of max precompile calls per transation to `10`. This is a necessesary setup to enable the revert mechanism for precompiles.

The other two items (disable Cosmos transactions and fixes of the critical security vulns around EVM state DB) are deep changes that don't require any specific logic to be run upon the fork. They are just present in the new v0.7.0 client binary.

### Testing

To test Matsnet flow locally, do the following steps:
1. Checkout to `v0.6.0-rc1`. This is the current tag used on Matsnet.
2. Create a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Run three nodes using `make localnet-bin-start` and let them produce a few blocks.
4. Checkout this PR's branch `v07-fork-prep`.
5. Get a private key to a funded account. For example using `./build/mezod keys unsafe-export-eth-key --home=./.localnet/node0/mezod --keyring-backend=test node0`
6. Set `networks.localhost.accounts` in the `tests/system/hardhat.config.ts ` file using the above private key (`networks.localhost.accounts: ["0x..."]`)
7. Move to `tests/system` and run `./system-tests.sh`. Running them on `v0.6.0-rc1` nodes will violate the BTC supply invariant.
8. Wait until `CONSENSUS FAILURE` appears on all three nodes. 
9. Stop system tests that are now hanging.
10. Stop all nodes.
11. Check the last `finalizing commit of block` log that appeared on nodes just before the consensus failure to get the current height.
12. Set current height as `TestnetUpgradeHeight` in `app/upgrades/v0_7/constants.go`.
13. Do `make build`.
14. Re-run all three nodes.
15. Nodes should resume and you should see the following log:
     ```
    10:27AM INF running v0.7.0 fork logic module=server
    10:27AM INF begin maintenance precompile version update module=server precompilesVersions=. 
    [{"precompile_address":"0x7b7c000000000000000000000000000000000000","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000011","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000012","version":2}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000013","version":2}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000014","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000015","version":1}]
    10:27AM INF maintenance precompile version updated module=server precompilesVersions=. 
    [{"precompile_address":"0x7b7c000000000000000000000000000000000000","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000011","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000012","version":2}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000013","version":3}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000014","version":1}, 
    {"precompile_address":"0x7b7c000000000000000000000000000000000015","version":1}]
    10:27AM INF begin setting max precompile calls per execution maxPrecompileCallsPerExecution=0 module=server
    10:27AM INF max precompile calls per execution updated maxPrecompileCallsPerExecution=10 module=server
    10:27AM INF v0.7.0 fork logic applied successfully module=server
     ```

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
