### PR TITLE
Enforce minimum gas cost in the contract.RequiredGas method

### DIFF
--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -103,14 +103,25 @@ func (c *Contract) Address() common.Address {
 func (c *Contract) RequiredGas(input []byte) uint64 {
 	methodID, methodInputArgs, err := c.parseCallInput(input)
 	if err != nil {
-		// Panic is unacceptable here, return 0 instead.
-		return 0
+		// Panic is unacceptable here. Instead, we charge the user for the
+		// maximum gas we can, this being: a Write method, and the full
+		// size of all the inputs passed to the method (method ID + inputs).
+		return DefaultRequiredGas(
+			store.KVGasConfig(),
+			Write,
+			input,
+		)
 	}
-
 	method, _, err := c.methodByID(methodID)
 	if err != nil {
-		// Panic is unacceptable here, return 0 instead.
-		return 0
+		// Panic is unacceptable here. Instead, we charge the user for the
+		// maximum gas we can, this being: a Write method, and the full
+		// size of all the inputs passed to the method (method ID + inputs).
+		return DefaultRequiredGas(
+			store.KVGasConfig(),
+			Write,
+			input,
+		)
 	}
 
 	requiredGas, ok := method.RequiredGas(methodInputArgs)

--- a/tests/system/test/BTCTransfers.test.ts
+++ b/tests/system/test/BTCTransfers.test.ts
@@ -28,7 +28,6 @@ describe("BTCTransfers", function () {
     recipientAddress = ethers.Wallet.createRandom().address;
   });
 
-
   describe("approveZeroBeforeUserHaveEverApproved", function () {
     let receipt: any;
     let tx: any;


### PR DESCRIPTION
### Introduction

Add a minimum gas requirement even on precompile calls which failed unpacking method ID and input parameters.

### Changes

Every precompile calls now requires a minimum gas payment.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
