### PR TITLE
Monitoring system tweaks

### DIFF
--- a/infrastructure/kubernetes/common/monitoring/README.md
+++ b/infrastructure/kubernetes/common/monitoring/README.md
@@ -78,3 +78,25 @@ monitoring dashboard through HTTPS at the path "/grafana". It is pinned to the
 `mezo-<environment>-monitoring-hub-external-ip` static global IP and uses
 `mezo-<environment>-monitoring-hub-ssl-certificate` SSL certificate, both created by
 the `mezo-<environment>` Terraform module.
+
+### Add a node to the monitoring
+
+The monitoring system does not automatically discover new nodes yet. That said, 
+new nodes must be added to the monitoring system manually. This can be done by 
+running the `add-node.sh` script on the desired environment.
+
+First, switch to the desired environment by setting the right `kubectl` context:
+```Shell
+kubectl config use-context <context-name>
+```
+
+You can use `kubectl config get-contexts` to list the available contexts. If you don't
+see the context you need, you have to download cluster credentials using the
+`gcloud container clusters get-credentials` command.
+
+Then, run the `add-node.sh` script:
+```Shell
+./add-node.sh <rpc_url> <moniker>
+```
+where `<rpc_url>` is the EVM JSON-RPC URL of the node and `<moniker>` is the moniker that
+will be displayed in the monitoring dashboard.

--- a/infrastructure/kubernetes/common/monitoring/add-node.sh
+++ b/infrastructure/kubernetes/common/monitoring/add-node.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if required arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <rpc_url> <moniker>"
+    exit 1
+fi
+
+RPC_URL=$1
+MONIKER=$2
+SECRET_NAME="metrics-scraper-config"
+NAMESPACE="monitoring"
+
+# Get the existing secret data
+EXISTING_CONFIG=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.config\.json}' | base64 --decode)
+
+# Create a temporary file with the existing config
+TMP_FILE=$(mktemp)
+echo "$EXISTING_CONFIG" > "$TMP_FILE"
+
+# Add the new node using jq
+jq --arg url "$RPC_URL" --arg moniker "$MONIKER" '.nodes += [{"rpc_url": $url, "moniker": $moniker}]' "$TMP_FILE" > "${TMP_FILE}.new"
+
+# Update the secret
+kubectl create secret generic $SECRET_NAME -n $NAMESPACE --from-file=config.json="${TMP_FILE}.new" --dry-run=client -o yaml | kubectl apply -f -
+
+# Clean up temporary files
+rm "$TMP_FILE" "${TMP_FILE}.new"
+
+# Restart the metrics-scraper deployment
+kubectl rollout restart deployment metrics-scraper -n $NAMESPACE
+
+echo "Successfully added new node with moniker: $MONIKER and restarted metrics-scraper deployment" 

--- a/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
@@ -37,6 +37,10 @@ spec:
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               value: "grafana-clock-panel,grafana-simple-json-datasource"
+            - name: GF_SERVER_ROOT_URL
+              value: "https://%(domain)s/grafana/"
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
           readinessProbe:
             httpGet:
               path: /api/health

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/mezo-nodes-public.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/mezo-nodes-public.json
@@ -88,13 +88,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "sum by(chain_id) (sum by(moniker) (up{chain_id=\"mezo_31611-1\"}))",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "Nodes Up"
         }
       ],
       "title": "Nodes Up",
@@ -198,7 +198,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
           "expr": "min by(moniker) (ethereum_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
@@ -206,7 +206,7 @@
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "Discovered Keep Nodes"
+          "refId": "Ethereum sidecar connectivity"
         }
       ],
       "title": "Ethereum sidecar connectivity",
@@ -310,7 +310,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "min by(moniker) (connect_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
@@ -318,7 +318,7 @@
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "Discovered Keep Nodes"
+          "refId": "Connect sidecar connectivity"
         }
       ],
       "title": "Connect sidecar connectivity",
