### PR TITLE
Unit tests for Ethereum sidecar

### DIFF
--- a/ethereum/bindings/portal/portal.go
+++ b/ethereum/bindings/portal/portal.go
@@ -35,8 +35,9 @@ func MezoBridgeAddress(network ethconfig.Network) string {
 }
 
 type (
-	MezoBridge             = mainnetabi.MezoBridge
-	MezoBridgeAssetsLocked = mainnetabi.MezoBridgeAssetsLocked
+	MezoBridge                     = mainnetabi.MezoBridge
+	MezoBridgeAssetsLocked         = mainnetabi.MezoBridgeAssetsLocked
+	MezoBridgeAssetsLockedIterator = mainnetabi.MezoBridgeAssetsLockedIterator
 )
 
 var NewMezoBridge = mainnetabi.NewMezoBridge

--- a/ethereum/sidecar/chain/chain.go
+++ b/ethereum/sidecar/chain/chain.go
@@ -1,0 +1,25 @@
+package chain
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mezo-org/mezod/ethereum/bindings/portal"
+)
+
+type AssetsLockedIterator interface {
+	Next() bool
+	Error() error
+	Close() error
+	Event() *portal.MezoBridgeAssetsLocked
+}
+
+type BridgeContract interface {
+	FilterAssetsLocked(
+		opts *bind.FilterOpts,
+		sequenceNumber []*big.Int,
+		recipient []common.Address,
+		token []common.Address,
+	) (AssetsLockedIterator, error)
+}

--- a/ethereum/sidecar/chain/ethereum/ethereum.go
+++ b/ethereum/sidecar/chain/ethereum/ethereum.go
@@ -1,0 +1,55 @@
+package ethereum
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mezo-org/mezod/ethereum/bindings/portal"
+	"github.com/mezo-org/mezod/ethereum/sidecar/chain"
+)
+
+func NewBridgeContract(
+	delegate *portal.MezoBridge,
+) *BridgeContract {
+	return &BridgeContract{
+		delegate: delegate,
+	}
+}
+
+type BridgeContract struct {
+	delegate *portal.MezoBridge
+}
+
+func (r *BridgeContract) FilterAssetsLocked(
+	opts *bind.FilterOpts,
+	sequenceNumber []*big.Int,
+	recipient []common.Address,
+	token []common.Address,
+) (chain.AssetsLockedIterator, error) {
+	iter, err := r.delegate.FilterAssetsLocked(opts, sequenceNumber, recipient, token)
+	if err != nil {
+		return nil, err
+	}
+	return &AssetsLockedIterator{iter: iter}, nil
+}
+
+type AssetsLockedIterator struct {
+	iter *portal.MezoBridgeAssetsLockedIterator
+}
+
+func (r *AssetsLockedIterator) Next() bool {
+	return r.iter.Next()
+}
+
+func (r *AssetsLockedIterator) Error() error {
+	return r.iter.Error()
+}
+
+func (r *AssetsLockedIterator) Close() error {
+	return r.iter.Close()
+}
+
+func (r *AssetsLockedIterator) Event() *portal.MezoBridgeAssetsLocked {
+	return r.iter.Event
+}

