### PR TITLE
Websocket rpc issues

### DIFF
--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -99,7 +99,7 @@ func (m *memEventBus) Subscribe(name string) (<-chan coretypes.ResultEvent, Unsu
 		return nil, nil, errors.Errorf("topic not found: %s", name)
 	}
 
-	ch := make(chan coretypes.ResultEvent, 10000)
+	ch := make(chan coretypes.ResultEvent, 1000)
 	m.subscribersMux.Lock()
 	defer m.subscribersMux.Unlock()
 

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -204,6 +204,7 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 		// cancel all subscriptions when connection closed
 		// #nosec G705
 		for _, subCtx := range subCtxs {
+			s.logger.Debug("clearing subscription", "subId", subCtx.sub.ID())
 			subCtx.Cleanup(s.api.events)
 		}
 	}()
@@ -283,6 +284,8 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 			if err := wsConn.WriteJSON(res); err != nil {
 				break
 			}
+
+			s.logger.Debug("eth_subscribe", "subId", sub.ID())
 		case "eth_unsubscribe":
 			params, ok := s.getParamsAndCheckValid(msg, wsConn)
 			if !ok {
@@ -311,6 +314,7 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 			if err := wsConn.WriteJSON(res); err != nil {
 				break
 			}
+			s.logger.Debug("eth_unsubscribe", "subId", subID)
 		default:
 			// otherwise, call the usual rpc server to respond
 			if err := s.tcpGetAndSendResponse(wsConn, mb); err != nil {


### PR DESCRIPTION
close: https://linear.app/thesis-co/issue/TET-1371/mezo-websoket-doesnt-log-events-when-subscribed-to-specific-token

### Introduction

Fix issue with properly installing websockets, to prevent them to be closed when the initial socket which subscribed to the topic is closed.

### Changes

- Add extra debug logging around websockets.
- Properly install the websocket even if the topic is already created.
- Reduce size of the channel for the Events to 1000

### Testing

<!--
Describe how the presented changes can be tested. Execute some basic tests
on your own and provide a short summary of the results in this section.
-->

---

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
