### PR TITLE
Update v3 upgrade block for mainnet in docs

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -191,4 +191,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 |----------|---------|--------------------------------------|-------------------------------------------------------------------------------|
 | `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                      |
 | `v2.0.0` | 706500  | Planned upgrade with chain halt      | [v2.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v2.0.0) |
-| `v3.0.0` | 1737000 | Planned upgrade with chain halt      | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |
+| `v3.0.0` | 1735000 | Planned upgrade with chain halt      | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1300/the-v300-mezod-release-mainnet

### Introduction

We initially set 1737000 as v3 upgrade block for mainnet. However, this is quite late in the day. Because of that, we will set 1735000. Here we update the upgrade docs.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
