### PR TITLE
Remove panic condition guarding mainnet chain config

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -39,8 +39,6 @@ func LoadConfig(chainID string) (Config, error) {
 	//nolint:gocritic
 	if utils.IsMainnet(chainID) {
 		baseDir = mainnetPath
-		// TODO: Remove panic once mainnet is supported.
-		panic("mainnet is not supported yet")
 	} else if utils.IsTestnet(chainID) {
 		baseDir = testnetPath
 	} else {


### PR DESCRIPTION
### Introduction

In #444 we forgot to remove a panic condition preventing premature mainnet usage. Here we fix that.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
