### PR TITLE
Bump Mezo testnet nodes to v2.0.2

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.6.0
+    version: 3.0.2
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.6.0
+    version: 3.0.2
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.6.0
+    version: 3.0.2
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.6.0
+    version: 3.0.2
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 1.6.0
+    version: 3.0.2
     labels:
       type: validator
     values:

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,11 +1,22 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+image: mezo/mezod
 # tag: ""
 
 env:
   NETWORK: testnet
+  MEZOD_CHAIN_ID: mezo_31611-1
   PUBLIC_IP: "34.134.59.27" # mezo-staging-node-0-external-ip
   MEZOD_MONIKER: "mezo-node-0"
   MEZOD_JSON_RPC_ENABLE_INDEXER: true
+
+customConfigs:
+  enabled: true
+  appTomlTxt: ""
+  clientTomlTxt: ""
+  configTomlTxt: |
+    statesync.enable=true
+    statesync.rpc_servers=mezo-node-3.test.mezo.org:26657,mezo-node-3.test.mezo.org:26657
+    statesync.trust_height=5554501
+    statesync.trust_hash=1A5227D45C4EF9F0B39C2815DD40D85032403EA81ABF112FAEC757BAC29F36E8    
 
 secrets:
   credentials: "mezo-node-0" # created manually

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,10 +1,21 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+image: mezo/mezod
 # tag: ""
 
 env:
   NETWORK: testnet
+  MEZOD_CHAIN_ID: mezo_31611-1
   PUBLIC_IP: "104.198.64.215" # mezo-staging-node-1-external-ip
   MEZOD_MONIKER: "mezo-node-1"
+
+customConfigs:
+  enabled: true
+  appTomlTxt: ""
+  clientTomlTxt: ""
+  configTomlTxt: |
+    statesync.enable=true
+    statesync.rpc_servers=mezo-node-3.test.mezo.org:26657,mezo-node-3.test.mezo.org:26657
+    statesync.trust_height=5554501
+    statesync.trust_hash=1A5227D45C4EF9F0B39C2815DD40D85032403EA81ABF112FAEC757BAC29F36E8    
 
 secrets:
   credentials: "mezo-node-1" # created manually

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,10 +1,21 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+image: mezo/mezod
 # tag: ""
 
 env:
   NETWORK: testnet
+  MEZOD_CHAIN_ID: mezo_31611-1
   PUBLIC_IP: "104.197.235.84" # mezo-staging-node-2-external-ip
   MEZOD_MONIKER: "mezo-node-2"
+
+customConfigs:
+  enabled: true
+  appTomlTxt: ""
+  clientTomlTxt: ""
+  configTomlTxt: |
+    statesync.enable=true
+    statesync.rpc_servers=mezo-node-3.test.mezo.org:26657,mezo-node-3.test.mezo.org:26657
+    statesync.trust_height=5554501
+    statesync.trust_hash=1A5227D45C4EF9F0B39C2815DD40D85032403EA81ABF112FAEC757BAC29F36E8  
 
 secrets:
   credentials: "mezo-node-2" # created manually

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,8 +1,9 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+image: mezo/mezod
 # tag: ""
 
 env:
   NETWORK: testnet
+  MEZOD_CHAIN_ID: mezo_31611-1
   PUBLIC_IP: "34.170.77.124" # mezo-staging-node-3-external-ip
   MEZOD_MONIKER: "mezo-node-3"
 

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,10 +1,21 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+image: mezo/mezod
 # tag: ""
 
 env:
   NETWORK: testnet
+  MEZOD_CHAIN_ID: mezo_31611-1
   PUBLIC_IP: "34.70.22.86" # mezo-staging-node-4-external-ip
   MEZOD_MONIKER: "mezo-node-4"
+
+customConfigs:
+  enabled: true
+  appTomlTxt: ""
+  clientTomlTxt: ""
+  configTomlTxt: |
+    statesync.enable=true
+    statesync.rpc_servers=mezo-node-3.test.mezo.org:26657,mezo-node-3.test.mezo.org:26657
+    statesync.trust_height=5554501
+    statesync.trust_hash=1A5227D45C4EF9F0B39C2815DD40D85032403EA81ABF112FAEC757BAC29F36E8
 
 secrets:
   credentials: "mezo-node-4" # created manually


### PR DESCRIPTION
>[!WARNING]
> Apply this change AFTER the upgrade block [5559500](https://explorer.test.mezo.org/block/countdown/5559500) was reached on testnet

References: https://linear.app/thesis-co/issue/TET-1294/the-v202-mezod-release

### Introduction

Here we bump Mezo testnet nodes controlled by us to `v2.0.2` which is the recent version of `mezod`.

### Changes

The aforementioned Mezo nodes live on our `mezo-staging` GCP cluster and use the Helm chart from the Validator Kit. We bump the chart version to `3.0.2` which under the hood resolves to `mezod` `v2.0.2`.

### Testing

Changes must be applied using `helmfile apply -i -l type=validator --context 1 --concurrency 1` executed inside the `infrastructure/kubernetes/mezo-staging` directory. Once done, make sure all nodes are up and running.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
