### PR TITLE
Final mainnet genesis file

### DIFF
--- a/chain/mainnet/mezo_31612-1/genesis.json
+++ b/chain/mainnet/mezo_31612-1/genesis.json
@@ -1,7 +1,7 @@
 {
   "app_name": "mezod",
-  "app_version": "1.0.0-rc2",
-  "genesis_time": "2025-04-14T08:50:53.767481Z",
+  "app_version": "1.0.0",
+  "genesis_time": "2025-05-05T00:00:00Z",
   "chain_id": "mezo_31612-1",
   "initial_height": 1,
   "app_hash": null,
@@ -18,7 +18,7 @@
         {
           "@type": "/ethermint.types.v1.EthAccount",
           "base_account": {
-            "address": "mezo188vx087k295fxdlx7f4wkznmghajnf0maysxpe",
+            "address": "mezo1lgqdjxlda6gaj9sx836y54qnr3jqght9k4evlp",
             "pub_key": null,
             "account_number": "0",
             "sequence": "0"
@@ -28,7 +28,7 @@
         {
           "@type": "/ethermint.types.v1.EthAccount",
           "base_account": {
-            "address": "mezo1qcjuy52698gf7xaymfdg00guh3nnse6chm0s2t",
+            "address": "mezo1v9klhl4r0jz53mfxnaqpsjthrmdqj29f9x75vj",
             "pub_key": null,
             "account_number": "1",
             "sequence": "0"
@@ -38,7 +38,7 @@
         {
           "@type": "/ethermint.types.v1.EthAccount",
           "base_account": {
-            "address": "mezo14ugypmyfn2whx4dhsw4jwflk2x5fx2vkvmjrzk",
+            "address": "mezo1798j0fx86am2rwqjzxg90yzd0ljf6ha4akc3g4",
             "pub_key": null,
             "account_number": "2",
             "sequence": "0"
@@ -48,7 +48,7 @@
         {
           "@type": "/ethermint.types.v1.EthAccount",
           "base_account": {
-            "address": "mezo1lgrfdvcj38gwcwr0qv4ytdfcygc0mg6slsj3yt",
+            "address": "mezo1zac4c8uemn9u4r2fu5t9uj45e9vg9xplj7euf5",
             "pub_key": null,
             "account_number": "3",
             "sequence": "0"
@@ -67,16 +67,16 @@
       },
       "balances": [
         {
-          "address": "mezo1qcjuy52698gf7xaymfdg00guh3nnse6chm0s2t",
+          "address": "mezo1zac4c8uemn9u4r2fu5t9uj45e9vg9xplj7euf5",
           "coins": [
             {
               "denom": "amezo",
-              "amount": "200000000000000000000000000"
+              "amount": "100000000000000000000000000"
             }
           ]
         },
         {
-          "address": "mezo188vx087k295fxdlx7f4wkznmghajnf0maysxpe",
+          "address": "mezo1v9klhl4r0jz53mfxnaqpsjthrmdqj29f9x75vj",
           "coins": [
             {
               "denom": "amezo",
@@ -85,7 +85,7 @@
           ]
         },
         {
-          "address": "mezo14ugypmyfn2whx4dhsw4jwflk2x5fx2vkvmjrzk",
+          "address": "mezo1798j0fx86am2rwqjzxg90yzd0ljf6ha4akc3g4",
           "coins": [
             {
               "denom": "amezo",
@@ -94,11 +94,11 @@
           ]
         },
         {
-          "address": "mezo1lgrfdvcj38gwcwr0qv4ytdfcygc0mg6slsj3yt",
+          "address": "mezo1lgqdjxlda6gaj9sx836y54qnr3jqght9k4evlp",
           "coins": [
             {
               "denom": "amezo",
-              "amount": "100000000000000000000000000"
+              "amount": "200000000000000000000000000"
             }
           ]
         }
@@ -224,7 +224,7 @@
       "params": {
         "max_validators": 150
       },
-      "owner": "mezo1jr94z044k6p34pmnj2hx6s9e4xmrz4wgg56ln5",
+      "owner": "mezo1zgmffzrdhadvjnw6quf4xj2ng5mdzn90eeettl",
       "validators": [
         {
           "operator_bech32": "mezovaloper16c35xww08dkapvqv3fmv2f4zgjyvk47ujeds70",
@@ -253,6 +253,28 @@
           "cons_pub_key_bech32": "mezovalconspub1zcjduepqmxfn93wn28r2nfjsce0d6d5y98maqmsdu0xx23uay4y2ksfztm2qy9r6pm",
           "description": {
             "moniker": "Imperator.co",
+            "identity": "",
+            "website": "",
+            "security_contact": "",
+            "details": ""
+          }
+        },
+        {
+          "operator_bech32": "mezovaloper1q4uynw367laz23lpc5s0txmatfrtusual05mky",
+          "cons_pub_key_bech32": "mezovalconspub1zcjduepq3e0n3wnp42ezvxmg8tk7wq2gh65sswx7fpaymjzfqgpg7fyq7rgqyslfun",
+          "description": {
+            "moniker": "Chorus One",
+            "identity": "",
+            "website": "",
+            "security_contact": "",
+            "details": ""
+          }
+        },
+        {
+          "operator_bech32": "mezovaloper1ts790uaa43wgralzwtfkfenvvc5y6sxv4xq7pq",
+          "cons_pub_key_bech32": "mezovalconspub1zcjduepqk2j255k2khjkxlvqk7jfntpr2u098u6y9p7yqt5sf9p09kmtly9qkmawcm",
+          "description":{
+            "moniker":"Enigma",
             "identity": "",
             "website": "",
             "security_contact": "",


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-788/final-mainnet-genesis-file-update

> [!NOTE]
> I used `mezod keys parse` to convert between EVM and bech32 addresses. Please cross-check using a DIFFERENT tool to make sure addresses encoded in genesis match the ones from the PR description. 

### Introduction

Here we update the existing genesis file for pre-mainnet (https://github.com/mezo-org/mezod/pull/444) and turn it into a final genesis file for mainnet.

### Changes

#### Update app version and genesis time

We set the app version to be `v1.0.0` (final stable mainnet version) and genesis time to May 5th, 2025, 00:00 UTC. This way, we guarantee genesis doesn't happen earlier than this time.

#### Update MEZO allocations

We update the MEZO allocation buckets:
- Bucket 1: `0x616dfbFea37c8548ED269f401849771edA0928a9`
- Bucket 2: `0xFa00d91beDEE91d916063C744a54131c64045d65`
- Bucket 3: `0xf14f27A4c7d776A1B812119057904D7fe49d5fB5`
- Bucket 4: `0x17715C1F99DccBcA8d49e5165e4Ab4c95882983f`

We mint 1B (1,000,000,000) of MEZO and allocate the supply to the aforementioned buckets as follows:
- Bucket 1: 300,000,000 MEZO
- Bucket 2: 200,000,000 MEZO
- Bucket 3: 400,000,000 MEZO
- Bucket 4: 100,000,000 MEZO

#### Add two genesis validators

We add two additional genesis validators (next to the existing three).

#### Update PoA owner

We update the PoA owner to be our usual deployer address: `0x123694886DBf5Ac94DDA07135349534536D14cAf`

### Testing

First of all, double check all the addresses and numbers. Note that MEZO allocations may be in different order in the genesis file than in the PR description because of the sorting done by the `x/bank` module from Cosmos SDK.

Second, make sure the set of parameters we update here for mainnet is complete and we did not miss anything important that should be changed comparing to pre-mainnet.

Third, make sure the operator addresses and consensus public keys of the all 5 genesis validators match what they use for current pre-mainnet. The easiest way is to convert the bech32 values from the genesis file to hex and cross-check with the block explorer (see [ValidatorPool.validators](https://explorer.mezo.org/address/0x7B7C000000000000000000000000000000000011?tab=read_contract#ca1e7819) and [ValidatorPool.validator](https://explorer.mezo.org/address/0x7B7C000000000000000000000000000000000011?tab=read_contract#223b3b7a)). Remember that that when converting the consensus public key from bech32, you need to take the last 32 bytes from the resulting hex for comparison.

Last but not least, you can spin out a localnet using this genesis file. However, you need to:
- Adjust the genesis time so blocks start immediately
- Adjust the chain id to localnet 
- Update the validator set to the localnet ones (remember about updating the bridge validator as well)

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
