### PR TITLE
Prevent BTC minting to blocked addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -415,6 +415,7 @@ func NewMezo(
 		keys[bridgetypes.StoreKey],
 		app.BankKeeper,
 		app.EvmKeeper,
+		app.BlockedAddrs(),
 	)
 
 	precompiles, err := customEvmPrecompiles(

--- a/x/bridge/keeper/assets_locked.go
+++ b/x/bridge/keeper/assets_locked.go
@@ -96,10 +96,9 @@ func (k Keeper) AcceptAssetsLocked(
 			return fmt.Errorf("failed to parse recipient address: %w", err)
 		}
 
-		// we need to ensure that the funds are not sent
-		// to a blocked address first, in case they are blocked,
-		// then no minting should happen, the funds will
-		// be locked in the bridge.
+		// We need to ensure that the funds are not sent to a blocked address first.
+		// In case the address is blocked, no minting should happen, and the funds should
+		// remain locked in the bridge.
 		if _, ok := k.blockedAddrs[recipient.String()]; ok {
 			ctx.Logger().Warn(
 				"deposit recipient is a blocked address; "+
@@ -111,7 +110,6 @@ func (k Keeper) AcceptAssetsLocked(
 		}
 
 		if bytes.Equal(event.TokenBytes(), sourceBTCToken) {
-
 			err = k.mintBTC(ctx, recipient, event.Amount)
 			if err != nil {
 				return fmt.Errorf(

--- a/x/bridge/keeper/assets_locked_test.go
+++ b/x/bridge/keeper/assets_locked_test.go
@@ -279,8 +279,7 @@ func TestAcceptAssetsLocked(t *testing.T) {
 			},
 			events: types.AssetsLockedEvents{
 				// Sequence tip is 10, so the expected start is 11.
-				// Use an arbitrary token whose mapping is not set.
-				mockEvent(11, testBlockedAddress, 1, "0x96c1493e5a9efa5C7572D98b5e9544B17bD9AE72"),
+				mockEvent(11, testBlockedAddress, 1, testSourceERC20Token1),
 			},
 			errContains: "", // This case shouldn't lead to an error.
 			postCheckFn: func(ctx sdk.Context, k Keeper) {

--- a/x/bridge/keeper/assets_locked_test.go
+++ b/x/bridge/keeper/assets_locked_test.go
@@ -206,6 +206,64 @@ func TestAcceptAssetsLocked(t *testing.T) {
 			errContains: "failed to send coins",
 		},
 		{
+			name: "BTC mint to blocked address as recipient",
+			bankKeeperFn: func(ctx sdk.Context) *mockBankKeeper {
+				bankKeeper := newMockBankKeeper()
+
+				bankKeeper.On(
+					"MintCoins",
+					ctx,
+					types.ModuleName,
+					sdk.NewCoins(
+						sdk.NewCoin(evmtypes.DefaultEVMDenom, math.NewInt(1)),
+					),
+				).Return(nil)
+
+				bankKeeper.On(
+					"SendCoinsFromModuleToAccount",
+					ctx,
+					types.ModuleName,
+					mock.Anything,
+					mock.Anything,
+				).Return(nil)
+
+				return bankKeeper
+			},
+			evmKeeperFn: func(_ sdk.Context) *mockEvmKeeper {
+				return newMockEvmKeeper()
+			},
+			events: types.AssetsLockedEvents{
+				// Sequence tip is 10, so the expected start is 11.
+				mockEvent(11, testBlockedAddress, 1, testSourceBTCToken),
+			},
+			errContains: "", // This case shouldn't lead to an error.
+			postCheckFn: func(ctx sdk.Context, k Keeper) {
+				// The bank state change should not have been executed.
+				k.bankKeeper.(*mockBankKeeper).AssertNotCalled(
+					t,
+					"MintCoins",
+					mock.Anything,
+					mock.Anything,
+				)
+
+				// The bank state change should not have been executed.
+				k.bankKeeper.(*mockBankKeeper).AssertNotCalled(
+					t,
+					"SendCoinsFromModuleToAccount",
+					mock.Anything,
+					mock.Anything,
+				)
+
+				// The sequence tip should have been updated as the event
+				// was skipped.
+				require.EqualValues(
+					t,
+					math.NewInt(11),
+					k.GetAssetsLockedSequenceTip(ctx),
+				)
+			},
+		},
+		{
 			name:         "ERC20 mapping not found",
 			bankKeeperFn: func(_ sdk.Context) *mockBankKeeper { return newMockBankKeeper() },
 			evmKeeperFn: func(ctx sdk.Context) *mockEvmKeeper {

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -24,14 +24,14 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	bankKeeper types.BankKeeper,
 	evmKeeper types.EvmKeeper,
-	blockAddrs map[string]bool,
+	blockedAddrs map[string]bool,
 ) Keeper {
 	return Keeper{
 		cdc:          cdc,
 		storeKey:     storeKey,
 		bankKeeper:   bankKeeper,
 		evmKeeper:    evmKeeper,
-		blockedAddrs: blockAddrs,
+		blockedAddrs: blockedAddrs,
 	}
 }
 

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Keeper struct {
-	cdc        codec.Codec
-	storeKey   storetypes.StoreKey
-	bankKeeper types.BankKeeper
-	evmKeeper  types.EvmKeeper
+	cdc          codec.Codec
+	storeKey     storetypes.StoreKey
+	bankKeeper   types.BankKeeper
+	evmKeeper    types.EvmKeeper
+	blockedAddrs map[string]bool
 }
 
 func NewKeeper(
@@ -23,12 +24,14 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	bankKeeper types.BankKeeper,
 	evmKeeper types.EvmKeeper,
+	blockAddrs map[string]bool,
 ) Keeper {
 	return Keeper{
-		cdc:        cdc,
-		storeKey:   storeKey,
-		bankKeeper: bankKeeper,
-		evmKeeper:  evmKeeper,
+		cdc:          cdc,
+		storeKey:     storeKey,
+		bankKeeper:   bankKeeper,
+		evmKeeper:    evmKeeper,
+		blockedAddrs: blockAddrs,
 	}
 }
 

--- a/x/bridge/keeper/keeper_test.go
+++ b/x/bridge/keeper/keeper_test.go
@@ -20,6 +20,8 @@ import (
 //nolint:gosec
 const testSourceBTCToken = "0x517f2982701695D4E52f1ECFBEf3ba31Df470161"
 
+const testBlockedAddress = "mezo10d07y265gmmuvt4z0w9aw880jnsr700jdl5p9z"
+
 func mockContext() (sdk.Context, Keeper) {
 	logger := log.NewNopLogger()
 
@@ -29,7 +31,7 @@ func mockContext() (sdk.Context, Keeper) {
 	cdc := codec.NewProtoCodec(registry)
 
 	// Create the keeper
-	keeper := NewKeeper(cdc, keys[types.StoreKey], newMockBankKeeper(), newMockEvmKeeper())
+	keeper := NewKeeper(cdc, keys[types.StoreKey], newMockBankKeeper(), newMockEvmKeeper(), map[string]bool{testBlockedAddress: true})
 
 	// Create multiStore in memory
 	db := dbm.NewMemDB()


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-598.

### Introduction

When users bridge BTC to mezo using a blocked address as a
recipient for the funds, the x/bank method SendCoinsFromModuleToAccount
will fail, resulting in the minting and transfer failing down the line.

To prevent this behavour, when processing the AssetLocked events, we
now ignore events where a recipient is one of the blocked addresses.

### Changes

In the x/bridge module, when the keeper processes the new AssetLocked events, we ensure that the event recipient is not in the list of blocked addresses.

### Testing

see the scenario added in x/bridge/keeper/assets_locked_test.go

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
