### PR TITLE
Align Ethereum sidecar flags naming

### DIFF
--- a/ethereum/sidecar/cli/ethereum_sidecar.go
+++ b/ethereum/sidecar/cli/ethereum_sidecar.go
@@ -33,7 +33,7 @@ func NewEthereumSidecarCmd() *cobra.Command {
 	// per 2 seconds, which is 30 requests per minute. Flag should be set to 30 for
 	// this example.
 	defaultServerRequestsPerMinute := uint64(600) // 10 requests per second
-	defaultAssetsUnlockedEndpoint := "127.0.0.1:9090"
+	defaultServerAssetsUnlockedEndpoint := "127.0.0.1:9090"
 	defaultKeyringBackend := flags.DefaultKeyringBackend
 	defaultKeyringDir := ""
 	defaultKeyName := ""
@@ -53,7 +53,7 @@ func NewEthereumSidecarCmd() *cobra.Command {
 			defaultServerEthereumNetwork.String(),
 			defaultServerBatchSize,
 			defaultServerRequestsPerMinute,
-			defaultAssetsUnlockedEndpoint,
+			defaultServerAssetsUnlockedEndpoint,
 			defaultKeyringBackend,
 			defaultKeyringDir,
 			defaultKeyName,
@@ -73,7 +73,7 @@ func runEthereumSidecar(cmd *cobra.Command, _ []string) error {
 	network, _ := cmd.Flags().GetString(FlagServerNetwork)
 	batchSize, _ := cmd.Flags().GetUint64(FlagServerBatchSize)
 	requestsPerMinute, _ := cmd.Flags().GetUint64(FlagServerRequestsPerMinute)
-	assetsUnlockedEndpoint, _ := cmd.Flags().GetString(FlagAssetsUnlockedEndpoint)
+	assetsUnlockedEndpoint, _ := cmd.Flags().GetString(FlagServerAssetsUnlockedEndpoint)
 	keyName, _ := cmd.Flags().GetString(FlagKeyName)
 
 	clientCtx, err := client.GetClientQueryContext(cmd)

--- a/ethereum/sidecar/cli/flags.go
+++ b/ethereum/sidecar/cli/flags.go
@@ -7,15 +7,15 @@ import (
 )
 
 const (
-	FlagServerAddress             = "ethereum-sidecar.server.address"
-	FlagServerEthereumNodeAddress = "ethereum-sidecar.server.ethereum-node-address"
-	FlagServerNetwork             = "ethereum-sidecar.server.network"
-	FlagServerBatchSize           = "ethereum-sidecar.server.batch-size"
-	FlagServerRequestsPerMinute   = "ethereum-sidecar.server.requests-per-minute"
-	FlagAssetsUnlockedEndpoint    = "ethereum-sidecar.assets-unlocked-endpoint"
-	FlagKeyringBackend            = "keyring-backend"
-	FlagKeyringDir                = "keyring-dir"
-	FlagKeyName                   = "key-name"
+	FlagServerAddress                = "ethereum-sidecar.server.address"
+	FlagServerEthereumNodeAddress    = "ethereum-sidecar.server.ethereum-node-address"
+	FlagServerNetwork                = "ethereum-sidecar.server.network"
+	FlagServerBatchSize              = "ethereum-sidecar.server.batch-size"
+	FlagServerRequestsPerMinute      = "ethereum-sidecar.server.requests-per-minute"
+	FlagServerAssetsUnlockedEndpoint = "ethereum-sidecar.server.assets-unlocked-endpoint"
+	FlagKeyringBackend               = "keyring-backend"
+	FlagKeyringDir                   = "keyring-dir"
+	FlagKeyName                      = "key-name"
 )
 
 func NewFlagSetEthereumSidecar(
@@ -24,7 +24,7 @@ func NewFlagSetEthereumSidecar(
 	defaultServerNetwork string,
 	defaultServerBatchSize uint64,
 	defaultServerRequestsPerMinute uint64,
-	defaultAssetsUnlockedEndpoint string,
+	defaultServerAssetsUnlockedEndpoint string,
 	defaultKeyringBackend,
 	defaultKeyringDir,
 	defaultKeyName string,
@@ -70,9 +70,9 @@ func NewFlagSetEthereumSidecar(
 	)
 
 	fs.String(
-		FlagAssetsUnlockedEndpoint,
-		defaultAssetsUnlockedEndpoint,
-		"Address of the gRPC endpoint for providing info on AssetsUnlocked "+
+		FlagServerAssetsUnlockedEndpoint,
+		defaultServerAssetsUnlockedEndpoint,
+		"Address of the mezod gRPC endpoint used to get AssetsUnlocked "+
 			"events emitted on the Mezo chain",
 	)
 
@@ -91,7 +91,7 @@ func NewFlagSetEthereumSidecar(
 	fs.String(
 		FlagKeyName,
 		defaultKeyName,
-		"Name of the key to extract from keyring (optional)",
+		"Name of the key to extract from keyring (mandatory for bridge validator nodes, optional for other node types)",
 	)
 
 	return fs


### PR DESCRIPTION
### Introduction

Here we rename the `ethereum-sidecar.assets-unlocked-endpoint` flag to `ethereum-sidecar.server.assets-unlocked-endpoint` in the sidecar to align with the existing naming and make everything consistent.

### Testing

Check the renamed flag works as expected.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