--- a/ethereum/sidecar/chain/local/local.go
+++ b/ethereum/sidecar/chain/local/local.go
@@ -1,0 +1,85 @@
+package local
+
+import (
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mezo-org/mezod/ethereum/bindings/portal"
+	"github.com/mezo-org/mezod/ethereum/sidecar/chain"
+)
+
+func NewBridgeContract() *BridgeContract {
+	return &BridgeContract{
+		events: make([]*portal.MezoBridgeAssetsLocked, 0),
+	}
+}
+
+type BridgeContract struct {
+	mutex  sync.RWMutex
+	events []*portal.MezoBridgeAssetsLocked
+	// queue of errors that will be returned on subsequent calls
+	// to `FilterAssetsLocked`
+	errors []error
+}
+
+func (m *BridgeContract) FilterAssetsLocked(
+	_ *bind.FilterOpts,
+	_ []*big.Int,
+	_ []common.Address,
+	_ []common.Address,
+) (chain.AssetsLockedIterator, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	var err error
+	if len(m.errors) > 0 {
+		err = m.errors[0]
+		// pop first error
+		m.errors = m.errors[1:]
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &AssetsLockedIterator{
+		events: m.events,
+		index:  -1,
+	}, nil
+}
+
+func (m *BridgeContract) SetEvents(events []*portal.MezoBridgeAssetsLocked) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.events = events
+}
+
+func (m *BridgeContract) SetErrors(errors []error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.errors = errors
+}
+
+type AssetsLockedIterator struct {
+	events []*portal.MezoBridgeAssetsLocked
+	index  int
+}
+
+func (m *AssetsLockedIterator) Next() bool {
+	m.index++
+	return m.index < len(m.events)
+}
+
+func (m *AssetsLockedIterator) Error() error {
+	return nil
+}
+
+func (m *AssetsLockedIterator) Close() error {
+	return nil
+}
+
+func (m *AssetsLockedIterator) Event() *portal.MezoBridgeAssetsLocked {
+	return m.events[m.index]
+}

--- a/ethereum/sidecar/server_test.go
+++ b/ethereum/sidecar/server_test.go
@@ -2,16 +2,330 @@ package sidecar
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
+	"cosmossdk.io/log"
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mezo-org/mezod/cmd/config"
+	"github.com/mezo-org/mezod/ethereum/bindings/portal"
+	"github.com/mezo-org/mezod/ethereum/sidecar/chain/local"
 	pb "github.com/mezo-org/mezod/ethereum/sidecar/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	bridgetypes "github.com/mezo-org/mezod/x/bridge/types"
 )
