### PR TITLE
Fix behaviour of the ERC20.approve(0)

### DIFF
--- a/precompile/erc20/approve.go
+++ b/precompile/erc20/approve.go
@@ -135,7 +135,7 @@ func handleAuthorization(
 
 	if authorization == nil {
 		if amount.Sign() == 0 {
-			err = fmt.Errorf("no existing approvals, cannot approve 0")
+			err = nil // this is not an error to comply with the ERC20 std behaviour.
 		} else {
 			err = createAuthorization(context.SdkCtx(), denom, spender, granter, amount, authzkeeper)
 		}

--- a/precompile/erc20/approve.go
+++ b/precompile/erc20/approve.go
@@ -1,6 +1,7 @@
 package erc20
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -90,8 +91,13 @@ func (am *ApproveMethod) Run(
 	if !ok {
 		return nil, fmt.Errorf("invalid amount: %v", inputs[1])
 	}
-	if amount == nil || amount.Sign() < 0 {
-		amount = big.NewInt(0)
+
+	if amount == nil {
+		return nil, errors.New("amount is required")
+	}
+
+	if amount.Sign() < 0 {
+		return nil, errors.New("amount cannot be negative")
 	}
 
 	granter := context.MsgSender()

--- a/precompile/erc20/approve.go
+++ b/precompile/erc20/approve.go
@@ -117,7 +117,7 @@ func (am *ApproveMethod) Run(
 	return precompile.MethodOutputs{true}, nil
 }
 
-// no authorization, amount 0 -> error
+// no authorization, amount 0 -> noop
 // no authorization, amount positive -> create a new authorization
 // authorization exists, amount 0 -> delete authorization
 // authorization exists, amount positive -> update authorization
@@ -135,7 +135,7 @@ func handleAuthorization(
 
 	if authorization == nil {
 		if amount.Sign() == 0 {
-			err = nil // this is not an error to comply with the ERC20 std behaviour.
+			err = nil // this is not an error to comply with the ERC20 std behavior.
 		} else {
 			err = createAuthorization(context.SdkCtx(), denom, spender, granter, amount, authzkeeper)
 		}

--- a/precompile/erc20/permit.go
+++ b/precompile/erc20/permit.go
@@ -3,6 +3,7 @@ package erc20
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -106,8 +107,13 @@ func (am *PermitMethod) Run(
 	if !ok {
 		return nil, fmt.Errorf("invalid amount: %v", inputs[2])
 	}
-	if amount == nil || amount.Sign() < 0 {
-		amount = big.NewInt(0)
+
+	if amount == nil {
+		return nil, errors.New("amount is required")
+	}
+
+	if amount.Sign() < 0 {
+		return nil, errors.New("amount cannot be negative")
 	}
 
 	deadline, ok := inputs[3].(*big.Int)

--- a/tests/system/contracts/BTCTransfers.sol
+++ b/tests/system/contracts/BTCTransfers.sol
@@ -29,12 +29,6 @@ contract BTCTransfers {
     address private constant testbedPrecompile = 0x7b7c100000000000000000000000000000000000;
     uint256 public balanceTracker = 1;
 
-
-    function approveZeroDoesntReverts(address recipient) external payable {
-        bool ok = IBTC(precompile).approve(recipient, 0);
-	require(ok);
-    }
-
     function basicSpendTo0(address recipient) external payable {
         uint256 balance = IBTC(precompile).balanceOf(address(this));
         require(balance > 0, "No balance to transfer");

--- a/tests/system/contracts/BTCTransfers.sol
+++ b/tests/system/contracts/BTCTransfers.sol
@@ -29,6 +29,12 @@ contract BTCTransfers {
     address private constant testbedPrecompile = 0x7b7c100000000000000000000000000000000000;
     uint256 public balanceTracker = 1;
 
+
+    function approveZeroDoesntReverts(address recipient) external payable {
+        bool ok = IBTC(precompile).approve(recipient, 0);
+	require(ok);
+    }
+
     function basicSpendTo0(address recipient) external payable {
         uint256 balance = IBTC(precompile).balanceOf(address(this));
         require(balance > 0, "No balance to transfer");

--- a/tests/system/test/BTCTransfers.test.ts
+++ b/tests/system/test/BTCTransfers.test.ts
@@ -61,10 +61,8 @@ describe("BTCTransfers", function () {
     before(async function () {
       await fixture();
 
-      // here we try to first do an approve,
-      // then reset it with 0,
-      // then approve again with 0, before this would
-      // panic
+      // Here we try to first do an approve, then reset it with 0, then approve again with 0.
+      // All transactions should pass.
       tx1 =  await btcErc20Token.connect(senderSigner)
         .approve(otherSpender, 10, {gasLimit: 1000000});
       await tx1.wait();


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-999/approve-in-erc20-reverts-when-making-a-zero-call-if-the-current

### Introduction

The ERC20 std implementation (e.g: openzeppelin) allow a user to approve 0 with success. This is to allow such expected pattern where a user would first call approve(0) then approve(actualAmount) on the contract. Until now the Mezo precompile would actually return an error an revert if the allowance was already 0.

This PR fixes this behaviour, and basically makes a call to approve(0) a no op effectively.

### Changes

We don't return an error anymore if the allowance of the user is already 0.

### Testing

2 system tests have been added to cover:
- allowing 0 for the very first time
- allowing for an amount initially, then allowing 0, then allowing 0 again.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
