### PR TITLE
Bump Mezo testnet nodes to v1.0.0-rc1

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.5.0
+    version: 1.6.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.5.0
+    version: 1.6.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.5.0
+    version: 1.6.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.5.0
+    version: 1.6.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.5.0
+    version: 1.6.0
     labels:
       type: validator
     values:


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-701/the-v100-rc1-matsnet-upgrade

### Introduction

Here we bump the Mezo testnet nodes we host to the new `mezod` version `v1.0.0-rc1`.

### Changes

We do the mentioned action by bumping the V-Kit Helm chart version to `v1.6.0`. Under the hood, this chart resolves to `mezod` `v1.0.0-rc1`.

### Testing

No local testing. Already deployed on our cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