@@ -386,14 +386,14 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "min by(moniker) (up{chain_id=\"mezo_31611-1\"})",
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "A"
+          "refId": "Uptime"
         }
       ],
       "title": "Uptime (experimental)",

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/mezo-nodes-public.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/mezo-nodes-public.json
@@ -60,7 +60,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 11,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -91,14 +91,290 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum by(chain_id) (sum by(moniker) (up{chain_id=\"mezo_31611-1\"}))",
+          "expr": "sum by(chain_id) (sum by(moniker) (up{chain_id=\"mezo_31612-1\"}))",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "Nodes Up"
+          "refId": "Monitored nodes"
         }
       ],
-      "title": "Nodes Up",
+      "title": "Monitored nodes",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "min by(moniker) (up{chain_id=\"mezo_31612-1\"})",
+          "interval": "",
+          "legendFormat": "{{chain_address}}",
+          "range": true,
+          "refId": "Uptime"
+        }
+      ],
+      "title": "Uptime (experimental)",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "min by(moniker) (latest_block{chain_id=\"mezo_31612-1\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Latest block",
+          "useBackend": false
+        }
+      ],
+      "title": "Latest block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "min by(moniker) (latest_timestamp{chain_id=\"mezo_31612-1\"}) * 1000",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Latest block time",
+          "useBackend": false
+        }
+      ],
+      "title": "Latest block time",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -169,10 +445,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 20,
-        "w": 13,
-        "x": 11,
-        "y": 0
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
       },
       "id": 11,
       "interval": "1m",
@@ -182,7 +458,7 @@
             "last"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Last",
           "sortDesc": true
@@ -201,7 +477,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "min by(moniker) (ethereum_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
+          "expr": "min by(moniker) (ethereum_sidecar_connectivity{chain_id=\"mezo_31612-1\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{chain_address}}",
@@ -281,10 +557,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 20,
-        "w": 13,
-        "x": 11,
-        "y": 20
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
       },
       "id": 13,
       "interval": "1m",
@@ -294,7 +570,7 @@
             "last"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Last",
           "sortDesc": true
@@ -313,7 +589,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "min by(moniker) (connect_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
+          "expr": "min by(moniker) (connect_sidecar_connectivity{chain_id=\"mezo_31612-1\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{chain_address}}",
@@ -335,16 +611,11 @@
             "mode": "thresholds"
           },
           "custom": {
-            "axisPlacement": "auto",
-            "fillOpacity": 70,
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "insertNulls": false,
-            "lineWidth": 0,
-            "spanNulls": false
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -352,6 +623,10 @@
             "steps": [
               {
                 "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -359,45 +634,149 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 25,
-        "w": 13,
-        "x": 11,
-        "y": 40
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
       },
-      "id": 6,
+      "id": 16,
       "options": {
-        "alignValue": "left",
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "mergeValues": true,
-        "rowHeight": 0.9,
-        "showValue": "auto",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "frameIndex": 1,
+        "showHeader": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "mezod_version{chain_id=\"mezo_31612-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Mezod version",
+          "useBackend": false
+        },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "min by(moniker) (up{chain_id=\"mezo_31611-1\"})",
-          "interval": "",
-          "legendFormat": "{{chain_address}}",
-          "range": true,
-          "refId": "Uptime"
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "ethereum_sidecar_connectivity{chain_id=\"mezo_31612-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Ethereum sidecar version",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "connect_sidecar_connectivity{chain_id=\"mezo_31612-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Uptime (experimental)",
-      "type": "state-timeline"
+      "title": "Versions",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "moniker",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": false,
+              "Time 2": true,
+              "Time 3": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #Ethereum sidecar version": true,
+              "Value #Mezod version": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "chain_id 1": true,
+              "chain_id 2": true,
+              "chain_id 3": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time 1": 0,
+              "Time 2": 8,
+              "Time 3": 15,
+              "Value #A": 21,
+              "Value #Ethereum sidecar version": 14,
+              "Value #Mezod version": 7,
+              "__name__ 1": 2,
+              "__name__ 2": 9,
+              "__name__ 3": 16,
+              "chain_id 1": 3,
+              "chain_id 2": 10,
+              "chain_id 3": 17,
+              "instance 1": 4,
+              "instance 2": 11,
+              "instance 3": 18,
+              "job 1": 5,
+              "job 2": 12,
+              "job 3": 19,
+              "moniker": 1,
+              "sidecar_version 1": 13,
+              "sidecar_version 2": 20,
+              "version": 6
+            },
+            "renameByName": {
+              "instance 2": "",
+              "sidecar_version": "ethereum sidecar version",
+              "sidecar_version 1": "ethereum sidecar",
+              "sidecar_version 2": "connect sidecar",
+              "version": "mezod"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,
@@ -411,12 +790,12 @@
     "list": []
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Mezo Nodes (Public)",
   "uid": "hhDyYDI4z",
-  "version": 2
+  "version": 3
 }

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/deployement-patch.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/deployement-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: grafana
+          env:
+            - name: GF_SERVER_DOMAIN
+              value: monitoring.mezo.org

--- a/infrastructure/kubernetes/mezo-production/monitoring/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ingress.yaml
 
 patches:
-  - path: metrics-scraper/service-patch.yaml
   - path: grafana/deployement-patch.yaml
 
 configMapGenerator:

--- a/infrastructure/kubernetes/mezo-production/monitoring/metrics-scraper/service-patch.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/metrics-scraper/service-patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: metrics-scraper
-  namespace: monitoring
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: "mezo-production-monitoring-external-ip"
-    kubernetes.io/ingress.class: "gce"

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/mezo-nodes-public.json
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/mezo-nodes-public.json
@@ -60,7 +60,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 11,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -94,11 +94,287 @@
           "expr": "sum by(chain_id) (sum by(moniker) (up{chain_id=\"mezo_31611-1\"}))",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "Nodes Up"
+          "refId": "Monitored nodes"
         }
       ],
