### PR TITLE
Fix dropping events in the eth_subscribe rpc

### DIFF
--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -99,7 +99,7 @@ func (m *memEventBus) Subscribe(name string) (<-chan coretypes.ResultEvent, Unsu
 		return nil, nil, errors.Errorf("topic not found: %s", name)
 	}
 
-	ch := make(chan coretypes.ResultEvent)
+	ch := make(chan coretypes.ResultEvent, 10000)
 	m.subscribersMux.Lock()
 	defer m.subscribersMux.Unlock()
 

--- a/tests/performance/run.go
+++ b/tests/performance/run.go
@@ -190,7 +190,7 @@ func runERC20(
 	var stop atomic.Bool
 	stop.Store(false)
 	go aggregateBlockDataParallel()
-	time.Sleep(10 * time.Second) // wait to get a few blocks first to see baseline
+	time.Sleep(1 * time.Second) // wait to get a few blocks first to see baseline
 
 	startedAt := time.Now()
 	for i := 0; i < cnt; i++ {
@@ -253,10 +253,7 @@ func runERC20One(
 		log.Fatalf("Failed to get nonce: %v", err)
 	}
 
-	// gasLimit := uint64(65000) // more or less an ERC20 gas requirement
-	// gasLimit := uint64(22000)
-	// gasLimit := uint64(50000)
-	gasLimit := uint64(25000)
+	gasLimit := uint64(50000) // more or less an ERC20 gas requirement
 
 	// Initialize the ERC20 contract
 	token, err := token.NewTokenTransactor(tokenAddress, client)


### PR DESCRIPTION
git close: https://linear.app/thesis-co/issue/TET-1371/mezo-websoket-doesnt-log-events-when-subscribed-to-specific-token

### Introduction

The websocket connection was dropping events with some node providers. I was able to reproduce it locally with high load on the node.

### Changes

The code was using unbuffered channels to propagate down the events to the websockets, this was making more or less the the process synchronous. We now create channels with 10k buffers.

I'm still not 100% sure of 100% of the behaviour.

### Testing

Download the script here: https://gist.github.com/jeremyletang/893f844c690f2c6a93eb20e6bbda9135 inside a separate folder.

> NOTE: 
> Before starting, update the file https://github.com/mezo-org/mezod/blob/main/tests/performance/run.go on main, uncomment line 258 (`// gasLimit := uint64(50000)`) and comment line 259 (`gasLimit := uint64(25000)`).

Then test against main:
```
git checkout main
# first install the performance tools
cd tests/performance && go install && cd ../..

# init the network
make localnet-bin-clean && make localnet-bin-init
make localnet-bin-start # 3 times to bootstrap the network

# generate an address
performance generate -rpc_address="http://localhost:8545" -rate=100ms -count=1 -localkey .localnet/node0/mezod/key_seed.json -wait_for_receipt=false

# topup some gas to generated account
performance topup -rpc_address="http://0.0.0.0:8545" -rate=100ms -count=1 -localkey .localnet/node0/mezod/key_seed.json -wait_for_receipt=false

# deploy a test token, copy the address from the output
performance deploy_token -rpc_address="http://0.0.0.0:8545" -localkey .localnet/node0/mezod/key_seed.json

# topup some of the token to our account
performance topup_erc20 -address=<GENERATED_TOKEN_ADDRESS> -rpc_address="http://0.0.0.0:8545" -rate=100ms -count=1 -localkey .localnet/node0/mezod/key_seed.json -wait_for_receipt=false

# in the scrip we downloaded earlier updated the following line with the address of the token we created: https://gist.github.com/jeremyletang/893f844c690f2c6a93eb20e6bbda9135#file-main-go-L162
# run the script we downloaded at first with
go run main.go

# run the perf tests
performance run_erc20 -address=<GENERATED_TOKEN_ADDRESS> -tendermint_rpc_address="http://0.0.0.0:26657" -rpc_address="http://0.0.0.0:8545" -duration=1m -rate=10ms -count=1 -localkey .localnet/node0/mezod/key_seed.json -wait_for_receipt=false
```

Doing so will run the performance tests for a a minute, using 1 account, sending 4210 txs more or less (see the last line of output.csv). Now look at the output for of the script, it's opened 100 websockets, so its hould have received more or less 421000 events, locally for me I get around 350000 events.

Now checkout the `fix-missed-rpc-events` branch, stop the nodes, recompile with `make build`, and redo the previous steps. For me running it locally, I get 100% of events sent properly through the websocket. 

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
