### PR TITLE
The v2.0.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -13,10 +13,11 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_6"
 	"github.com/mezo-org/mezod/app/upgrades/v0_7"
 	"github.com/mezo-org/mezod/app/upgrades/v1_0"
+	"github.com/mezo-org/mezod/app/upgrades/v2_0"
 )
 
 var (
-	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1}
+	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1, v2_0.Upgrade}
 	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )
 

--- a/app/upgrades/v2_0/constants.go
+++ b/app/upgrades/v2_0/constants.go
@@ -1,0 +1,16 @@
+//nolint:revive,stylecheck
+package v2_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+// UpgradeName defines the name of the upgrade.
+const UpgradeName = "v2.0.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v2_0/upgrades.go
+++ b/app/upgrades/v2_0/upgrades.go
@@ -1,0 +1,31 @@
+//nolint:revive,stylecheck
+package v2_0
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdk.UnwrapSDKContext(ctx).Logger().Info("running v2.0.0 upgrade handler")
+
+		// There are no particular state upgrades that must be executed globally during this upgrade.
+		// The RunMigrations call may still execute module-specific state upgrades. This is not the
+		// case for this upgrade but it's a Cosmos SDK requirement to call it here.
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -185,6 +185,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 
 ### Mainnet
 
-| Version  | Block   | Type                                 | Details                                                                                                                                                                                 |
-|----------|---------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                                                                                                                                |
+| Version  | Block   | Type                                 | Details                                                                       |
+|----------|---------|--------------------------------------|-------------------------------------------------------------------------------|
+| `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                      |
+| `v2.0.0` | 706500  | Planned upgrade with chain halt      | [v2.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v2.0.0) |


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1126/the-v200-mainnet-upgrade

### Introduction

Here we add the v2.0.0 upgrade handler that will be executed on mainnet.  Based on https://github.com/mezo-org/mezod/compare/v1.0.0...main, there are no global nor module-specific state changes that must be executed during the upgrade hence this handler is basically a no-op. 

The upgrade will occur on block [706500](https://explorer.mezo.org/block/countdown/706500) which is planned on Jun 3rd, around noon UTC.

### Changes

Did the necessary changes as described in [upgrades.md](https://github.com/mezo-org/mezod/blob/main/docs/upgrades.md#planned-upgrade-with-chain-halt)

### Testing

1. Checkout the v1.0.0 tag currently used on mainnet.
2. Spin up a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Start at least three nodes using `make localnet-bin-start`.
4. Get PoA owner address using `npx hardhat validatorPool:owner` from `precompile/hardhat`.
5. Schedule an upgrade using `npx hardhat upgrade:submitPlan --signer <poa-owner> --name v2.0.0 --height <H+20>  --info ''` where `H` is the current block of your localnet.
6. Wait until the upgrade block. Nodes should stop consensus and ask for an upgrade.
7. Switch to this PR's branch (`v2-prep`) and stop all your nodes. 
8. Run `make build`.
9. Restart your nodes.
10. They should print "running v2.0.0 upgrade handler" and start producing blocks after a short while.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