-      "title": "Nodes Up",
+      "title": "Monitored nodes",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "min by(moniker) (up{chain_id=\"mezo_31611-1\"})",
+          "interval": "",
+          "legendFormat": "{{chain_address}}",
+          "range": true,
+          "refId": "Uptime"
+        }
+      ],
+      "title": "Uptime (experimental)",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "min by(moniker) (latest_block{chain_id=\"mezo_31611-1\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Latest block",
+          "useBackend": false
+        }
+      ],
+      "title": "Latest block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "min by(moniker) (latest_timestamp{chain_id=\"mezo_31611-1\"}) * 1000",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Latest block time",
+          "useBackend": false
+        }
+      ],
+      "title": "Latest block time",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -169,10 +445,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 20,
-        "w": 13,
-        "x": 11,
-        "y": 0
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
       },
       "id": 11,
       "interval": "1m",
@@ -182,7 +458,7 @@
             "last"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Last",
           "sortDesc": true
@@ -281,10 +557,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 20,
-        "w": 13,
-        "x": 11,
-        "y": 20
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
       },
       "id": 13,
       "interval": "1m",
@@ -294,7 +570,7 @@
             "last"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Last",
           "sortDesc": true
@@ -335,16 +611,11 @@
             "mode": "thresholds"
           },
           "custom": {
-            "axisPlacement": "auto",
-            "fillOpacity": 70,
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "insertNulls": false,
-            "lineWidth": 0,
-            "spanNulls": false
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -352,6 +623,10 @@
             "steps": [
               {
                 "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -359,45 +634,149 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 25,
-        "w": 13,
-        "x": 11,
-        "y": 40
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
       },
-      "id": 6,
+      "id": 16,
       "options": {
-        "alignValue": "left",
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "mergeValues": true,
-        "rowHeight": 0.9,
-        "showValue": "auto",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "frameIndex": 1,
+        "showHeader": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "mezod_version{chain_id=\"mezo_31611-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Mezod version",
+          "useBackend": false
+        },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "min by(moniker) (up{chain_id=\"mezo_31611-1\"})",
-          "interval": "",
-          "legendFormat": "{{chain_address}}",
-          "range": true,
-          "refId": "Uptime"
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "ethereum_sidecar_connectivity{chain_id=\"mezo_31611-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Ethereum sidecar version",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "connect_sidecar_connectivity{chain_id=\"mezo_31611-1\"}",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Uptime (experimental)",
-      "type": "state-timeline"
+      "title": "Versions",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "moniker",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": false,
+              "Time 2": true,
+              "Time 3": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #Ethereum sidecar version": true,
+              "Value #Mezod version": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "chain_id 1": true,
+              "chain_id 2": true,
+              "chain_id 3": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time 1": 0,
+              "Time 2": 8,
+              "Time 3": 15,
+              "Value #A": 21,
+              "Value #Ethereum sidecar version": 14,
+              "Value #Mezod version": 7,
+              "__name__ 1": 2,
+              "__name__ 2": 9,
+              "__name__ 3": 16,
+              "chain_id 1": 3,
+              "chain_id 2": 10,
+              "chain_id 3": 17,
+              "instance 1": 4,
+              "instance 2": 11,
+              "instance 3": 18,
+              "job 1": 5,
+              "job 2": 12,
+              "job 3": 19,
+              "moniker": 1,
+              "sidecar_version 1": 13,
+              "sidecar_version 2": 20,
+              "version": 6
+            },
+            "renameByName": {
+              "instance 2": "",
+              "sidecar_version": "ethereum sidecar version",
+              "sidecar_version 1": "ethereum sidecar",
+              "sidecar_version 2": "connect sidecar",
+              "version": "mezod"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,
@@ -411,12 +790,12 @@
     "list": []
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Mezo Nodes (Public)",
   "uid": "hhDyYDI4z",
-  "version": 2
+  "version": 3
 }

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/mezo-nodes-public.json
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/mezo-nodes-public.json
@@ -88,13 +88,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "sum by(chain_id) (sum by(moniker) (up{chain_id=\"mezo_31611-1\"}))",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "Nodes Up"
         }
       ],
       "title": "Nodes Up",
