### PR TITLE
Missing unit tests for Ethereum sidecar server

### DIFF
--- a/ethereum/chain.go
+++ b/ethereum/chain.go
@@ -1,0 +1,12 @@
+package ethereum
+
+import (
+	"context"
+	"math/big"
+)
+
+type Chain interface {
+	CurrentBlock() (uint64, error)
+	FinalizedBlock(ctx context.Context) (*big.Int, error)
+	WatchBlocks(ctx context.Context) <-chan uint64
+}

--- a/ethereum/ethereum.go
+++ b/ethereum/ethereum.go
@@ -141,12 +141,16 @@ func newBaseChain(
 	}, nil
 }
 
-func (bc *BaseChain) BlockCounter() *ethereum.BlockCounter {
-	return bc.blockCounter
+func (bc *BaseChain) CurrentBlock() (uint64, error) {
+	return bc.blockCounter.CurrentBlock()
 }
 
 func (bc *BaseChain) FinalizedBlock(ctx context.Context) (*big.Int, error) {
 	return bc.finalizedBlockFn(ctx)
+}
+
+func (bc *BaseChain) WatchBlocks(ctx context.Context) <-chan uint64 {
+	return bc.blockCounter.WatchBlocks(ctx)
 }
 
 func (bc *BaseChain) Client() ethutil.EthereumClient {

--- a/ethereum/sidecar/server.go
+++ b/ethereum/sidecar/server.go
@@ -117,7 +117,7 @@ type Server struct {
 
 	bridgeContract ethconnect.BridgeContract
 
-	chain *ethconnect.BaseChain
+	chain ethconnect.Chain
 
 	batchSize         uint64
 	requestsPerMinute uint64
@@ -337,7 +337,7 @@ func (s *Server) observeAssetsLockedEvents(ctx context.Context) error {
 	close(s.assetsLockedReady)
 
 	// Start a ticker to periodically check the current block number
-	tickerChan := s.chain.BlockCounter().WatchBlocks(ctx)
+	tickerChan := s.chain.WatchBlocks(ctx)
 
 	for {
 		select {
@@ -750,7 +750,7 @@ func (s *Server) findUnconfirmedAssetsUnlockedEvents(
 		return []bridgetypes.AssetsUnlockedEvent{}, nil
 	}
 
-	currentBlock, err := s.chain.BlockCounter().CurrentBlock()
+	currentBlock, err := s.chain.CurrentBlock()
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get current block on Ethereum chain [%w]",


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1182/ethereum-sidecar-monitoring-loop
Depends on https://github.com/mezo-org/mezod/pull/506

### Introduction

This PR is a follow-up to https://github.com/mezo-org/mezod/pull/506.
It adds more unit tests.
To make some functions testable we had to create an interface for Ethereum chain communication.

### Changes

- added the `Chain` interface for communication with Ethereum.
- added missing unit tests for Ethereum sidecar server

### Testing

Covered with unit tests

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [X] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
