### PR TITLE
Bump Mezo testnet nodes to v3.0.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,5 +1,5 @@
-image: mezo/mezod
-# tag: ""
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v3.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,5 +1,5 @@
-image: mezo/mezod
-# tag: ""
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v3.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,5 +1,5 @@
-image: mezo/mezod
-# tag: ""
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v3.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,5 +1,5 @@
-image: mezo/mezod
-# tag: ""
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v3.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,5 +1,5 @@
-image: mezo/mezod
-# tag: ""
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v3.0.0-rc0
 
 env:
   NETWORK: testnet


### PR DESCRIPTION
>[!WARNING]
> Apply this change AFTER the upgrade block [5695000](https://explorer.test.mezo.org/block/countdown/5695000) was reached on testnet

Closes: https://linear.app/thesis-co/issue/TET-1299/the-v300-mezod-release-candidate-testnet

### Introduction

Here we bump Mezo testnet nodes controlled by us to `v3.0.0-rc0` which is the recent candidate release version of `mezod`.

### Changes

The aforementioned Mezo nodes live on our `mezo-staging` GCP cluster and use the Helm chart from the Validator Kit. We bump the image tag directly as the chart points to a stable `mezod` version by default. We do not bump the version of the chart.

### Testing

Changes must be applied using `helmfile apply -i -l type=validator --context 1 --concurrency 1` executed inside the `infrastructure/kubernetes/mezo-staging` directory. Once done, make sure all nodes are up and running.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
