### PR TITLE
Websocket rpc issue

### DIFF
--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -24,6 +24,8 @@ import (
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
+var ErrTopicNotFound = errors.New("topic not found")
+
 type UnsubscribeFunc func()
 
 type EventBus interface {
@@ -92,7 +94,7 @@ func (m *memEventBus) Subscribe(name string) (<-chan coretypes.ResultEvent, Unsu
 	m.topicsMux.RUnlock()
 
 	if !ok {
-		return nil, nil, errors.Errorf("topic not found: %s", name)
+		return nil, nil, ErrTopicNotFound
 	}
 
 	ch := make(chan coretypes.ResultEvent, 1000)

--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -67,18 +67,14 @@ func (m *memEventBus) Topics() (topics []string) {
 }
 
 func (m *memEventBus) AddTopic(name string, src <-chan coretypes.ResultEvent) error {
-	m.topicsMux.RLock()
-	_, ok := m.topics[name]
-	m.topicsMux.RUnlock()
+	m.topicsMux.Lock()
+	defer m.topicsMux.Unlock()
 
-	if ok {
+	if _, ok := m.topics[name]; ok {
 		return errors.New("topic already registered")
 	}
 
-	m.topicsMux.Lock()
 	m.topics[name] = src
-	m.topicsMux.Unlock()
-
 	go m.publishTopic(name, src)
 
 	return nil

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -133,63 +133,63 @@ func (es *EventSystem) subscribe(sub *Subscription) (*Subscription, pubsub.Unsub
 
 		// We haven't returned so error is ErrTopicNotFound.
 		// Continue with execution and create topic.
-		// topic doesn't exist, to create it
-		switch sub.typ {
-		case filters.LogsSubscription:
-			err = es.tmWSClient.Subscribe(ctx, sub.event)
-		case filters.BlocksSubscription:
-			err = es.tmWSClient.Subscribe(ctx, sub.event)
-		case filters.PendingTransactionsSubscription:
-			err = es.tmWSClient.Subscribe(ctx, sub.event)
-		default:
-			err = fmt.Errorf("invalid filter subscription type %d", sub.typ)
-		}
-
-		if err != nil {
-			sub.err <- err
-			return nil, nil, err
-		}
-
-		// create topic channel and add to event bus
-		ch := make(chan coretypes.ResultEvent)
-		if err := es.eventBus.AddTopic(sub.event, ch); err != nil {
-			es.logger.Error("AddTopic failed after verification, there might be a bug in the EventSystem",
-				"topic", sub.event, "error", err, "subscription", sub.id)
-			sub.err <- err
-			return nil, nil, fmt.Errorf("event system internal error: %w", err)
-		}
-
-		// add subscription to the index
-		es.index[sub.typ][sub.id] = sub
-		// store the topic channel
-		es.topicChans[sub.event] = ch
-
-		// subscribe to the newly created topic
-		eventCh, unsubFn, err = es.eventBus.Subscribe(sub.event)
-		if err != nil {
-			es.logger.Error("Subscribe failed after AddTopic succeeded, there might be a bug in the EventSystem",
-				"topic", sub.event, "error", err, "subscription", sub.id)
-			// we remove the subscription as we had an error when subscribing.
-			sub.err <- err
-			delete(es.index[sub.typ], sub.id)
-			es.eventBus.RemoveTopic(sub.event)
-			// this call to subscribe created the topicChans, however, seeing that
-			// the subscription failed, and there's no other subscriber for it
-			// we need to delete the chan for the topic to leave no unused
-			// resources behind
-			delete(es.topicChans, sub.event)
-			return nil, nil, fmt.Errorf("event system internal error: %w", err)
-		}
-
-		sub.eventCh = eventCh
-		return sub, unsubFn, nil
-
 	} else {
 		// No error. Topic exists so add subscription to the index.
 		es.index[sub.typ][sub.id] = sub
 		sub.eventCh = eventCh
 		return sub, unsubFn, nil
 	}
+
+	// topic doesn't exist, to create it
+	switch sub.typ {
+	case filters.LogsSubscription:
+		err = es.tmWSClient.Subscribe(ctx, sub.event)
+	case filters.BlocksSubscription:
+		err = es.tmWSClient.Subscribe(ctx, sub.event)
+	case filters.PendingTransactionsSubscription:
+		err = es.tmWSClient.Subscribe(ctx, sub.event)
+	default:
+		err = fmt.Errorf("invalid filter subscription type %d", sub.typ)
+	}
+
+	if err != nil {
+		sub.err <- err
+		return nil, nil, err
+	}
+
+	// create topic channel and add to event bus
+	ch := make(chan coretypes.ResultEvent)
+	if err := es.eventBus.AddTopic(sub.event, ch); err != nil {
+		es.logger.Error("AddTopic failed after verification, there might be a bug in the EventSystem",
+			"topic", sub.event, "error", err, "subscription", sub.id)
+		sub.err <- err
+		return nil, nil, fmt.Errorf("event system internal error: %w", err)
+	}
+
+	// add subscription to the index
+	es.index[sub.typ][sub.id] = sub
+	// store the topic channel
+	es.topicChans[sub.event] = ch
+
+	// subscribe to the newly created topic
+	eventCh, unsubFn, err = es.eventBus.Subscribe(sub.event)
+	if err != nil {
+		es.logger.Error("Subscribe failed after AddTopic succeeded, there might be a bug in the EventSystem",
+			"topic", sub.event, "error", err, "subscription", sub.id)
+		// we remove the subscription as we had an error when subscribing.
+		sub.err <- err
+		delete(es.index[sub.typ], sub.id)
+		es.eventBus.RemoveTopic(sub.event)
+		// this call to subscribe created the topicChans, however, seeing that
+		// the subscription failed, and there's no other subscriber for it
+		// we need to delete the chan for the topic to leave no unused
+		// resources behind
+		delete(es.topicChans, sub.event)
+		return nil, nil, fmt.Errorf("event system internal error: %w", err)
+	}
+
+	sub.eventCh = eventCh
+	return sub, unsubFn, nil
 }
 
 // SubscribeLogs creates a subscription that will write all logs matching the

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -146,18 +146,16 @@ func (es *EventSystem) subscribe(sub *Subscription) (*Subscription, pubsub.Unsub
 		return nil, nil, err
 	}
 
-	// add subscription to the index
-	es.index[sub.typ][sub.id] = sub
-
 	// create topic channel and add to event bus
 	ch := make(chan coretypes.ResultEvent)
 	if err := es.eventBus.AddTopic(sub.event, ch); err != nil {
 		es.logger.Error("AddTopic failed after verification, there might be a bug in the EventSystem",
 			"topic", sub.event, "error", err, "subscription", sub.id)
-		delete(es.index[sub.typ], sub.id)
 		return nil, nil, fmt.Errorf("event system internal error: %w", err)
 	}
 
+	// add subscription to the index
+	es.index[sub.typ][sub.id] = sub
 	// store the topic channel
 	es.topicChans[sub.event] = ch
 
@@ -166,8 +164,13 @@ func (es *EventSystem) subscribe(sub *Subscription) (*Subscription, pubsub.Unsub
 	if err != nil {
 		es.logger.Error("Subscribe failed after AddTopic succeeded, there might be a bug in the EventSystem",
 			"topic", sub.event, "error", err, "subscription", sub.id)
+		// we remove the subscription as we had an error when subscribing.
 		delete(es.index[sub.typ], sub.id)
 		es.eventBus.RemoveTopic(sub.event)
+		// this call to subscribe created the topicChans, however, seeing that
+		// the subscription failed, and there's no other subscriber for it
+		// we need to delete the chan for the topic to leave no unused
+		// resources behind
 		delete(es.topicChans, sub.event)
 		return nil, nil, fmt.Errorf("event system internal error: %w", err)
 	}

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -255,6 +255,8 @@ func (es EventSystem) SubscribePendingTxs() (*Subscription, pubsub.UnsubscribeFu
 type filterIndex map[filters.Type]map[rpc.ID]*Subscription
 
 // eventLoop (un)installs filters and processes mux events.
+//
+//nolint:gosimple
 func (es *EventSystem) eventLoop() {
 	for {
 		select {

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -120,7 +120,7 @@ func (es *EventSystem) subscribe(sub *Subscription) (*Subscription, pubsub.Unsub
 
 	// try to subscribe to existing topic first
 	// no need to loop over the existing topics, just try to
-	// get it, an error return the topic exists
+	// get it, an error is returned if the topic doesn't exist
 	eventCh, unsubFn, err := es.eventBus.Subscribe(sub.event)
 	if err == nil {
 		// topic exists, add subscription to the index

--- a/rpc/namespaces/ethereum/eth/filters/subscription.go
+++ b/rpc/namespaces/ethereum/eth/filters/subscription.go
@@ -27,17 +27,16 @@ import (
 
 // Subscription defines a wrapper for the private subscription
 type Subscription struct {
-	id        rpc.ID
-	typ       filters.Type
-	event     string
-	created   time.Time
-	logsCrit  filters.FilterCriteria
-	logs      chan []*ethtypes.Log
-	hashes    chan []common.Hash
-	headers   chan *ethtypes.Header
-	installed chan struct{} // closed when the filter is installed
-	eventCh   <-chan coretypes.ResultEvent
-	err       chan error
+	id       rpc.ID
+	typ      filters.Type
+	event    string
+	created  time.Time
+	logsCrit filters.FilterCriteria
+	logs     chan []*ethtypes.Log
+	hashes   chan []common.Hash
+	headers  chan *ethtypes.Header
+	eventCh  <-chan coretypes.ResultEvent
+	err      chan error
 }
 
 // ID returns the underlying subscription RPC identifier.


### PR DESCRIPTION
Part of: https://linear.app/thesis-co/issue/TET-1371/mezo-websoket-doesnt-log-events-when-subscribed-to-specific-token

### Introduction

The websockets issues still exists. here we found two new possible race conditions.

### Changes

First commit: in pubsub, use a single lock to see if the topic exists + create it if needed.
Second commit: Fix the EventSystem subscribe.
    - remove the install / installed channel
    - do not handle installation of the socket in eventLoop, just the uninstall there
    - lock the event system in the subscribe to atomically add the new subscribtion.

### Testing

Like with the previous attempts:
- boostrap a node with `make localnode-bin-start`
- `wscat -n -x '{"jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"], "id": 0}' -c ws://0.0.0.0:8546 --wait 100`

These still work, I've tried as well to use the the perf tests to listen to contracts events, and this works, but to be fair, this worked as well locally before.

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
