### PR TITLE
Add static IP for monitoring

### DIFF
--- a/infrastructure/terraform/mezo-staging/variables.tf
+++ b/infrastructure/terraform/mezo-staging/variables.tf
@@ -112,6 +112,7 @@ variable "global_external_ip_addresses" {
     "mezo-staging-rpc-external-ip",
     "mezo-staging-rpc-ws-external-ip",
     "mezo-staging-safe-external-ip",
+    "mezo-staging-monitoring-external-ip",
   ]
 }
 


### PR DESCRIPTION
Part of: https://linear.app/thesis-co/issue/TET-566/validators-status-page

### Introduction

This add a new reserved static IP which will be used to deploy some validators status monitoring.

### Changes

Adds a new static IP in the terraform staging infrastructure.

### Testing

Go inside the infrastructure/terraform/mezo-staging directory then set youself up using the steps in the README.md.
Then run `terraform plan`, the plan should reflect the new static IP creation.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
