### PR TITLE
Add extra test to prove that the behaviour of ERC20.approve is correct

### DIFF
--- a/tests/system/test/MEZOTransfers.test.ts
+++ b/tests/system/test/MEZOTransfers.test.ts
@@ -94,7 +94,7 @@ describe("MEZOTransfers", function () {
     });
   });
 
-  describe("multipleApproveAreHandledProperlyByTheCore", function () {
+  describe("approveMEZOAndBTCSimultaneously", function () {
     let receipt: any;
     let tx: any;
     let receipient = ethers.Wallet.createRandom().address;
@@ -102,6 +102,12 @@ describe("MEZOTransfers", function () {
     before(async function () {
       await fixture();
     });
+
+    // All the steps of this test are happening in the following `it` blocks.
+    // Each of them will in turn execute an approve transaction and validate
+    // that the state of the allowance between the receipient and sender
+    // is correct accross multiple execution targeted at both the MEZO and
+    // BTC token.
 
     it("should allow approving BTC for the receipient", async function () {
       tx =  await btcErc20Token.connect(sender)
@@ -115,12 +121,14 @@ describe("MEZOTransfers", function () {
 
     it("should allow approving MEZO for the receipient", async function () {
       tx =  await mezoErc20Token.connect(sender)
-        .approve(receipient, 10, {gasLimit: 1000000});
+        .approve(receipient, 20, {gasLimit: 1000000});
       await tx.wait();
       receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       expect(receipt!.status).to.equal(1);
-      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
-      expect(currentApproval).to.equal(10);
+      const currentMezoApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentMezoApproval).to.equal(20);
+      const currentBTCApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentBTCApproval).to.equal(10);
     });
 
     it("should allow to update the approved amount of MEZO for the receipient", async function () {
@@ -129,8 +137,10 @@ describe("MEZOTransfers", function () {
       await tx.wait();
       receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       expect(receipt!.status).to.equal(1);
-      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
-      expect(currentApproval).to.equal(15);
+      const currentMezoApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentMezoApproval).to.equal(15);
+      const currentBTCApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentBTCApproval).to.equal(10);
     });
 
     it("should allow revoking the approved amount of BTC for the receipient", async function () {
@@ -139,8 +149,10 @@ describe("MEZOTransfers", function () {
       await tx.wait();
       receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       expect(receipt!.status).to.equal(1);
-      const currentApproval = await btcErc20Token.allowance(sender.address, receipient);
-      expect(currentApproval).to.equal(0);
+      const currentBTCApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentBTCApproval).to.equal(0);
+      const currentMezoApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentMezoApproval).to.equal(15);
     });
 
     it("should allow revoking the approved amount of MEZO for the receipient", async function () {
@@ -150,8 +162,10 @@ describe("MEZOTransfers", function () {
       await tx.wait();
       receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       expect(receipt!.status).to.equal(1);
-      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
-      expect(currentApproval).to.equal(0);
+      const currentMezoApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentMezoApproval).to.equal(0);
+      const currentBTCApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentBTCApproval).to.equal(0);
     });
   });
 

--- a/tests/system/test/MEZOTransfers.test.ts
+++ b/tests/system/test/MEZOTransfers.test.ts
@@ -94,6 +94,68 @@ describe("MEZOTransfers", function () {
     });
   });
 
+  describe("multipleApproveAreHandledProperlyByTheCore", function () {
+    let receipt: any;
+    let tx: any;
+    let receipient = ethers.Wallet.createRandom().address;
+
+    before(async function () {
+      await fixture();
+    });
+
+    it("should allow approving BTC for the receipient", async function () {
+      tx =  await btcErc20Token.connect(sender)
+        .approve(receipient, 10, {gasLimit: 1000000});
+      await tx.wait();
+      receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      expect(receipt!.status).to.equal(1);
+      const currentApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentApproval).to.equal(10);
+    });
+
+    it("should allow approving MEZO for the receipient", async function () {
+      tx =  await mezoErc20Token.connect(sender)
+        .approve(receipient, 10, {gasLimit: 1000000});
+      await tx.wait();
+      receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      expect(receipt!.status).to.equal(1);
+      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentApproval).to.equal(10);
+    });
+
+    it("should allow to update the approved amount of MEZO for the receipient", async function () {
+      tx =  await mezoErc20Token.connect(sender)
+        .approve(receipient, 15, {gasLimit: 1000000});
+      await tx.wait();
+      receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      expect(receipt!.status).to.equal(1);
+      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentApproval).to.equal(15);
+    });
+
+    it("should allow revoking the approved amount of BTC for the receipient", async function () {
+      tx =  await btcErc20Token.connect(sender)
+        .approve(receipient, 0, {gasLimit: 1000000});
+      await tx.wait();
+      receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      expect(receipt!.status).to.equal(1);
+      const currentApproval = await btcErc20Token.allowance(sender.address, receipient);
+      expect(currentApproval).to.equal(0);
+    });
+
+    it("should allow revoking the approved amount of MEZO for the receipient", async function () {
+      // one first approve for a given value.
+      tx =  await mezoErc20Token.connect(sender)
+        .approve(receipient, 0, {gasLimit: 1000000});
+      await tx.wait();
+      receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      expect(receipt!.status).to.equal(1);
+      const currentApproval = await mezoErc20Token.allowance(sender.address, receipient);
+      expect(currentApproval).to.equal(0);
+    });
+  });
+
+
   describe("transferAllMEZO", function () {
     let mezoTransfersAddress: string;
     let mezoAmount: any;
@@ -284,7 +346,7 @@ describe("MEZOTransfers", function () {
     let mezoTransfersAddress: string;
     let mezoAmount: any;
     let btcAmount: any;
-    
+
     let initialSenderMEZOBalance: any;
     let initialSenderBTCBalance: any;
     let initialRecipientMEZOBalance: any;
@@ -353,7 +415,7 @@ describe("MEZOTransfers", function () {
     let mezoTransfersAddress: string;
     let mezoAmount: any;
     let btcAmount: any;
-    
+
     let initialSenderMEZOBalance: any;
     let initialSenderBTCBalance: any;
     let initialContractMEZOBalance: any;


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1040/potentially-wrong-allowance-cleanup-logic-in-erc20-precompiles#comment-79df4374

### Introduction

We add a small system tests to cover approve for the ERC20 token, specifically in the situation where an owner approves grants for multiples ERC20 and use approve(0) to revoke the grant.

### Changes

This PR adds a new system tests in the MezoToken suite.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
