### PR TITLE
Ethereum sidecar: Don't run monitoring and attestation loops for non-bridge validators

### DIFF
--- a/ethereum/chain.go
+++ b/ethereum/chain.go
@@ -3,9 +3,12 @@ package ethereum
 import (
 	"context"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 )
 
 type Chain interface {
+	Key() *keystore.Key
 	FinalizedBlock(ctx context.Context) (*big.Int, error)
 	LatestBlock(ctx context.Context) (*big.Int, error)
 	WatchBlocks(ctx context.Context) <-chan uint64

--- a/ethereum/sidecar/chain_test.go
+++ b/ethereum/sidecar/chain_test.go
@@ -3,6 +3,8 @@ package sidecar
 import (
 	"context"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 )
 
 func newLocalChain() *localChain {
@@ -11,6 +13,10 @@ func newLocalChain() *localChain {
 
 type localChain struct {
 	finalizedBlock *big.Int
+}
+
+func (lc *localChain) Key() *keystore.Key {
+	panic("unimplemented")
 }
 
 func (lc *localChain) FinalizedBlock(_ context.Context) (*big.Int, error) {

--- a/ethereum/sidecar/server.go
+++ b/ethereum/sidecar/server.go
@@ -281,7 +281,7 @@ func RunServer(
 
 	if id != 0 {
 		server.logger.Info(
-			"Account is an attesting validator. Waiting for the initial " +
+			"sidecar represents a bridge validator; waiting for the initial " +
 				"AssetsLocked sync before launching AssetsUnlocked routine",
 		)
 
@@ -320,7 +320,10 @@ func RunServer(
 			server.logger.Info("AssetsUnlocked events attestation routine stopped")
 		}()
 	} else {
-		server.logger.Info("Account is NOT an attesting validator")
+		server.logger.Info(
+			"sidecar does not represent a bridge validator; skipping " +
+				"AssetsUnlocked events processing",
+		)
 	}
 
 	<-ctx.Done()

--- a/ethereum/sidecar/server.go
+++ b/ethereum/sidecar/server.go
@@ -209,13 +209,6 @@ func RunServer(
 		panic(fmt.Sprintf("failed to initialize MezoBridge contract: %v", err))
 	}
 
-	accountAddress := chain.Key().Address
-
-	logger.Info(
-		"Extracted Ethereum account address",
-		"ethereum_account_address", accountAddress,
-	)
-
 	bridgeContract := NewBridgeContract(bridgeContractBinding)
 
 	attestationValidator := newAttestationValidation(
@@ -280,6 +273,7 @@ func RunServer(
 		server.logger.Info("gRPC server routine stopped")
 	}()
 
+	accountAddress := chain.Key().Address
 	id, err := server.bridgeContract.ValidatorIDs(accountAddress)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get bridge validator ID: %v", err))

--- a/ethereum/sidecar/server.go
+++ b/ethereum/sidecar/server.go
@@ -274,12 +274,12 @@ func RunServer(
 	}()
 
 	accountAddress := chain.Key().Address
-	id, err := server.bridgeContract.ValidatorIDs(accountAddress)
+	bridgeValidatorID, err := server.bridgeContract.ValidatorIDs(accountAddress)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get bridge validator ID: %v", err))
 	}
 
-	if id != 0 {
+	if bridgeValidatorID != 0 {
 		server.logger.Info(
 			"sidecar represents a bridge validator; waiting for the initial " +
 				"AssetsLocked sync before launching AssetsUnlocked routine",


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1383/ethereum-sidecar-dont-run-monitoring-and-attestation-loops-for-non

### Introduction

This PR adds a check validating whether the sidecar server we are running should participate in attesting. 

### Changes

- Account Ethereum address is extracted
- the address is used to retrieve validator ID from `MezoBridge`
- if the retrieved ID is not zero, it means that our instance of sidecar should participate in bridge-out attestation

### Testing

Test by launching the sidecar with appropriate Ethereum account.

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
