### PR TITLE
Hardhat task to call bridge out action

### DIFF
--- a/precompile/hardhat/tasks/assetsbridge.ts
+++ b/precompile/hardhat/tasks/assetsbridge.ts
@@ -82,3 +82,27 @@ task(
     console.log(result)
   }
 )
+
+task(
+  'assetsBridge:bridgeOut', 
+  'Initiates the bridge out process by unlocking the given assets on Mezo'
+)
+  .addParam('token', 'The address of the ERC20 token on Mezo')
+  .addParam('amount', 'The amount of the ERC20 token to unlock')
+  .addParam('chain', 'The target chain to bridge out to (uint8)')
+  .addParam('recipient', 'The target address to send the funds to (hex encoded bytes)')
+  .addParam('signer', 'The signer address (msg.sender)')
+  .setAction(
+    async (taskArguments, hre) => {
+      const signer = await hre.ethers.getSigner(taskArguments.signer)
+      const bridge = new hre.ethers.Contract(precompileAddress, abi, signer)
+      const pending = await bridge.bridgeOut(
+        taskArguments.token,
+        taskArguments.amount,
+        taskArguments.chain,
+        taskArguments.recipient
+      )
+      const confirmed = await pending.wait()
+      console.log(confirmed.hash)
+    } 
+  )


### PR DESCRIPTION
### Introduction

We add a new `assetsBridge:bridgeOut` task to the `precompile/hardhat` package to be able to invoke the `bridgeOut` transaction on the `AssetsBridge` precompile.

### Testing

I already used this task to test another PR, see: https://github.com/mezo-org/mezod/pull/509#issuecomment-3136596628

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
