### PR TITLE
Add GH service account as binary registry writer

### DIFF
--- a/infrastructure/terraform/mezo-staging/oidc-github.tf
+++ b/infrastructure/terraform/mezo-staging/oidc-github.tf
@@ -45,6 +45,12 @@ resource "google_artifact_registry_repository_iam_member" "gha_sa-docker_public_
   member     = "serviceAccount:${google_service_account.gha.email}"
 }
 
+resource "google_artifact_registry_repository_iam_member" "gha_sa-generic_public_writer" {
+  repository = google_artifact_registry_repository.generic_public.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.gha.email}"
+}
+
 # Attach the Workload Identity Pool (via role) to the Service Accounts
 # that will be used by GitHub Actions.
 resource "google_service_account_iam_member" "gha_sa-github_wi_user" {


### PR DESCRIPTION
### Introduction

In https://github.com/mezo-org/mezod/pull/411, we added a job that automatically publishes release candidate binaries to our GCP artifact registry in the `mezo-staging` project. To make it work, the GitHub service account used within the mentioned job must have write permission on the `mezo-staging-binary-public` registry. Here we add this piece to our TF config.

### Testing

Already deployed on `mezo-staging` GCP project.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
