### PR TITLE
Fix permissions for the GHA `Release Binary` workflow

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -5,11 +5,12 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]-+rc[0-9]+'  # release candidate
       - 'v[0-9]+.[0-9]+.[0-9]+'  # release
+  workflow_dispatch:
 
 jobs:
   client-build-publish:
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
### Introduction

In order to create a draft release, the workflow must have `contents: write`.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
