### PR TITLE
only pack the mezod binary in the release archive

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: 📦 Archive client binary
         run: |
-          tar -czvf linux-amd64.tar.gz -C build .
+          tar -czvf linux-amd64.tar.gz -C build mezod
 
       - name: 🔐 Authenticate to Google Cloud
         if: contains(github.ref_name, '-rc')


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-862/optimize-gha-workflow-publishing-mezod-binary

### Introduction

Pack only the mezod binary as part of the artifact when pushing a release.

### Changes

Remove metrics-scrapper from the release archive.

### Testing

N/A

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
