### PR TITLE
Parametrize mainnet explorer RPC

### DIFF
--- a/infrastructure/kubernetes/mezo-production/README.md
+++ b/infrastructure/kubernetes/mezo-production/README.md
@@ -17,6 +17,15 @@ This Helm release defines a Blockscout explorer for the mainnet chain.
 The release creates two stateful sets, for the app and the API, and
 exposes them using distinct ingress resources.
 
+Before applying the Blockscout stack, create the following secret
+(only if it does not exist yet):
+
+```shell
+kubectl create secret generic blockscout-stack -n default \
+  --from-literal=ETHEREUM_JSONRPC_HTTP_URL=<mezo-rpc-http> \
+  --from-literal=ETHEREUM_JSONRPC_WS_URL=<mezo-rpc-ws>
+```
+
 ### Postgres database
 
 This Helm release defines a Postgres database that is used as

--- a/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
+++ b/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
@@ -38,14 +38,10 @@ blockscout:
       cpu: 2000m
       memory: 4096Mi
   env:
-    # TODO: Current RPC is temporary. See: https://linear.app/thesis-co/issue/TET-894/internal-load-balancer-for-the-block-explorer
     ETHEREUM_JSONRPC_VARIANT: geth
-    ETHEREUM_JSONRPC_HTTP_URL: http://35.208.7.218:8545
-    ETHEREUM_JSONRPC_WS_URL: ws://35.208.7.218:8546
-    ETHEREUM_JSONRPC_TRACE_URL: http://35.208.7.218:8545
-    # ETHEREUM_JSONRPC_FALLBACK_HTTP_URL: 
-    # ETHEREUM_JSONRPC_FALLBACK_WS_URL: 
-    # ETHEREUM_JSONRPC_FALLBACK_TRACE_URL: 
+    ETHEREUM_JSONRPC_HTTP_URL: secretref+k8s://v1/Secret/default/blockscout-stack/ETHEREUM_JSONRPC_HTTP_URL
+    ETHEREUM_JSONRPC_WS_URL: secretref+k8s://v1/Secret/default/blockscout-stack/ETHEREUM_JSONRPC_WS_URL
+    ETHEREUM_JSONRPC_TRACE_URL: secretref+k8s://v1/Secret/default/blockscout-stack/ETHEREUM_JSONRPC_HTTP_URL # Use the HTTP URL for tracing as well
     NETWORK: Mezo
     SUBNETWORK: Mainnet
     BLOCKSCOUT_PROTOCOL: https
@@ -56,6 +52,7 @@ blockscout:
     CONTRACT_VERIFICATION_ALLOWED_VYPER_EVM_VERSIONS: byzantium,constantinople,petersburg,istanbul,berlin,london,default
     INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true # Disable internal transactions fetcher for now. It does not work in all cases and causes the whole indexer to stop.
     CACHE_ADDRESS_TRANSACTIONS_COUNTER_PERIOD: 5m
+    COIN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD: 5m
     COIN: BTC
     EXCHANGE_RATES_COINGECKO_COIN_ID: bitcoin
   extraEnv:


### PR DESCRIPTION
### Introduction

Here we add a way to parametrize the RPC used by the mainnet block explorer. Moreover, we have it in a secret for additional privacy.

By the way, we are also lowering the value of `COIN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD` which should result with faster balance updates, especially after the bridge action.

### Testing

Already deployed on `https://explorer.mezo.org`.

---

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