+
+func TestFetchABIEvents(t *testing.T) {
+	onchainErr := fmt.Errorf("onchain failure")
+	chain := local.NewBridgeContract()
+
+	server := &Server{
+		logger:            log.NewNopLogger(),
+		events:            make([]bridgetypes.AssetsLockedEvent, 0),
+		bridgeContract:    chain,
+		batchSize:         3,
+		requestsPerMinute: uint64(600),
+	}
+
+	tests := map[string]struct {
+		startBlock, endBlock uint64
+		onchainEvents        []*portal.MezoBridgeAssetsLocked
+		onchainErrors        []error
+		expectedEvents       []*portal.MezoBridgeAssetsLocked
+		expectedErr          error
+	}{
+		"fetching whole range successful": {
+			200,
+			300,
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(100),
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(101),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(100),
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(101),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+		},
+		"fetching whole range unsuccessful": {
+			2,
+			5,
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(100),
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(101),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			[]error{onchainErr, nil},
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(100),
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(101),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+		},
+		"error when fetching": {
+			200,
+			300,
+			[]*portal.MezoBridgeAssetsLocked{},
+			[]error{onchainErr, onchainErr}, // return error twice
+			nil,
+			onchainErr,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			fmt.Println()
+			chain.SetErrors(test.onchainErrors)
+			chain.SetEvents(test.onchainEvents)
+
+			events, err := server.fetchABIEvents(test.startBlock, test.endBlock)
+
+			require.ErrorIs(t, err, test.expectedErr)
+
+			if !reflect.DeepEqual(test.expectedEvents, events) {
+				t.Errorf(
+					"unexpected events\n expected: %v\n actual:   %v",
+					test.expectedEvents,
+					events,
+				)
+			}
+		})
+	}
+}
+
+func TestFetchFinalizedEvents(t *testing.T) {
+	chain := local.NewBridgeContract()
+
+	server := &Server{
+		logger:            log.NewNopLogger(),
+		events:            []bridgetypes.AssetsLockedEvent{},
+		bridgeContract:    chain,
+		batchSize:         3,
+		requestsPerMinute: uint64(600),
+	}
+
+	sdk.GetConfig().SetBech32PrefixForAccount(config.Bech32Prefix, "")
+
+	tests := map[string]struct {
+		startBlock, endBlock uint64
+		// Events already stored in server
+		serversEvents  []bridgetypes.AssetsLockedEvent
+		onchainEvents  []*portal.MezoBridgeAssetsLocked
+		onchainErrors  []error
+		expectedEvents []bridgetypes.AssetsLockedEvent
+		expectedErr    error
+	}{
+		"no new events": {
+			2,
+			5,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "cosmos1rct3qqhlh2drmy48e204s5n9hpctcwwkvgv2ds",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			[]*portal.MezoBridgeAssetsLocked{},
+			nil,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "cosmos1rct3qqhlh2drmy48e204s5n9hpctcwwkvgv2ds",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			nil,
+		},
+		"gap between events": {
+			2,
+			5,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "mezo1jjzztg6j49nv3tz4mcsp74gr86g0zm0n7lhr9j",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(3), // Greater by 2 from the already fetched events
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(4),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "mezo1jjzztg6j49nv3tz4mcsp74gr86g0zm0n7lhr9j",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			errSequenceGap,
+		},
+		"invalid events": {
+			2,
+			5,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "recipient1",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "token1",
+				},
+			},
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(2),
+					Recipient:      common.HexToAddress("0x0A219c03938FBC93aA23cAd65f7c480f52665C2a"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(4), // Greater by 2 from the previous event
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "recipient1",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "token1",
+				},
+			},
+			errInvalidEvents,
+		},
+		"fetched events valid": {
+			2,
+			5,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "mezo1jjzztg6j49nv3tz4mcsp74gr86g0zm0n7lhr9j",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			[]*portal.MezoBridgeAssetsLocked{
+				{
+					SequenceNumber: big.NewInt(2),
+					Recipient:      common.HexToAddress("0x948425A352A966c8AC55De201F55033E90F16Df3"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(1000000),
+				},
+				{
+					SequenceNumber: big.NewInt(3),
+					Recipient:      common.HexToAddress("0xd728eB5aB3C743e0c2Cf5aFd4c81FEEC0f8f7300"),
+					Token:          common.HexToAddress("0x3A128b915bee3645396d43Fe7A13A59a66C427d6"),
+					Amount:         big.NewInt(2000000),
+				},
+			},
+			nil,
+			[]bridgetypes.AssetsLockedEvent{
+				{
+					Sequence:  sdkmath.NewInt(1),
+					Recipient: "mezo1jjzztg6j49nv3tz4mcsp74gr86g0zm0n7lhr9j",
+					Amount:    sdkmath.NewInt(10000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+				{
+					Sequence:  sdkmath.NewInt(2),
+					Recipient: "mezo1jjzztg6j49nv3tz4mcsp74gr86g0zm0n7lhr9j",
+					Amount:    sdkmath.NewInt(1000000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+				{
+					Sequence:  sdkmath.NewInt(3),
+					Recipient: "mezo16u5wkk4ncap7psk0tt75eq07as8c7ucqua575k",
+					Amount:    sdkmath.NewInt(2000000),
+					Token:     "0x3A128b915bee3645396d43Fe7A13A59a66C427d6",
+				},
+			},
+			nil,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			chain.SetErrors(test.onchainErrors)
+			chain.SetEvents(test.onchainEvents)
+
+			server.events = test.serversEvents
+
+			err := server.fetchFinalizedEvents(test.startBlock, test.endBlock)
+			require.ErrorIs(t, err, test.expectedErr)
+
+			if !reflect.DeepEqual(test.expectedEvents, server.events) {
+				t.Errorf(
+					"unexpected events\n expected: %v\n actual:   %v",
+					test.expectedEvents,
+					server.events,
+				)
+			}
+		})
+	}
+}
 
 func TestAssetsLockedEvents(t *testing.T) {
 	server := &Server{


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-75/ethereum-sidecar-increase-unit-test-coverage-for-existing-code

### Introduction

This PR increases unit tests coverage for the Ethereum sidecar

### Changes

New unit tests have been added.

### Testing

None

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [X] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
