### PR TITLE
Switch to`mezo-org/keep-common` in Ethereum sidecar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -273,6 +273,8 @@ replace (
 	github.com/ethereum/go-ethereum => github.com/mezo-org/go-ethereum v1.14.8-mezo2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
+	github.com/keep-network/keep-common => github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47
 
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+
 )

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/influxdata/influxdb v1.8.3
 	github.com/influxdata/influxdb-client-go/v2 v2.4.0
 	github.com/ipfs/go-log v1.0.5
-	github.com/keep-network/keep-common v1.7.1-0.20240424094333-bd36cd25bb74
+	github.com/keep-network/keep-common v1.8.0
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/onsi/ginkgo/v2 v2.9.0
 	github.com/onsi/gomega v1.27.2
@@ -273,7 +273,8 @@ replace (
 	github.com/ethereum/go-ethereum => github.com/mezo-org/go-ethereum v1.14.8-mezo2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
-	github.com/keep-network/keep-common => github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47
+	// use mezo-org fork of keep-common
+	github.com/keep-network/keep-common => github.com/mezo-org/keep-common v1.8.0
 
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 

--- a/go.sum
+++ b/go.sum
@@ -1494,8 +1494,6 @@ github.com/kataras/pio v0.0.11/go.mod h1:38hH6SWH6m4DKSYmRhlrCJ5WItwWgCVrTNU62XZ
 github.com/kataras/sitemap v0.0.6/go.mod h1:dW4dOCNs896OR1HmG+dMLdT7JjDk7mYBzoIRwuj5jA4=
 github.com/kataras/tunnel v0.0.4/go.mod h1:9FkU4LaeifdMWqZu7o20ojmW4B7hdhv2CMLwfnHGpYw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keep-network/keep-common v1.7.1-0.20240424094333-bd36cd25bb74 h1:cG2BiQJj6+v86duIAuDd6sPJZqLVWaOPxzt3nWQQaAo=
-github.com/keep-network/keep-common v1.7.1-0.20240424094333-bd36cd25bb74/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -1605,6 +1603,8 @@ github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo h1:1UptFWudKEtlp8yrZ90QrXpK7X4Y
 github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
 github.com/mezo-org/go-ethereum v1.14.8-mezo2 h1:/U7VImjSy8pPu75rsDkgWiQ6yUqmRW7X+pADcHkGUE8=
 github.com/mezo-org/go-ethereum v1.14.8-mezo2/go.mod h1:ugZ1e3buGofOVBx5ZgNViY5ZVjS3bav1D4VqdtQViBI=
+github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47 h1:JcCuN5G6xmGYaLkCWsmNIEBpVOVs/VLsCYjdh9RrHKo=
+github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miguelmota/go-ethereum-hdwallet v0.1.1 h1:zdXGlHao7idpCBjEGTXThVAtMKs+IxAgivZ75xqkWK0=

--- a/go.sum
+++ b/go.sum
@@ -1603,8 +1603,8 @@ github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo h1:1UptFWudKEtlp8yrZ90QrXpK7X4Y
 github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
 github.com/mezo-org/go-ethereum v1.14.8-mezo2 h1:/U7VImjSy8pPu75rsDkgWiQ6yUqmRW7X+pADcHkGUE8=
 github.com/mezo-org/go-ethereum v1.14.8-mezo2/go.mod h1:ugZ1e3buGofOVBx5ZgNViY5ZVjS3bav1D4VqdtQViBI=
-github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47 h1:JcCuN5G6xmGYaLkCWsmNIEBpVOVs/VLsCYjdh9RrHKo=
-github.com/mezo-org/keep-common v0.0.0-20250602113635-d081d8c7cc47/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
+github.com/mezo-org/keep-common v1.8.0 h1:UWTYmXbEuqWqo6j8L2H9tzSnHoJ8/kV4JsrvytL4hTg=
+github.com/mezo-org/keep-common v1.8.0/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miguelmota/go-ethereum-hdwallet v0.1.1 h1:zdXGlHao7idpCBjEGTXThVAtMKs+IxAgivZ75xqkWK0=


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1133/fix-unsupported-pectra-transactions-in-the-ethereum-sidecar)

### Introduction

This PR replaces the usage of `keep-common` from `keep-core` to `keep-common` from `mezo-org`.
This change is needed because of new transaction types introduced by the Pectra update. 

### Changes

Switched to `mezo-org/keep-common` from Mezo's Ethereum sidecar.

### Testing

Run the sidecar multiple times and see if there is no error on startup.
Let the sidecar synch with the Ethereum on one occasion.

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
