### PR TITLE
add a gcp bucket via terraform to store coins logos for the explorer

### DIFF
--- a/infrastructure/terraform/mezo-production/gke.tf
+++ b/infrastructure/terraform/mezo-production/gke.tf
@@ -25,3 +25,21 @@ module "gke" {
     }
   ]
 }
+
+resource "google_storage_bucket" "explorer_logos_bucket" {
+  name     = "mezo-production-explorer-logos-bucket"
+  location = var.region.name
+
+  uniform_bucket_level_access = true
+  force_destroy               = false
+}
+
+resource "google_storage_bucket_iam_member" "public_read" {
+  bucket = google_storage_bucket.explorer_logos_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+output "explorer_logos_bucket_url" {
+  value = "https://storage.googleapis.com/${google_storage_bucket.explorer_logos_bucket.name}"
+}


### PR DESCRIPTION
### Introduction

Add a GCP bucket in the terraform scripts. It is meant to be used to store logos for the block explorer.

### Changes

Added the bucked configuration to the mezo-production terraform scripts.

### Testing

<!--
Describe how the presented changes can be tested. Execute some basic tests
on your own and provide a short summary of the results in this section.
-->

---

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
