### PR TITLE
Fix attestation ABI encoding and digest calculation

### DIFF
--- a/ethereum/sidecar/attestation_validator.go
+++ b/ethereum/sidecar/attestation_validator.go
@@ -80,51 +80,49 @@ func abiEncodeAttestation(attestation *portal.MezoBridgeAssetsUnlocked) ([]byte,
 // abiEncodeAttestationWithChainID is used to encode the attestation with the chain ID
 // which is used to produce a signature for the batch attestation process.
 func abiEncodeAttestationWithChainID(attestation *portal.MezoBridgeAssetsUnlocked, chainID *big.Int) ([]byte, error) {
-	uint256Type, err := abi.NewType("uint256", "uint256", nil)
-	if err != nil {
-		return nil, err
-	}
-	bytesType, err := abi.NewType("bytes", "bytes", nil)
-	if err != nil {
-		return nil, err
-	}
-	addressType, err := abi.NewType("address", "address", nil)
-	if err != nil {
-		return nil, err
-	}
-	uint8Type, err := abi.NewType("uint8", "uint8", nil)
-	if err != nil {
-		return nil, err
-	}
-
 	var argumentsTypes abi.Arguments
 	var arguments []any
+
 	if chainID != nil {
+		uint256Type, err := abi.NewType("uint256", "uint256", nil)
+		if err != nil {
+			return nil, err
+		}
 		argumentsTypes = append(argumentsTypes, abi.Argument{Type: uint256Type})
 		arguments = append(arguments, chainID)
 	}
 
-	argumentsTypes = append(
-		argumentsTypes,
-		abi.Arguments{
-			{Type: uint256Type},
-			{Type: bytesType},
-			{Type: addressType},
-			{Type: uint256Type},
-			{Type: uint8Type},
-		}...,
-	)
+	// Create tuple type for AssetsUnlocked struct
+	tupleType, err := abi.NewType("tuple", "tuple", []abi.ArgumentMarshaling{
+		{Name: "unlockSequenceNumber", Type: "uint256"},
+		{Name: "recipient", Type: "bytes"},
+		{Name: "token", Type: "address"},
+		{Name: "amount", Type: "uint256"},
+		{Name: "chain", Type: "uint8"},
+	})
+	if err != nil {
+		return nil, err
+	}
 
-	arguments = append(
-		arguments,
-		[]any{
-			attestation.UnlockSequenceNumber,
-			attestation.Recipient,
-			attestation.Token,
-			attestation.Amount,
-			attestation.Chain,
-		}...,
-	)
+	// Add the tuple as a single argument instead of individual fields
+	argumentsTypes = append(argumentsTypes, abi.Argument{Type: tupleType})
+
+	// Create the struct as a single tuple argument
+	assetsUnlockedTuple := struct {
+		UnlockSequenceNumber *big.Int
+		Recipient            []byte
+		Token                common.Address
+		Amount               *big.Int
+		Chain                uint8
+	}{
+		UnlockSequenceNumber: attestation.UnlockSequenceNumber,
+		Recipient:            attestation.Recipient,
+		Token:                attestation.Token,
+		Amount:               attestation.Amount,
+		Chain:                attestation.Chain,
+	}
+
+	arguments = append(arguments, assetsUnlockedTuple)
 
 	return argumentsTypes.Pack(arguments...)
 }

--- a/ethereum/sidecar/attestation_validator_test.go
+++ b/ethereum/sidecar/attestation_validator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/log"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mezo-org/mezod/ethereum/bindings/portal"
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
@@ -161,4 +162,42 @@ func defaultAttestation() *portal.MezoBridgeAssetsUnlocked {
 		Amount:               big.NewInt(1),
 		Chain:                0,
 	}
+}
+
+func TestAbiEncodeAttestation(t *testing.T) {
+	attestation := &portal.MezoBridgeAssetsUnlocked{
+		UnlockSequenceNumber: big.NewInt(10),
+		Recipient:            common.HexToAddress("0x87eaCD568b85dA3cfF39D3bb82F9329B23786b76").Bytes(),
+		Token:                common.HexToAddress("0x517f2982701695D4E52f1ECFBEf3ba31Df470161"),
+		Amount:               big.NewInt(77),
+		Chain:                0,
+	}
+
+	encoded, err := abiEncodeAttestation(attestation)
+	assert.NoError(t, err)
+
+	hash := crypto.Keccak256Hash(encoded)
+	// Expected hash computed using Solidity's `keccak256(abi.encode(AssetsUnlocked))`
+	expectedHash := common.HexToHash("0x68e75c66f0779e7c240868e0c8149c51f14fdd74aad9a3eb2781500edfde3137")
+
+	assert.Equal(t, expectedHash, hash)
+}
+
+func TestAbiEncodeAttestationWithChainID(t *testing.T) {
+	attestation := &portal.MezoBridgeAssetsUnlocked{
+		UnlockSequenceNumber: big.NewInt(10),
+		Recipient:            common.HexToAddress("0x87eaCD568b85dA3cfF39D3bb82F9329B23786b76").Bytes(),
+		Token:                common.HexToAddress("0x517f2982701695D4E52f1ECFBEf3ba31Df470161"),
+		Amount:               big.NewInt(77),
+		Chain:                0,
+	}
+
+	encoded, err := abiEncodeAttestationWithChainID(attestation, big.NewInt(1))
+	assert.NoError(t, err)
+
+	hash := crypto.Keccak256Hash(encoded)
+	// Expected hash computed using Solidity's `keccak256(abi.encode(1, AssetsUnlocked))`
+	expectedHash := common.HexToHash("0xa0c5a45f9393426db79c98ccd594e6f8ca6683268ee7e95101a4c85111f53318")
+
+	assert.Equal(t, expectedHash, hash)
 }

