### PR TITLE
update mezo-org/go-ethereum to use v1.14.8-mezo2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -279,7 +279,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	// use mezo geth fork
-	github.com/ethereum/go-ethereum => github.com/mezo-org/go-ethereum v1.14.8-mezo
+	github.com/ethereum/go-ethereum => github.com/mezo-org/go-ethereum v1.14.8-mezo2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
 

--- a/go.sum
+++ b/go.sum
@@ -1639,8 +1639,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/mediocregopher/radix/v3 v3.8.1/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo h1:1UptFWudKEtlp8yrZ90QrXpK7X4YWyZVuOlzyu9i3KY=
 github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
-github.com/mezo-org/go-ethereum v1.14.8-mezo h1:AVG+BS/tzmeq1Vux991u2jH35AWcDxEI4/bx5JonFSY=
-github.com/mezo-org/go-ethereum v1.14.8-mezo/go.mod h1:ugZ1e3buGofOVBx5ZgNViY5ZVjS3bav1D4VqdtQViBI=
+github.com/mezo-org/go-ethereum v1.14.8-mezo2 h1:/U7VImjSy8pPu75rsDkgWiQ6yUqmRW7X+pADcHkGUE8=
+github.com/mezo-org/go-ethereum v1.14.8-mezo2/go.mod h1:ugZ1e3buGofOVBx5ZgNViY5ZVjS3bav1D4VqdtQViBI=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miguelmota/go-ethereum-hdwallet v0.1.1 h1:zdXGlHao7idpCBjEGTXThVAtMKs+IxAgivZ75xqkWK0=


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-695/fix-evm-precompiles-mismatch-to-unblock-velar

### Introduction

A team building on the mezo testnet recently discovered a bug while trying to deploy a contract. For some background, Mezo uses a fork of go-ethereum (https://github.com/mezo-org/go-ethereum) which implement some changes around precompiles. When those changes where added, the kzgPointEvaluation precompile ended up with the same address as dataCopy (0x04) and all following address where shifted of 1 (e.g: 0x0b ended up being 0x0a). 

### Changes

This change update the mezod dependency to the go-ethereum fork (tag 1.14.8-mezo2). 

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