@@ -198,7 +198,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
           "expr": "min by(moniker) (ethereum_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
@@ -206,7 +206,7 @@
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "Discovered Keep Nodes"
+          "refId": "Ethereum sidecar connectivity"
         }
       ],
       "title": "Ethereum sidecar connectivity",
@@ -310,7 +310,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "min by(moniker) (connect_sidecar_connectivity{chain_id=\"mezo_31611-1\"})",
@@ -318,7 +318,7 @@
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "Discovered Keep Nodes"
+          "refId": "Connect sidecar connectivity"
         }
       ],
       "title": "Connect sidecar connectivity",
@@ -386,14 +386,14 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P09205B1DD12FB1C6"
+            "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
           "expr": "min by(moniker) (up{chain_id=\"mezo_31611-1\"})",
           "interval": "",
           "legendFormat": "{{chain_address}}",
           "range": true,
-          "refId": "A"
+          "refId": "Uptime"
         }
       ],
       "title": "Uptime (experimental)",

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/deployement-patch.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/deployement-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: grafana
+          env:
+            - name: GF_SERVER_DOMAIN
+              value: monitoring.test.mezo.org

--- a/infrastructure/kubernetes/mezo-staging/monitoring/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 patches:
   - path: metrics-scraper/service-patch.yaml
+  - path: grafana/deployement-patch.yaml
 
 configMapGenerator:
   - name: grafana-dashboards-mezo

--- a/infrastructure/kubernetes/mezo-staging/monitoring/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ingress.yaml
 
 patches:
-  - path: metrics-scraper/service-patch.yaml
   - path: grafana/deployement-patch.yaml
 
 configMapGenerator:

--- a/infrastructure/kubernetes/mezo-staging/monitoring/metrics-scraper/service-patch.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/metrics-scraper/service-patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: metrics-scraper
-  namespace: monitoring
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: "mezo-staging-monitoring-external-ip"
-    kubernetes.io/ingress.class: "gce"

--- a/infrastructure/terraform/mezo-production/variables.tf
+++ b/infrastructure/terraform/mezo-production/variables.tf
@@ -93,7 +93,6 @@ variable "global_external_ip_addresses" {
   default = [
     "mezo-production-blockscout-api-external-ip",
     "mezo-production-blockscout-app-external-ip",
-    "mezo-production-monitoring-external-ip",
     "mezo-production-monitoring-hub-external-ip",
   ]
 }

--- a/infrastructure/terraform/mezo-staging/variables.tf
+++ b/infrastructure/terraform/mezo-staging/variables.tf
@@ -112,7 +112,6 @@ variable "global_external_ip_addresses" {
     "mezo-staging-rpc-external-ip",
     "mezo-staging-rpc-ws-external-ip",
     "mezo-staging-safe-external-ip",
-    "mezo-staging-monitoring-external-ip",
     "mezo-staging-monitoring-hub-external-ip",
   ]
 }


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-566/validators-status-page

### Introduction

Here we add some tweaks and fixes to the monitoring stack.

### Changes

#### Serving Grafana from subpath and adding server root

We added three envs to the Grafana deployment: `GF_SERVER_ROOT_URL`, `GF_SERVER_SERVE_FROM_SUB_PATH`, and `GF_SERVER_DOMAIN`. They allow building proper links to the public grafana dashboards.

#### Tweaks to the dashboards

We fixed the wrong datasource UID in several places that led to errors in publicly shared dashboards. Moreover, we added new panes with latest blocks, latest timestamps, and versions.

#### Helper script allowing to add nodes to the monitoring

We also added a helper script `add-node.sh` that allows adding new nodes to the monitoring system before a proper service discovery is implemented.

#### Cleanup of metrics scraper service

The current definition of the service does not use the reserved monitoring IP for egress. Given the clusters configuration, all egress traffic goes through Cloud NAT in all cases. That said, we cleanup the current metrics scraper service from unnecessary stuff and we recommend providers allowlist the NAT IP.

### Testing

Deployed on `mezo-staging`. See: https://monitoring.test.mezo.org/grafana/public-dashboards/37720ad4d3724c01bc1c606b70f7dadc

Deployed on `mezo-production`. See: https://monitoring.mezo.org/grafana/public-dashboards/3f5bc2b2d2374d77ba1fb06bb937c7c6

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
