### PR TITLE
Disable multi sdk.Msg per transaction.

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -39,6 +39,9 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			if len(opts) > 0 {
 				switch typeURL := opts[0].GetTypeUrl(); typeURL {
 				case "/ethermint.evm.v1.ExtensionOptionsEthereumTx":
+					if len(tx.GetMsgs()) != 1 {
+						return ctx, errorsmod.Wrapf(errortypes.ErrNotSupported, "cannot submit more than one transaction at a time")
+					}
 					// handle as *evmtypes.MsgEthereumTx
 					anteHandler = newEVMAnteHandler(options)
 				default:


### PR DESCRIPTION
### Introduction

Mezo effectively only support EVM transaction from it's RPC, however what actually happens, is that the RPC layer wrap the ethereum transaction in a cosmos-sdk transacton. Such transaction can support a list of sdk.Msg.

Because this behaviour is not an usual behaviour for a EVM based chain, we decided to disable supporting more than 1 sdk.Msg per transaction, any other number of sdk.Msg will be rejected.

### Changes

Validation in the AnteHandler have been added to reject any transactions with the "ethermint.evm.v1.ExtensionOptionsEthereumTx" extension containing more that 1 Transaction.

### Testing

Unit test have been added in the ant/evm package.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
