### PR TITLE
backport fix from: https://github.com/cosmos/evm/pull/296

### DIFF
--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -437,7 +437,7 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
 func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*types.QueryTraceTxResponse, error) {
-	if req == nil {
+	if req == nil || req.Msg == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
 

--- a/x/evm/types/query.go
+++ b/x/evm/types/query.go
@@ -16,11 +16,17 @@
 package types
 
 import (
+	"fmt"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 // UnpackInterfaces implements UnpackInterfacesMesssage.UnpackInterfaces
 func (m QueryTraceTxRequest) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	if m.Msg == nil {
+		return fmt.Errorf("msg cannot be empty")
+	}
+
 	for _, msg := range m.Predecessors {
 		if err := msg.UnpackInterfaces(unpacker); err != nil {
 			return err


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-1386/patch-a-tracetx-dos-vector-in-the-grpc-api

### Introduction

Backport fixes from cosmos/evm regarding a panic which could happen when calling traceTx directly from the grpc API.

### Changes

Add validation fo the req.Msg field in appropriate places

### Testing

N/A

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
