### PR TITLE
Minor tweaks to the block explorer

### DIFF
--- a/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
+++ b/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
@@ -56,6 +56,8 @@ blockscout:
     CONTRACT_VERIFICATION_ALLOWED_VYPER_EVM_VERSIONS: byzantium,constantinople,petersburg,istanbul,berlin,london,default
     INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true # Disable internal transactions fetcher for now. It does not work in all cases and causes the whole indexer to stop.
     CACHE_ADDRESS_TRANSACTIONS_COUNTER_PERIOD: 5m
+    COIN: BTC
+    EXCHANGE_RATES_COINGECKO_COIN_ID: bitcoin
   extraEnv:
     - name: POSTGRES_PASSWORD
       valueFrom:
@@ -91,6 +93,8 @@ frontend:
     NEXT_PUBLIC_COLOR_THEME_DEFAULT: light
     NEXT_PUBLIC_NETWORK_LOGO: https://mezo.org/assets/mezo-vsve-pvk.svg
     NEXT_PUBLIC_NETWORK_ICON: https://mezo.org/assets/mezo-favicon-h-eecjcq.svg
+    NEXT_PUBLIC_VIEWS_TX_HIDDEN_FIELDS: '["burnt_fees"]'
+    NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE: validation
 
 stats:
   enabled: false # This won't be needed for now.

--- a/infrastructure/kubernetes/mezo-staging/values/blockscout-stack.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/blockscout-stack.yaml
@@ -17,6 +17,8 @@ config:
     enabled: false # This won't be needed for now.
 
 blockscout:
+  image:
+    tag: 6.9.2
   ingress:
     enabled: true
     hostname: api.explorer.test.mezo.org
@@ -53,6 +55,8 @@ blockscout:
     CONTRACT_VERIFICATION_ALLOWED_VYPER_EVM_VERSIONS: byzantium,constantinople,petersburg,istanbul,berlin,london,default
     INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true # Disable internal transactions fetcher for now. It does not work in all cases and causes the whole indexer to stop.
     CACHE_ADDRESS_TRANSACTIONS_COUNTER_PERIOD: 5m
+    COIN: BTC
+    EXCHANGE_RATES_COINGECKO_COIN_ID: bitcoin
   extraEnv:
     - name: POSTGRES_PASSWORD
       valueFrom:
@@ -63,6 +67,8 @@ blockscout:
       value: postgresql://postgres:$(POSTGRES_PASSWORD)@postgresql.default.svc.cluster.local:5432/blockscout
 
 frontend:
+  image:
+    tag: v1.33.1
   ingress:
     enabled: true
     hostname: explorer.test.mezo.org
@@ -86,6 +92,8 @@ frontend:
     NEXT_PUBLIC_COLOR_THEME_DEFAULT: light
     NEXT_PUBLIC_NETWORK_LOGO: https://mezo.org/assets/mezo-vsve-pvk.svg
     NEXT_PUBLIC_NETWORK_ICON: https://mezo.org/assets/mezo-favicon-h-eecjcq.svg
+    NEXT_PUBLIC_VIEWS_TX_HIDDEN_FIELDS: '["burnt_fees"]'
+    NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE: validation
 
 stats:
   enabled: false # This won't be needed for now.


### PR DESCRIPTION
### Introduction

We introduce minor UI tweaks to both testnet and mainnet explorers.

### Changes

Here we:
- Fix the exchange rates so USD values are displayed properly
- Disable the "Burnt fees" field in the tx view
- Change nomenclature from "miner" to "validator"

### Testing

Already deployed on https://explorer.test.mezo.org and https://explorer.mezo.org. Remember that you may have the previous version cached so try hitting the explorers after invaliding your browser cache or use a different browser.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
