### PR TITLE
add panics when converting AsTransaction as the transaction should always be valid

### DIFF
--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -366,7 +366,11 @@ func (msg *MsgEthereumTx) GetFrom() sdk.AccAddress {
 func (msg MsgEthereumTx) AsTransaction() *ethtypes.Transaction {
 	txData, err := UnpackTxData(msg.Data)
 	if err != nil {
-		return nil
+		// At that point, transaction should always be a valid ethereum transaction
+		// if AsTransaction return nil, this would mean that something very wrong
+		// happened up the line, and we should never have reached this point.
+		// We panic to leave time to operators to investigate the issue.
+		panic("invalid transaction format")
 	}
 
 	return ethtypes.NewTx(txData.AsEthereumData())


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-1033/missing-nil-checks-for-astransaction-may-cause-node-crash

### Introduction

Add panics on codepath were ethereum transaction could be incomplete. This should never happen, but we panic in case the transaction are nil in order to leave time for node operator to investigate the issue.

### Changes

Adds nil checks and panics.


### Testing

N/A

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
