### PR TITLE
The v1.0.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -12,10 +12,11 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_5"
 	"github.com/mezo-org/mezod/app/upgrades/v0_6"
 	"github.com/mezo-org/mezod/app/upgrades/v0_7"
+	"github.com/mezo-org/mezod/app/upgrades/v1_0"
 )
 
 var (
-	Upgrades = []upgrades.Upgrade{v0_3.Upgrade}
+	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.Upgrade}
 	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )
 

--- a/app/upgrades/v1_0/constants.go
+++ b/app/upgrades/v1_0/constants.go
@@ -1,0 +1,20 @@
+//nolint:revive,stylecheck
+package v1_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the name of the upgrade.
+	UpgradeName = "v1.0.0"
+	// UpgradeInfo defines the binaries that will be used for the upgrade.
+	UpgradeInfo = `'{"binaries":{"linux/amd64":"https://artifactregistry.googleapis.com/download/v1/projects/mezo-test-420708/locations/us-central1/repositories/mezo-staging-binary-public/files/mezod:v1.0.0-rc0:linux-amd64.tar.gz:download?alt=media"}}'`
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v1_0/upgrades.go
+++ b/app/upgrades/v1_0/upgrades.go
@@ -1,0 +1,27 @@
+//nolint:revive,stylecheck
+package v1_0
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdk.UnwrapSDKContext(ctx).Logger().Info("running v1.0.0 upgrade handler")
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -10,20 +10,24 @@ both part of the `app/upgrades` module:
 
 - `Fork`: This component represents a hard fork upgrade that executes a one-time
   code block upon a programmatically enforced block. A `Fork` can schedule an
