### PR TITLE
Bump internal RPC node to v3.0.0

### DIFF
--- a/infrastructure/kubernetes/mezo-production/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-production/helmfile.yaml
@@ -28,6 +28,6 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.0
+    version: 4.0.0
     values:
       - ./values/mezo-rpc-node.yaml

--- a/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
+++ b/infrastructure/kubernetes/mezo-production/values/blockscout-stack.yaml
@@ -92,7 +92,7 @@ frontend:
     NEXT_PUBLIC_VIEWS_TX_HIDDEN_FIELDS: '["burnt_fees"]'
     NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE: validation
     NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: secretref+k8s://v1/Secret/default/blockscout-stack/WALLET_CONNECT_PROJECT_ID
-    NEXT_PUBLIC_NETWORK_RPC_URL: secretref+k8s://v1/Secret/default/blockscout-stack/ETHEREUM_JSONRPC_HTTP_URL
+    NEXT_PUBLIC_NETWORK_RPC_URL: https://rpc-internal.mezo.org
 
 stats:
   enabled: false # This won't be needed for now.


### PR DESCRIPTION
### Introduction

Here we bump our internal mainnet RPC node to v3.0.0 by bumping the Helm chart to the recent version (v4.0.0).

Moreover, by the way, we are setting the RPC address that is used by the explorer while adding Mezo to Metamask to be constant https://rpc-internal.mezo.org. We need to differ it from the RPC used for data indexing (taken from a secret) as it will likely be changed soon to a commercial private one.

### Testing

N/A. Already deployed on `mezo-production` cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
