### PR TITLE
New attempt at fixing the RPC leak

### DIFF
--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -195,7 +195,6 @@ func (s *subContext) Cleanup(es *rpcfilters.EventSystem) {
 	s.sub.Unsubscribe(es)
 	// then the unsub fn
 	s.unsubFn()
-
 }
 
 func (s *websocketsServer) readLoop(wsConn *wsConn) {


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-1256/fix-sudden-panics-of-rpc-nodes-reported-by-boar

### Introduction

In a previous attempt at fixing the issue (https://github.com/mezo-org/mezod/pull/495), we previously wrapped the UnsubscribeFunc of the subscribtion to also call the Unsubscribe method of the subscribtion. While this worked on the eth_subscribe / eth_unsubscribe json-rpc calls nicely, this was breaking other API (eth_newFilters) which were themselves handle separately the calls to Unsubscribe.

### Changes

Previous changes have been reverted mostly. Instead of wrapping the Unsubscribe function into another one calling as well Unsubscribe on the *filters.Subscribtion, we are now passing down the Subscription up to the creator of the subscribtion, and when it being cancelled (socket closed or explicit calls to eth_unsubscribe) the call to sub.Unsubscribe(eventSytem) is done explicitly.

### Testing

First on the current main start a localnode.

Then use the following script to test the panic:
```
curl -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [{
      "fromBlock": "0x1",
      "toBlock": "latest",
      "address": "0xA0b86a33E6417c66f87c6D4c0Dd8FD8Eb5b20A1b",
      "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
    }],
    "id": 1
  }' \
  http:///localhost:8545
```

Save the id returned, then using this script with the following command: `./cleanupFilter.sh ID`
```
#!/bin/bash

curl -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "method": "eth_uninstallFilter",
    "params": ["'"$1"'"],
    "id": 3
  }' \
  http:///localhost:8545
```

Confirm that the node panics.

Now, check out the `fix-rpc-memory-leak` branch.

Try to run the same check, it should work, without panics

Now you can also try to run some subscribtions with eth_subscribe and eth_unsubscribe they should work as expected.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