-  `Upgrade` with state migrations or just perform simple state changes (e.g. parameter upgrades).
-- `Upgrade`: This component defines a set of state migrations. An `Upgrade`
-  can be scheduled either through a `Fork` or through the `Upgrade` precompile.
-  The state migrations are executed using the built-in
+  `Upgrade` or activate state/logic changes at a specific height, using the
+  feature flag approach. `Fork` changes are executed on a running chain.
+- `Upgrade`: This component typically defines state changes that require migrations
+  of the store schema. Moreover, it can be used to roll out complex logic changes
+  that cannot be applied using a feature flag. `Upgrade` changes require
+  a coordinated chain halt to be executed. An `Upgrade` can be scheduled either
+  through a `Fork` or through the `Upgrade` precompile. The store migrations are
+  executed using the built-in
   [Cosmos In-Place Store Migrations mechanism](https://docs.cosmos.network/v0.52/learn/advanced/upgrade).
 
 Those two primitives can be combined to perform different upgrade procedures
 depending on the requirements of the upgrade. Each procedure assumes
 all Mezo chain clients run on version `v1.0.0` initially.
 
-### Hard fork upgrade without state migrations
+### Hard fork upgrade without chain halt
 
-This procedure is suitable for upgrades that do not require any state migrations.
-A good example is an upgrade of consensus parameters.
+This procedure is suitable for upgrades that do not require any store migrations
+nor complex logic changes. A good example is an upgrade of consensus parameters.
 
 The procedure is as follows:
 
@@ -35,13 +39,13 @@ The procedure is as follows:
 5. Once validators reach the fork block, the fork code will be executed.
 
 After the upgrade, the `v2.0.0` clients are still able to validate past blocks produced
-by `v1.0.0` clients. New nodes can sync from the genesis block using`v2.0.0` directly.
+by `v1.0.0` clients. New nodes can sync from the genesis block using `v2.0.0` directly.
 
-### Hard fork upgrade with state migrations
+### Hard fork upgrade with chain halt
 
-This procedure is suitable for urgent upgrades that require state migrations.
-A good example is adding/removing a module or changing the state schema as
-response to a critical vulnerability.
+This procedure is suitable for urgent upgrades that require store migrations
+or complex logic changes. A good example is adding/removing a module or changing
+the store schema as response to a critical vulnerability.
 
 The procedure is as follows:
 
@@ -52,7 +56,7 @@ The procedure is as follows:
    should have the same height as the fork block.
 3. Define a new `v2.Upgrade` in the `app/upgrades/v2/constants.go` file and the
    upgrade handler in the `app/upgrades/v2/upgrades.go` file. The upgrade handler
-   should perform all necessary state migrations.
+   should perform all necessary store migrations.
 4. Register the `v2.Fork` in the `app.Forks` list, in the `app/upgrades.go` file.
 5. Register the `v2.Upgrade` in the `app.Upgrades` list, in the `app/upgrades.go` file.
 6. Release version `v2.0.0` of the Mezo chain client.
@@ -71,18 +75,18 @@ This process can be automated using Cosmovisor. Alternatively, nodes can
 use the state sync process that starts syncing from a snapshot block
 compatible with the latest version.
 
-### Planned upgrade with state migrations
+### Planned upgrade with chain halt
 
-This procedure is suitable for planned upgrades that require state migrations.
-A good example is adding/removing a module or changing the state schema
-as part of a planned feature.
+This procedure is suitable for planned upgrades that require store migrations
+or complex logic changes. A good example is adding/removing a module or changing
+the store schema as part of a planned feature.
 
 The procedure is as follows:
 
 1. Create a package for the new upgrade: `app/upgrades/v2`.
 2. Define a new `v2.Upgrade` in the `app/upgrades/v2/constants.go` file and the
    upgrade handler in the `app/upgrades/v2/upgrades.go` file. The upgrade handler
-   should perform all necessary state migrations.
+   should perform all necessary store migrations.
 3. Register the `v2.Upgrade` in the `app.Upgrades` list, in the `app/upgrades.go` file.
 4. Release version `v2.0.0` of the Mezo chain client.
 5. The governance schedules the `v2` upgrade plan through the `Upgrade` precompile.
@@ -98,9 +102,9 @@ compatible with the latest version.
 
 ## The Upgrade precompile
 
-The `Upgrade` precompile `precompile/upgrade`, serves as an EVM interface to the
+The `Upgrade` precompile (`precompile/upgrade`), serves as an EVM interface to the
 [x/upgrade module](https://docs.cosmos.network/main/build/modules/upgrade) and is used by
-the `Planned upgrade with state migrations` scenario described above.
+the [Planned upgrade with chain halt](#planned-upgrade-with-chain-halt) scenario described above.
 
 ### Upgrade Plan
 
@@ -110,15 +114,15 @@ precompile after a Mezo chain client release with an appropriate upgrade handler
 
 An upgrade `Plan` has the following values:
 
-- `Name`: The upgrade name (corresponds to handler)
+- `Name`: The upgrade name (corresponds to the handler name)
 - `Height`: The block height old clients should halt at to prevent state corruption
 - `Info`: Any metadata about the upgrade (e.g. urls to updated binaries or git commit hash)
 
 ### Upgrade precompile API
 
-Address: `0x7b7c000000000000000000000000000000000014`
-ABI: `precompile/upgrade/abi.json`
-Interface: `precompile/upgrade/IUpgrade.sol`
+- Address: `0x7b7c000000000000000000000000000000000014`
+- ABI: `precompile/upgrade/abi.json`
+- Interface: `precompile/upgrade/IUpgrade.sol`
 
 The `Upgrade` precompile provides 3 methods:
 
@@ -149,33 +153,37 @@ npx hardhat upgrade:cancelPlan --signer OWNER
 
 ### Versioning
 
-Mezo client uses `v0.Y.Z-rcN` versioning pattern for the initial phase
-of the project where only testnet is available. The major version is fixed
-to `0` before mainnet readiness is reached. Moreover, all testnet
-version all release candidates (`-rcN`) to indicate that the software is
+Mezo client was using `v0.Y.Z-rcN` versioning pattern for the initial phase
+of the project where only testnet was available. The major version was fixed
+to `0` before mainnet readiness was reached. Moreover, all testnet-only
+versions were release candidates (`-rcN`) to indicate that the software was
 still in the testing phase.
 
-Once mainnet readiness is reached, the major version will be bumped to `1`
-and proper semantic versioning will be used (`vX.Y.Z`) from there.
-The first mainnet release will be `v1.0.0`.
+Since mainnet readiness was reached, the major version was bumped to `1`
+and proper semantic versioning (`vX.Y.Z`) started to be used from there.
+The first mainnet release is `v1.0.0`.
 
 ### Testnet
 
 Here is the list of upgrades performed on the Mezo Matsnet testnet.
-The `-rcN` suffix is omitted for brevity. Always assume the latest `-rcN` suffix
-for the given version. Consult the <!-- markdown-link-check-disable-line --> [tags list](https://github.com/mezo-org/mezod/tags)
-for full version information.
+For testnet-only versions, the `-rcN` suffix is omitted for brevity.
+In that case, always assume the latest `-rcN` suffix for the given version.
 
-| Version  | Block   | Type                                       | Details                                                                                                                                                                                 |
-|----------|---------|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `v0.1.0` | 1       | N/A                                        | Initial genesis version.                                                                                                                                                                |
-| `v0.2.0` | 496901  | Hard fork upgrade without state migrations | Change gas formula for the `ValidatorPool` precompile. <br/>This change was done before the `Fork` primitive was introduced. <br/>It was executed by introducing versioned precompiles. |
-| `v0.3.0` | 1093500 | Hard fork upgrade with state migrations    | Introduce the Connect price oracle.                                                                                                                                                     |
-| `v0.4.0` | 1745000 | Hard fork upgrade without state migrations | Update EVM storage root strategy (fix for Mezo Passport create2 problem) and introduce EVM observability for the BTC bridge.                                                            |
-| `v0.5.0` | 2213000 | Hard fork upgrade without state migrations | On-chain precompile versioning. New Upgrade and PriceOracle precompiles and upgrade of the existing Maintenance precompile.                                                             |
-| `v0.6.0` | 2563000 | Hard fork upgrade without state migrations | Introduce the ERC20 bridge and the BTC supply assertion.                                                                                                                                |
-| `v0.7.0` | 3078794 | Hard fork upgrade without state migrations | Fix security issues in the EVM state DB. Introduce proper reverts for precompiles. Add chain fee splitter support. Disable Cosmos transactions.                                                                                                                                 |
+Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version information.
+
+| Version  | Block   | Type                                 | Details                                                                                                                                                                                 |
+|----------|---------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `v0.1.0` | 1       | N/A                                  | Initial genesis version.                                                                                                                                                                |
+| `v0.2.0` | 496901  | Hard fork upgrade without chain halt | Change gas formula for the `ValidatorPool` precompile. <br/>This change was done before the `Fork` primitive was introduced. <br/>It was executed by introducing versioned precompiles. |
+| `v0.3.0` | 1093500 | Hard fork upgrade with chain halt    | Introduce the Connect price oracle.                                                                                                                                                     |
+| `v0.4.0` | 1745000 | Hard fork upgrade without chain halt | Update EVM storage root strategy (fix for Mezo Passport create2 problem) and introduce EVM observability for the BTC bridge.                                                            |
+| `v0.5.0` | 2213000 | Hard fork upgrade without chain halt | On-chain precompile versioning. New Upgrade and PriceOracle precompiles and upgrade of the existing Maintenance precompile.                                                             |
+| `v0.6.0` | 2563000 | Hard fork upgrade without chain halt | Introduce the ERC20 bridge and the BTC supply assertion.                                                                                                                                |
+| `v0.7.0` | 3078794 | Hard fork upgrade without chain halt | Fix security issues in the EVM state DB. Introduce proper reverts for precompiles. Add chain fee splitter support. Disable Cosmos transactions.                                         |
+| `v1.0.0` | 3569000 | Hard fork upgrade with chain halt    | Patch for a DoS vector in the bridge. Fix for the precompile revert mechanism                                                                                                           |
 
 ### Mainnet
 
-Mainnet is not yet launched.
+| Version  | Block   | Type                                 | Details                                                                                                                                                                                 |
+|----------|---------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                                                                                                                                |


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-684/the-v100-matsnet-upgrade

### Introduction

Here we make the necessary preparations in order to execute the v1.0.0 upgrade on Mezo Matsnet. The mentioned upgrade will introduce the following things:
1. Patch for a DoS vector in the bridge (https://github.com/mezo-org/mezod/pull/430)
2. Fix for the precompile revert mechanism (https://github.com/mezo-org/mezod/pull/431)
3. The `mezo_estimateCost` RPC function (https://github.com/mezo-org/mezod/pull/426)

### Changes

#### The v1.0.0 upgrade handler

The aforementioned changes introduced by v1.0.0 are consensus breaking and require a coordinated chain halt to be rolled out properly. That said, we schedule an upgrade against the `Upgrade` precompile, which is our EVM interface to the Cosmos SDK `x/upgrade` module. An upgrade like that requires an upgrade handler to be created to satisfy the Cosmos upgrade mechanism. Here we add such a handler. Altough the handler is a no-op, it is necessary so nodes can resume after the coordinated chain halt.

### Testing

1. Switch to `v0.7.0-rc0` which is the current version used on Matsnet.
2. Spin up a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Start at least three nodes using `make localnet-bin-start`.
4. Switch to `precompile/hardhat`.
5. Schedule an upgrade using `npx hardhat upgrade:submitPlan --signer <poa-owner> --name v1.0.0 --height <height> --info ""`. Fetch `poa-owner` using `npx hardhat validatorPool:owner`. As `height`, use your current height + 10 blocks.
6. Wait until the chain halts and stop your nodes.
7. Switch to this branch `v1-fork-prep` and `make build` the new binary.
8. Restart your nodes. The chain should resume.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
