### PR TITLE
add google auth login to the monitoring

### DIFF
--- a/infrastructure/kubernetes/common/monitoring/README.md
+++ b/infrastructure/kubernetes/common/monitoring/README.md
@@ -18,12 +18,25 @@ following command:
 kubectl create namespace monitoring
 ```
 
+### Setup google Oauth login
+
+##### Set up Google OAuth Application
+
+First, create an OAuth application in Google Cloud Console:
+- Go to Google Cloud Console
+- Navigate to APIs & Services > Credentials
+- Click Create Credentials > OAuth 2.0 Client IDs
+- Set Application type to Web application
+- Add your authorized redirect URIs: `https://<GRAFANA_DOMAIN>/grafana/login/google`
+
+Save and note down the Client ID and Client Secret.
+
 ### Secrets
 
 #### Grafana
 
 Secrets are used to set the default user and password to log in to
-the Grafana UI. Here are the required entries:
+the Grafana UI. Here are the required entries under grafana-secret:
 - admin-password
 - admin-user
 
@@ -32,6 +45,19 @@ Use `kubectl` to create the secrets or apply changes:
 kubectl create secret generic -n monitoring grafana-secret \
   --from-literal=admin-user=<USER> \
   --from-literal=admin-password=<PASSWORD>
+
+```
+
+And under grafana-auth-google-secret:
+- client-id
+- secret-id
+
+Use `kubectl` to create the secrets or apply changes:
+```Shell
+kubectl create secret generic -n monitoring grafana-secret \
+  --from-literal=client-id=<CLIENT_ID> \
+  --from-literal=client-secret=<CLIENT_SECRET>
+
 ```
 
 #### Metrics Scraper
@@ -81,8 +107,8 @@ the `mezo-<environment>` Terraform module.
 
 ### Add a node to the monitoring
 
-The monitoring system does not automatically discover new nodes yet. That said, 
-new nodes must be added to the monitoring system manually. This can be done by 
+The monitoring system does not automatically discover new nodes yet. That said,
+new nodes must be added to the monitoring system manually. This can be done by
 running the `add-node.sh` script on the desired environment.
 
 First, switch to the desired environment by setting the right `kubectl` context:

--- a/infrastructure/kubernetes/common/monitoring/grafana/config/grafana.ini
+++ b/infrastructure/kubernetes/common/monitoring/grafana/config/grafana.ini
@@ -1,2 +1,9 @@
 [feature_toggles]
 publicDashboards = true
+
+[auth.google]
+enabled = true
+scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+auth_url = https://accounts.google.com/o/oauth2/auth
+token_url = https://accounts.google.com/o/oauth2/token
+allow_sign_up = true

--- a/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
@@ -41,6 +41,16 @@ spec:
               value: "https://%(domain)s/grafana/"
             - name: GF_SERVER_SERVE_FROM_SUB_PATH
               value: "true"
+            - name: GF_AUTH_GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-auth-google
+                  key: client-id
+            - name: GF_AUTH_GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-auth-google
+                  key: client-secret
           readinessProbe:
             httpGet:
               path: /api/health
@@ -51,7 +61,7 @@ spec:
           livenessProbe:
             initialDelaySeconds: 30
             tcpSocket:
-              port: grafana    
+              port: grafana
           resources:
             limits:
               cpu: 300m


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-824/enable-google-oauth-for-the-monitoring-system

### Introduction

Enable google auth login for the mezo monitoring grafana stack.

### Changes

Adds:
- change to the grafana deployment to support the google login
- change to the grafana config to support the google login
- documentation to create the secret and enable google login from the gcp console.

### Testing

N/A

---

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
