### PR TITLE
Fix Dockerfile after MezoBridge bindings changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --parents ./**/*.txt ./
 COPY --parents ./**/.keep ./
 COPY --parents ./**/*.json ./
 COPY --parents ./**/*.go ./
-COPY --parents ethereum/bindings/portal/gen/_address/MezoBridge ./
+COPY --parents ethereum/bindings/portal/*/gen/_address/MezoBridge ./
 
 RUN make bindings
 RUN make build


### PR DESCRIPTION
### Introduction

The `ethereum/bindings` directory structure was recently changed to include multiple networks. We forgot to reflect that change in the Dockerfile though. Here we fix that mistake.

### Changes

One-liner in the root `Dockerfile`.

### Testing

`make build-docker-linux`

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
