### PR TITLE
prevent goroutine leaks in rpc/websocket

### DIFF
--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -164,6 +164,7 @@ func (es *EventSystem) subscribe(sub *Subscription) (*Subscription, pubsub.Unsub
 // SubscribeLogs creates a subscription that will write all logs matching the
 // given criteria to the given logs channel. Default value for the from and to
 // block is "latest". If the fromBlock > toBlock an error is returned.
+
 func (es *EventSystem) SubscribeLogs(crit filters.FilterCriteria) (*Subscription, pubsub.UnsubscribeFunc, error) {
 	if len(crit.Addresses) > defaultMaxAddressesFilter {
 		return nil, nil, fmt.Errorf("max number of addresses exceeded (max allowed %v)", defaultMaxAddressesFilter)
@@ -207,7 +208,32 @@ func (es *EventSystem) subscribeLogs(crit filters.FilterCriteria) (*Subscription
 		installed: make(chan struct{}, 1),
 		err:       make(chan error, 1),
 	}
-	return es.subscribe(sub)
+
+	return es.subscribeWithCleanup(sub)
+}
+
+func (es *EventSystem) subscribeWithCleanup(sub *Subscription) (*Subscription, pubsub.UnsubscribeFunc, error) {
+	sub, fn, err := es.subscribe(sub)
+	if err != nil {
+		return sub, fn, err
+	}
+
+	// wrap the unsubscribe func into our own, so we can do extra
+	// cleaning up of the subscription (e.g: add the call to
+	// Subscription.Unsubscribe, which cancel infinite loops
+	// in charge of installing / uninstalling the sub.
+	// This will down the line close the err channel, which
+	// will be caught in the channels listening for error,
+	// finally exiting the subscription properly.
+	fnW := func() {
+		// first we unsubscribe
+		sub.Unsubscribe(es)
+		// then we just continue with clearing up the inner
+		// tendermint channels.
+		fn()
+	}
+
+	return sub, fnW, err
 }
 
 // SubscribeNewHeads subscribes to new block headers events.
@@ -221,7 +247,7 @@ func (es EventSystem) SubscribeNewHeads() (*Subscription, pubsub.UnsubscribeFunc
 		installed: make(chan struct{}, 1),
 		err:       make(chan error, 1),
 	}
-	return es.subscribe(sub)
+	return es.subscribeWithCleanup(sub)
 }
 
 // SubscribePendingTxs subscribes to new pending transactions events from the mempool.
@@ -235,7 +261,7 @@ func (es EventSystem) SubscribePendingTxs() (*Subscription, pubsub.UnsubscribeFu
 		installed: make(chan struct{}, 1),
 		err:       make(chan error, 1),
 	}
-	return es.subscribe(sub)
+	return es.subscribeWithCleanup(sub)
 }
 
 type filterIndex map[filters.Type]map[rpc.ID]*Subscription


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-1132/investigate-high-memory-consumption-on-boars-rpc

### Introduction

The rpc eth_subscribe endpoint seems appear to not properly free up goroutines and some channels. This PR fixes this.

### Changes

Use proper rpc.ID in the websocket layer + ensure that inner goroutine are being closed properly

### Testing

N/A

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
