### PR TITLE
The v3.0.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,10 +14,11 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_7"
 	"github.com/mezo-org/mezod/app/upgrades/v1_0"
 	"github.com/mezo-org/mezod/app/upgrades/v2_0"
+	"github.com/mezo-org/mezod/app/upgrades/v3_0"
 )
 
 var (
-	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1, v2_0.Upgrade}
+	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1, v2_0.Upgrade, v3_0.Upgrade}
 	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )
 

--- a/app/upgrades/v3_0/constants.go
+++ b/app/upgrades/v3_0/constants.go
@@ -1,0 +1,16 @@
+//nolint:revive,stylecheck
+package v3_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+// UpgradeName defines the name of the upgrade.
+const UpgradeName = "v3.0.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v3_0/upgrades.go
+++ b/app/upgrades/v3_0/upgrades.go
@@ -1,0 +1,177 @@
+//nolint:revive,stylecheck
+package v3_0
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+
+	sdkmath "cosmossdk.io/math"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+	"github.com/mezo-org/mezod/utils"
+	evmkeeper "github.com/mezo-org/mezod/x/evm/keeper"
+	evmtypes "github.com/mezo-org/mezod/x/evm/types"
+	feemarketkeeper "github.com/mezo-org/mezod/x/feemarket/keeper"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		sdkCtx.Logger().Info("running v3.0.0 upgrade handler")
+
+		err := updateMinGasPrice(sdkCtx, keepers.FeeMarketKeeper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update minimum gas price: %w", err)
+		}
+
+		err = updateMaintenancePrecompileVersion(sdkCtx, keepers.EvmKeeper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update maintenance precompile version: %w", err)
+		}
+
+		err = updateBridgePrecompileVersion(sdkCtx, keepers.EvmKeeper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update bridge precompile version: %w", err)
+		}
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
+func updateMinGasPrice(sdkCtx sdk.Context, feeMarketKeeper feemarketkeeper.Keeper) error {
+	chainID := sdkCtx.ChainID()
+	params := feeMarketKeeper.GetParams(sdkCtx)
+
+	sdkCtx.Logger().Info(
+		"begin minimum gas price update",
+		"chainID", chainID,
+		"minGasPrice", params.MinGasPrice,
+	)
+
+	var newMinGasPrice sdkmath.LegacyDec
+	var err error
+
+	if utils.IsMainnet(chainID) {
+		newMinGasPrice, err = sdkmath.LegacyNewDecFromStr("1300000.000000000000000000")
+		if err != nil {
+			return err
+		}
+	} else if utils.IsTestnet(chainID) {
+		newMinGasPrice, err = sdkmath.LegacyNewDecFromStr("130.000000000000000000")
+		if err != nil {
+			return err
+		}
+	} else {
+		panic(fmt.Sprintf("invalid chain ID: %s", chainID))
+	}
+
+	params.MinGasPrice = newMinGasPrice
+	err = feeMarketKeeper.SetParams(sdkCtx, params)
+	if err != nil {
+		return err
+
+	}
+
+	sdkCtx.Logger().Info(
+		"minimum gas price updated",
+		"chainID", chainID,
+		"minGasPrice", feeMarketKeeper.GetParams(sdkCtx).MinGasPrice,
+	)
+
+	return nil
+}
+
+func updateMaintenancePrecompileVersion(ctx sdk.Context, evmKeeper *evmkeeper.Keeper) error {
+	params := evmKeeper.GetParams(ctx)
+
+	ctx.Logger().Info(
+		"begin maintenance precompile version update",
+		"precompilesVersions",
+		params.PrecompilesVersions,
+	)
+
+	maintenanceVersionInfoIndex := slices.IndexFunc(
+		params.PrecompilesVersions,
+		func(versionInfo *evmtypes.PrecompileVersionInfo) bool {
+			// Compare bytes just in case to avoid any potential issues
+			// with string comparison.
+			return bytes.Equal(
+				evmtypes.HexAddressToBytes(versionInfo.PrecompileAddress),
+				evmtypes.HexAddressToBytes(evmtypes.MaintenancePrecompileAddress),
+			)
+		},
+	)
+
+	// 4 is the value of evmtypes.MaintenancePrecompileLatestVersion at
+	// the time of this upgrade. We avoid using the constant directly
+	// as it will change in the future so the actual value of the version
+	// used during this upgrade would perish over time.
+	params.PrecompilesVersions[maintenanceVersionInfoIndex].Version = 4
+
+	err := evmKeeper.SetParams(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	ctx.Logger().Info(
+		"maintenance precompile version updated",
+		"precompilesVersions",
+		evmKeeper.GetParams(ctx).PrecompilesVersions,
+	)
+
+	return nil
+}
+
+func updateBridgePrecompileVersion(ctx sdk.Context, evmKeeper *evmkeeper.Keeper) error {
+	params := evmKeeper.GetParams(ctx)
+
+	ctx.Logger().Info(
+		"begin bridge precompile version update",
+		"precompilesVersions",
+		params.PrecompilesVersions,
+	)
+
+	bridgeVersionInfoIndex := slices.IndexFunc(
+		params.PrecompilesVersions,
+		func(versionInfo *evmtypes.PrecompileVersionInfo) bool {
+			// Compare bytes just in case to avoid any potential issues
+			// with string comparison.
+			return bytes.Equal(
+				evmtypes.HexAddressToBytes(versionInfo.PrecompileAddress),
+				evmtypes.HexAddressToBytes(evmtypes.AssetsBridgePrecompileAddress),
+			)
+		},
+	)
+
+	// 3 is the value of evmtypes.AssetsBridgePrecompileLatestVersion at
+	// the time of this upgrade. We avoid using the constant directly to
+	// as it will change in the future so the actual value of the version
+	// used during this upgrade would perish over time.
+	params.PrecompilesVersions[bridgeVersionInfoIndex].Version = 3
+
+	err := evmKeeper.SetParams(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	ctx.Logger().Info(
+		"bridge precompile version updated",
+		"precompilesVersions",
+		evmKeeper.GetParams(ctx).PrecompilesVersions,
+	)
+
+	return nil
+}

--- a/app/upgrades/v3_0/upgrades.go
+++ b/app/upgrades/v3_0/upgrades.go
@@ -83,7 +83,6 @@ func updateMinGasPrice(sdkCtx sdk.Context, feeMarketKeeper feemarketkeeper.Keepe
 	err = feeMarketKeeper.SetParams(sdkCtx, params)
 	if err != nil {
 		return err
-
 	}
 
 	sdkCtx.Logger().Info(

--- a/app/upgrades/v3_0/upgrades.go
+++ b/app/upgrades/v3_0/upgrades.go
@@ -64,6 +64,7 @@ func updateMinGasPrice(sdkCtx sdk.Context, feeMarketKeeper feemarketkeeper.Keepe
 	var newMinGasPrice sdkmath.LegacyDec
 	var err error
 
+	//nolint:gocritic
 	if utils.IsMainnet(chainID) {
 		newMinGasPrice, err = sdkmath.LegacyNewDecFromStr("1300000.000000000000000000")
 		if err != nil {

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -183,6 +183,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v1.0.0-rc0` | 3569000 | Planned upgrade with chain halt    | Patch for a DoS vector in the bridge. Fix for the precompile revert mechanism.                                                                                                           |
 | `v1.0.0-rc1` | 3712500 | Planned upgrade with chain halt    | Patch for mixed precompile addresses.                                                                                                           |
 | `v2.0.2` | 5559500 | Planned upgrade with chain halt    | Bring back parity with mainnet.                                                                                                           |
+| `v3.0.0` | 5695000 | Planned upgrade with chain halt    | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |
 
 ### Mainnet
 
@@ -190,3 +191,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 |----------|---------|--------------------------------------|-------------------------------------------------------------------------------|
 | `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                      |
 | `v2.0.0` | 706500  | Planned upgrade with chain halt      | [v2.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v2.0.0) |
+| `v3.0.0` | 1737000 | Planned upgrade with chain halt      | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1103/reduce-gas-price
References: https://linear.app/thesis-co/issue/TET-1299/the-v300-mezod-release-candidate-testnet
References: https://linear.app/thesis-co/issue/TET-1300/the-v300-mezod-release-mainnet
Depends on: #510 

### Introduction

Here we add the v3.0.0 upgrade handler that will be executed on testnet and mainnet. Based on https://github.com/mezo-org/mezod/compare/v2.0.2...main, the breaking changes that require actions in the upgrade handler are:
- [Expose sequence tip in asset bridge precompile](https://github.com/mezo-org/mezod/pull/501): we need to bump the `AssetsBridge` precompile version
- [Governable minimum gas price](https://github.com/mezo-org/mezod/pull/510): we need to bump the `Maintenance` precompile version and change the current minimum gas price at the upgrade block

Tentative plan is to execute this upgrade as follows:
- Testnet: On block 5695000 which is expected on July 10, around 09:30 UTC
- Mainnet: On block 1737000 which is expected on July 16, around 11:00 UTC

### Changes

Did the necessary changes as described in [upgrades.md](https://github.com/mezo-org/mezod/blob/main/docs/upgrades.md#planned-upgrade-with-chain-halt)

### Testing

1. Checkout the v2.0.2 tag currently used on testnet and mainnet.
2. Spin up a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Start at least three nodes using `make localnet-bin-start`.
4. Get PoA owner address using `npx hardhat validatorPool:owner` from `precompile/hardhat`.
5. Schedule an upgrade using `npx hardhat upgrade:submitPlan --signer <poa-owner> --name v3.0.0 --height <H+20>  --info ''` where `H` is the current block of your localnet.
6. Wait until the upgrade block. Nodes should stop consensus and ask for an upgrade.
7. Switch to this PR's branch (`v3-upgrade-handler`) and stop all your nodes. 
8. Run `make build`.
9. Restart your nodes.
10. They should print "running v3.0.0 upgrade handler" and start producing blocks after a short while.
11. Ensure the features enabled in the upgrade handler work (gas price changed and governable through `Maintenance` precompile, sequence tip exposed from the `AssetsBridge` precompile)

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
