### PR TITLE
Bump testnet nodes to v3.0.1-rc1

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.0-rc0
+tag: v3.0.1-rc1
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.0-rc0
+tag: v3.0.1-rc1
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.0-rc0
+tag: v3.0.1-rc1
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.0-rc0
+tag: v3.0.1-rc1
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.0-rc0
+tag: v3.0.1-rc1
 
 env:
   NETWORK: testnet


### PR DESCRIPTION
### Introduction

Here we bump our Mezo testnet nodes to the recent v3.0.1-rc1 version containing the fix for the missing events issue.

### Testing

Already deployed.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
