### PR TITLE
Auto-restore CometBFT subscriptions upon internal WS client reconnection

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -34,8 +34,6 @@ import (
 	"github.com/mezo-org/mezod/rpc/namespaces/ethereum/txpool"
 	"github.com/mezo-org/mezod/rpc/namespaces/ethereum/web3"
 	"github.com/mezo-org/mezod/types"
-
-	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 )
 
 // RPC namespaces and API version
@@ -62,7 +60,7 @@ const (
 type APICreator = func(
 	ctx *server.Context,
 	clientCtx client.Context,
-	tendermintWebsocketClient *rpcclient.WSClient,
+	cometWSClient *types.CometWSClient,
 	allowUnprotectedTxs bool,
 	indexer types.EVMTxIndexer,
 ) []rpc.API
@@ -74,7 +72,7 @@ func init() {
 	apiCreators = map[string]APICreator{
 		EthNamespace: func(serverCtx *server.Context,
 			clientCtx client.Context,
-			tmWSClient *rpcclient.WSClient,
+			cometWSClient *types.CometWSClient,
 			allowUnprotectedTxs bool,
 			indexer types.EVMTxIndexer,
 		) []rpc.API {
@@ -89,12 +87,12 @@ func init() {
 				{
 					Namespace: EthNamespace,
 					Version:   apiVersion,
-					Service:   filters.NewPublicAPI(serverCtx.Logger, clientCtx, tmWSClient, evmBackend),
+					Service:   filters.NewPublicAPI(serverCtx.Logger, clientCtx, cometWSClient, evmBackend),
 					Public:    true,
 				},
 			}
 		},
-		Web3Namespace: func(*server.Context, client.Context, *rpcclient.WSClient, bool, types.EVMTxIndexer) []rpc.API {
+		Web3Namespace: func(*server.Context, client.Context, *types.CometWSClient, bool, types.EVMTxIndexer) []rpc.API {
 			return []rpc.API{
 				{
 					Namespace: Web3Namespace,
@@ -104,7 +102,7 @@ func init() {
 				},
 			}
 		},
-		NetNamespace: func(serverCtx *server.Context, clientCtx client.Context, _ *rpcclient.WSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
+		NetNamespace: func(serverCtx *server.Context, clientCtx client.Context, _ *types.CometWSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
 			return []rpc.API{
 				{
 					Namespace: NetNamespace,
@@ -116,7 +114,7 @@ func init() {
 		},
 		PersonalNamespace: func(serverCtx *server.Context,
 			clientCtx client.Context,
-			_ *rpcclient.WSClient,
+			_ *types.CometWSClient,
 			allowUnprotectedTxs bool,
 			indexer types.EVMTxIndexer,
 		) []rpc.API {
@@ -130,7 +128,7 @@ func init() {
 				},
 			}
 		},
-		TxPoolNamespace: func(serverCtx *server.Context, _ client.Context, _ *rpcclient.WSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
+		TxPoolNamespace: func(serverCtx *server.Context, _ client.Context, _ *types.CometWSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
 			return []rpc.API{
 				{
 					Namespace: TxPoolNamespace,
@@ -142,7 +140,7 @@ func init() {
 		},
 		DebugNamespace: func(serverCtx *server.Context,
 			clientCtx client.Context,
-			_ *rpcclient.WSClient,
+			_ *types.CometWSClient,
 			allowUnprotectedTxs bool,
 			indexer types.EVMTxIndexer,
 		) []rpc.API {
@@ -158,7 +156,7 @@ func init() {
 		},
 		MinerNamespace: func(serverCtx *server.Context,
 			clientCtx client.Context,
-			_ *rpcclient.WSClient,
+			_ *types.CometWSClient,
 			allowUnprotectedTxs bool,
 			indexer types.EVMTxIndexer,
 		) []rpc.API {
@@ -175,7 +173,7 @@ func init() {
 		MezoNamespace: func(
 			serverCtx *server.Context,
 			clientCtx client.Context,
-			_ *rpcclient.WSClient,
+			_ *types.CometWSClient,
 			allowUnprotectedTxs bool,
 			indexer types.EVMTxIndexer,
 		) []rpc.API {
@@ -195,7 +193,7 @@ func init() {
 // GetRPCAPIs returns the list of all APIs
 func GetRPCAPIs(ctx *server.Context,
 	clientCtx client.Context,
-	tmWSClient *rpcclient.WSClient,
+	cometWSClient *types.CometWSClient,
 	allowUnprotectedTxs bool,
 	indexer types.EVMTxIndexer,
 	selectedAPIs []string,
@@ -204,7 +202,7 @@ func GetRPCAPIs(ctx *server.Context,
 
 	for _, ns := range selectedAPIs {
 		if creator, ok := apiCreators[ns]; ok {
-			apis = append(apis, creator(ctx, clientCtx, tmWSClient, allowUnprotectedTxs, indexer)...)
+			apis = append(apis, creator(ctx, clientCtx, cometWSClient, allowUnprotectedTxs, indexer)...)
 		} else {
 			ctx.Logger.Error("invalid namespace value", "namespace", ns)
 		}

--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -121,10 +121,7 @@ func (m *memEventBus) publishTopic(name string, src <-chan coretypes.ResultEvent
 		msg, ok := <-src
 		if !ok {
 			m.closeAllSubscribers(name)
-			// TODO (Lukasz): We can use RemoveTopic instead of this.
-			m.topicsMux.Lock()
-			delete(m.topics, name)
-			m.topicsMux.Unlock()
+			m.RemoveTopic(name)
 			return
 		}
 		m.publishAllSubscribers(name, msg)

--- a/rpc/ethereum/pubsub/pubsub.go
+++ b/rpc/ethereum/pubsub/pubsub.go
@@ -121,6 +121,7 @@ func (m *memEventBus) publishTopic(name string, src <-chan coretypes.ResultEvent
 		msg, ok := <-src
 		if !ok {
 			m.closeAllSubscribers(name)
+			// TODO (Lukasz): We can use RemoveTopic instead of this.
 			m.topicsMux.Lock()
 			delete(m.topics, name)
 			m.topicsMux.Unlock()

--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -31,7 +31,6 @@ import (
 	"cosmossdk.io/log"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
-	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	tmtypes "github.com/cometbft/cometbft/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -104,14 +103,14 @@ type PublicFilterAPI struct {
 }
 
 // NewPublicAPI returns a new PublicFilterAPI instance.
-func NewPublicAPI(logger log.Logger, clientCtx client.Context, tmWSClient *rpcclient.WSClient, backend Backend) *PublicFilterAPI {
+func NewPublicAPI(logger log.Logger, clientCtx client.Context, cometWSClient *mezodtypes.CometWSClient, backend Backend) *PublicFilterAPI {
 	logger = logger.With("api", "filter")
 	api := &PublicFilterAPI{
 		logger:    logger,
 		clientCtx: clientCtx,
 		backend:   backend,
 		filters:   make(map[rpc.ID]*filter),
-		events:    NewEventSystem(logger, tmWSClient),
+		events:    NewEventSystem(logger, cometWSClient),
 	}
 
 	go api.timeoutLoop()

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -39,13 +39,13 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"cosmossdk.io/log"
-	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	tmtypes "github.com/cometbft/cometbft/types"
 
 	"github.com/mezo-org/mezod/rpc/ethereum/pubsub"
 	rpcfilters "github.com/mezo-org/mezod/rpc/namespaces/ethereum/eth/filters"
 	"github.com/mezo-org/mezod/rpc/types"
 	"github.com/mezo-org/mezod/server/config"
+	mezodtypes "github.com/mezo-org/mezod/types"
 	evmtypes "github.com/mezo-org/mezod/x/evm/types"
 )
 
@@ -90,7 +90,7 @@ type websocketsServer struct {
 	logger   log.Logger
 }
 
-func NewWebsocketsServer(clientCtx client.Context, logger log.Logger, tmWSClient *rpcclient.WSClient, cfg *config.Config) WebsocketsServer {
+func NewWebsocketsServer(clientCtx client.Context, logger log.Logger, cometWSClient *mezodtypes.CometWSClient, cfg *config.Config) WebsocketsServer {
 	logger = logger.With("api", "websocket-server")
 	_, port, _ := net.SplitHostPort(cfg.JSONRPC.Address) // #nosec G703
 
@@ -99,7 +99,7 @@ func NewWebsocketsServer(clientCtx client.Context, logger log.Logger, tmWSClient
 		wsAddr:   cfg.JSONRPC.WsAddress,
 		certFile: cfg.TLS.CertificatePath,
 		keyFile:  cfg.TLS.KeyPath,
-		api:      newPubSubAPI(clientCtx, logger, tmWSClient),
+		api:      newPubSubAPI(clientCtx, logger, cometWSClient),
 		logger:   logger,
 	}
 }
@@ -379,10 +379,10 @@ type pubSubAPI struct {
 }
 
 // newPubSubAPI creates an instance of the ethereum PubSub API.
-func newPubSubAPI(clientCtx client.Context, logger log.Logger, tmWSClient *rpcclient.WSClient) *pubSubAPI {
+func newPubSubAPI(clientCtx client.Context, logger log.Logger, cometWSClient *mezodtypes.CometWSClient) *pubSubAPI {
 	logger = logger.With("module", "websocket-client")
 	return &pubSubAPI{
-		events:    rpcfilters.NewEventSystem(logger, tmWSClient),
+		events:    rpcfilters.NewEventSystem(logger, cometWSClient),
 		logger:    logger,
 		clientCtx: clientCtx,
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -18,7 +18,6 @@ package server
 import (
 	"net"
 	"net/http"
-	"time"
 
 	// TODO update import to local pkg when rpc pkg is migrated
 	"github.com/gorilla/mux"
@@ -34,7 +33,6 @@ import (
 	"cosmossdk.io/log"
 
 	tmcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
-	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 )
 
 // AddCommands adds server commands
@@ -71,34 +69,6 @@ func AddCommands(
 		// custom tx indexer command
 		NewIndexTxCmd(),
 	)
-}
-
-func ConnectTmWS(tmRPCAddr, tmEndpoint string, logger log.Logger) *rpcclient.WSClient {
-	tmWsClient, err := rpcclient.NewWS(tmRPCAddr, tmEndpoint,
-		rpcclient.MaxReconnectAttempts(256),
-		rpcclient.ReadWait(120*time.Second),
-		rpcclient.WriteWait(120*time.Second),
-		rpcclient.PingPeriod(50*time.Second),
-		rpcclient.OnReconnect(func() {
-			logger.Debug("EVM RPC reconnects to Tendermint WS", "address", tmRPCAddr+tmEndpoint)
-		}),
-	)
-
-	if err != nil {
-		logger.Error(
-			"Tendermint WS client could not be created",
-			"address", tmRPCAddr+tmEndpoint,
-			"error", err,
-		)
-	} else if err := tmWsClient.OnStart(); err != nil {
-		logger.Error(
-			"Tendermint WS client could not start",
-			"address", tmRPCAddr+tmEndpoint,
-			"error", err,
-		)
-	}
-
-	return tmWsClient
 }
 
 func MountGRPCWebServices(

--- a/types/cometbft_ws_client.go
+++ b/types/cometbft_ws_client.go
@@ -1,0 +1,150 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+)
+
+// CometWSClient is a wrapper around the cometbft rpc client that provides a
+// mechanism to restore subscriptions after a reconnect.
+type CometWSClient struct {
+	*rpcclient.WSClient
+
+	logger             log.Logger
+	subscriptionsMutex sync.Mutex
+	subscriptions      map[string]bool
+}
+
+func ConnectCometWS(logger log.Logger, address, endpoint, moniker string) (*CometWSClient, error) {
+	clientLogger := logger.With(
+		"client-moniker", moniker,
+		"server-address", address+endpoint,
+	)
+
+	reconnectedCh := make(chan struct{}, 1)
+
+	wsClient, err := rpcclient.NewWS(address, endpoint,
+		rpcclient.MaxReconnectAttempts(256),
+		rpcclient.ReadWait(120*time.Second),
+		rpcclient.WriteWait(120*time.Second),
+		rpcclient.PingPeriod(50*time.Second),
+		rpcclient.OnReconnect(func() {
+			reconnectedCh <- struct{}{}
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("internal cometbft ws client could not be created: %w", err)
+	} else if err := wsClient.OnStart(); err != nil {
+		return nil, fmt.Errorf("internal cometbft ws client could not be started: %w", err)
+	}
+
+	wrapper := &CometWSClient{
+		logger:        clientLogger,
+		WSClient:      wsClient,
+		subscriptions: make(map[string]bool),
+	}
+
+	go func() {
+		for {
+			select {
+			case <-reconnectedCh:
+				clientLogger.Info("internal cometbft ws client reconnected")
+				wrapper.restoreSubscriptions()
+			case <-wsClient.Quit():
+				clientLogger.Warn("internal cometbft ws client quit")
+				return
+			}
+		}
+	}()
+
+	return wrapper, nil
+}
+
+func (cwc *CometWSClient) restoreSubscriptions() {
+	cwc.subscriptionsMutex.Lock()
+	defer cwc.subscriptionsMutex.Unlock()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	for query := range cwc.subscriptions {
+		// This is a fresh connection so there shouldn't be any subscriptions but unsubscribe just in case.
+		err := cwc.WSClient.Unsubscribe(ctx, query)
+		if err != nil {
+			cwc.logger.Error(
+				"internal cometbft ws client failed to unsubscribe from query while restoring subscriptions",
+				"query", query,
+				"error", err,
+			)
+		}
+
+		err = cwc.WSClient.Subscribe(ctx, query)
+		if err != nil {
+			cwc.logger.Error(
+				"internal cometbft ws client failed to subscribe to query while restoring subscriptions",
+				"query", query,
+				"error", err,
+			)
+		}
+	}
+
+	cwc.logger.Info(
+		"internal cometbft ws client restored subscriptions after reconnect",
+		"subscriptions", cwc.subscriptions,
+	)
+}
+
+func (cwc *CometWSClient) Subscribe(ctx context.Context, query string) error {
+	cwc.subscriptionsMutex.Lock()
+	defer cwc.subscriptionsMutex.Unlock()
+
+	cwc.logger.Debug("internal cometbft ws client subscribing to query", "query", query)
+
+	err := cwc.WSClient.Subscribe(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	cwc.subscriptions[query] = true
+
+	return nil
+}
+
+func (cwc *CometWSClient) Unsubscribe(ctx context.Context, query string) error {
+	cwc.subscriptionsMutex.Lock()
+	defer cwc.subscriptionsMutex.Unlock()
+
+	cwc.logger.Debug("internal cometbft ws client unsubscribing from query", "query", query)
+
+	err := cwc.WSClient.Unsubscribe(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	delete(cwc.subscriptions, query)
+
+	return nil
+}
+
+func (cwc *CometWSClient) UnsubscribeAll(ctx context.Context) error {
+	cwc.subscriptionsMutex.Lock()
+	defer cwc.subscriptionsMutex.Unlock()
+
+	cwc.logger.Debug("internal cometbft ws client unsubscribing from all queries")
+
+	err := cwc.WSClient.UnsubscribeAll(ctx)
+	if err != nil {
+		return err
+	}
+
+	for query := range cwc.subscriptions {
+		delete(cwc.subscriptions, query)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1371/mezo-websoket-doesnt-log-events-when-subscribed-to-specific-token

### Introduction

We observe a problem where Websocket subscribers of our EVM JSON-RPC sometimes do not receive expected contract events (i.e. events from an `eth_subscribe` call made with `logs` as parameter). It turns out the root cause are reconnections of the internal Websocket between EVM JSON-RPC and CometBFT RPC which is the actual source of those events. The EVM JSON-RPC server maintains internal subscriptions for specific types of CometBFT events (transactions, blocks, etc.) and uses them to feed its own subscribers (external clients of EVM JSON-RPC). Upon reconnection between EVM and CometBFT, all internal subscriptions are lost and not automatically restored. This PR aims to fix this issue. It also introduces some minor changes that aim to make the RPC module better.

### Changes

#### The new `CometWSClient` component

We introduce `CometWSClient` which wraps the original `rpcclient.WSClient` used so far and automatically restores all internal subscriptions to CometBFT RPC upon a reconnect between EVM and CometBFT. This ensures that CometBFT RPC delivers the necessary events all the time.

#### Use `RemoveTopic` inside `publishTopic`

`publishTopic` removed the topic from `m.topics` map manually while this should be done through the `RemoveTopic` function. Here we fix that. This change slightly improves readability of this code.

#### Simplify and rename `eventLoop` to `uninstallLoop`

There was a single-case select inside `eventLoop`, we replaced it with the for-loop as linter suggested. Moreover, this function deals only with uninstalls now hence we renamed it to `uninstallLoop`.

### Testing

Testing is tricky. I will build a custom `mezod` image, deploy it on one of our testnet nodes, and create some long-running subscriptions to `logs` and `newHeads`. If they don't lose events for at least 1 hour despite reconnections, we should consider this fix as sufficient.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