--- a/ethereum/sidecar/batch_attestation.go
+++ b/ethereum/sidecar/batch_attestation.go
@@ -130,13 +130,24 @@ func (ba *batchAttestation) sendPayload(
 	}
 }
 
+func attestationDigestHash(attestation *portal.MezoBridgeAssetsUnlocked, chainID *big.Int) ([]byte, error) {
+	abiEncoded, err := abiEncodeAttestationWithChainID(attestation, chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	digest := crypto.Keccak256(abiEncoded)
+
+	return accounts.TextHash(digest), nil
+}
+
 func (ba *batchAttestation) signPayload(attestation *portal.MezoBridgeAssetsUnlocked) (string, error) {
-	abiEncoded, err := abiEncodeAttestationWithChainID(attestation, ba.chainID)
+	digestHash, err := attestationDigestHash(attestation, ba.chainID)
 	if err != nil {
 		return "", err
 	}
 
-	signature, err := crypto.Sign(accounts.TextHash(abiEncoded), ba.privateKey)
+	signature, err := crypto.Sign(digestHash, ba.privateKey)
 	if err != nil {
 		return "", err
 	}

--- a/ethereum/sidecar/batch_attestation_test.go
+++ b/ethereum/sidecar/batch_attestation_test.go
@@ -221,3 +221,20 @@ func TestBatchAttestation_TryAttest(t *testing.T) {
 		})
 	}
 }
+
+func TestAttestationDigestHash(t *testing.T) {
+	attestation := &portal.MezoBridgeAssetsUnlocked{
+		UnlockSequenceNumber: big.NewInt(10),
+		Recipient:            common.HexToAddress("0x87eaCD568b85dA3cfF39D3bb82F9329B23786b76").Bytes(),
+		Token:                common.HexToAddress("0x517f2982701695D4E52f1ECFBEf3ba31Df470161"),
+		Amount:               big.NewInt(77),
+		Chain:                0,
+	}
+
+	digestHash, err := attestationDigestHash(attestation, big.NewInt(1))
+	assert.NoError(t, err)
+
+	// Expected digest hash computed using Solidity's `keccak256(abi.encode(1, AssetsUnlocked)).toEthSignedMessageHash()`
+	expectedDigestHash := common.HexToHash("0xcb97fcb7f22cc5aadd1b5e6497d547723d4a652d31cf38e78d3644b44a71846d").Bytes()
+	assert.Equal(t, expectedDigestHash, digestHash)
+}


### PR DESCRIPTION
### Introduction

The `AssetsUnlocked` entry was wrongly encoded to ABI and the signature digest for batch mode missed the intermediary hash. Here we fix that and cover it with missing unit tests.


### Testing

Covered with unit tests.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
