### PR TITLE
encode nonceKeys for permit to hex, before hashing them

### DIFF
--- a/precompile/erc20/permit.go
+++ b/precompile/erc20/permit.go
@@ -2,6 +2,7 @@ package erc20
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -209,7 +210,7 @@ func (am *PermitMethod) incrementNonce(address common.Address, ctx sdk.Context) 
 	// Increment nonce by 1 so that the signature can be used once over the message
 	nonceBigInt.Add(nonceBigInt, big.NewInt(1))
 	// Set the new nonce value
-	am.evmkeeper.SetStateExtension(ctx, address, common.HexToHash(string(key)), nonceBigInt.Bytes())
+	am.evmkeeper.SetStateExtension(ctx, address, common.HexToHash(hex.EncodeToString(key)), nonceBigInt.Bytes())
 
 	return nil
 }
@@ -323,7 +324,7 @@ func getNonce(key []byte, evmkeeper evmkeeper.Keeper, address common.Address, ct
 	if len(key) > 32 {
 		return common.Hash{}, nil, fmt.Errorf("key %s is longer than 32 bytes", key)
 	}
-	nonce := evmkeeper.GetStateExtension(ctx, address, common.HexToHash(string(key)))
+	nonce := evmkeeper.GetStateExtension(ctx, address, common.HexToHash(hex.EncodeToString(key)))
 	if len(nonce) == 0 {
 		return common.Hash{}, nil, fmt.Errorf("failed to get nonce for address %s", address.Hex())
 	}

--- a/precompile/erc20/testsuite/permit.go
+++ b/precompile/erc20/testsuite/permit.go
@@ -1,6 +1,7 @@
 package testsuite
 
 import (
+	"encoding/hex"
 	"math/big"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/mezo-org/mezod/precompile"
 	"github.com/mezo-org/mezod/x/evm/statedb"
+	evmtypes "github.com/mezo-org/mezod/x/evm/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -16,6 +18,23 @@ import (
 )
 
 const PermitTypehash = "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+
+func (s *TestSuite) TestPermitHashCollision() {
+	btcNonceKey := evmtypes.PrecompileBTCNonceKey()
+	mezoNonceKey := evmtypes.PrecompileMEZONonceKey()
+
+	// this the previous implementation of the hash
+	// for the nonceKey, they collide which would corrupt
+	// storage
+	btcHash := common.HexToHash(string(btcNonceKey))
+	mezoHash := common.HexToHash(string(mezoNonceKey))
+	s.Equal(btcHash, mezoHash)
+
+	// new implementation produce different hashes
+	btcHash = common.HexToHash(hex.EncodeToString(btcNonceKey))
+	mezoHash = common.HexToHash(hex.EncodeToString(mezoNonceKey))
+	s.NotEqual(btcHash, mezoHash)
+}
 
 func (s *TestSuite) TestPermit() {
 	amount := int64(100)


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1039/potential-storage-collision-for-nonce-keys-of-distinct-erc20

### Introduction

The implementation of the erc20 permit nonce saves nonce in the evm state, this state is saved using the user address, and an nonceKey which is meant to be unique per ERC20 tokens. The uniqueness of it is done using a hash of the byte slices Key which is unique per ERC20 implemented (BTC, and Mezo). However, the hash created for this key is made using the common.HexToHash function, which takes an Hex string. Our mistake was to give this function a non Hex string, which would generate an empty hash everytime.

### Changes

This changes first call the hex.EncodeToString() function on the byte slice of the nonce key before sending it to HexToHash, which in turn provides a correct hash.

### Testing

A small test has been added to prove that the previous version was in fact providing 0 hashes, adding the hex.EncodeToString now provides different hashes.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
