### PR TITLE
Update Dockerfile to use Go version 1.22.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Build layer
 #
-FROM golang:1.22.8-bullseye AS build
+FROM golang:1.22.11-bullseye AS build
 
 WORKDIR /go/src/github.com/mezo-org/mezod
 


### PR DESCRIPTION
### Introduction

We recently bumped Go in `go.mod` to 1.22.11. We need to do the same in the Dockerfile.

### Testing

`make build-docker-linux`

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
