### PR TITLE
The v4.0.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -15,10 +15,11 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v1_0"
 	"github.com/mezo-org/mezod/app/upgrades/v2_0"
 	"github.com/mezo-org/mezod/app/upgrades/v3_0"
+	"github.com/mezo-org/mezod/app/upgrades/v4_0"
 )
 
 var (
-	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1, v2_0.Upgrade, v3_0.Upgrade}
+	Upgrades = []upgrades.Upgrade{v0_3.Upgrade, v1_0.UpgradeRC0, v1_0.UpgradeRC1, v2_0.Upgrade, v3_0.Upgrade, v4_0.Upgrade}
 	Forks    = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )
 

--- a/app/upgrades/v4_0/constants.go
+++ b/app/upgrades/v4_0/constants.go
@@ -1,0 +1,16 @@
+//nolint:revive,stylecheck
+package v4_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+// UpgradeName defines the name of the upgrade.
+const UpgradeName = "v4.0.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v4_0/upgrades.go
+++ b/app/upgrades/v4_0/upgrades.go
@@ -1,0 +1,80 @@
+//nolint:revive,stylecheck
+package v4_0
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+	evmkeeper "github.com/mezo-org/mezod/x/evm/keeper"
+	evmtypes "github.com/mezo-org/mezod/x/evm/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		sdkCtx.Logger().Info("running v4.0.0 upgrade handler")
+
+		err := updateBridgePrecompileVersion(sdkCtx, keepers.EvmKeeper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update bridge precompile version: %w", err)
+		}
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
+func updateBridgePrecompileVersion(ctx sdk.Context, evmKeeper *evmkeeper.Keeper) error {
+	params := evmKeeper.GetParams(ctx)
+
+	ctx.Logger().Info(
+		"begin bridge precompile version update",
+		"precompilesVersions",
+		params.PrecompilesVersions,
+	)
+
+	bridgeVersionInfoIndex := slices.IndexFunc(
+		params.PrecompilesVersions,
+		func(versionInfo *evmtypes.PrecompileVersionInfo) bool {
+			// Compare bytes just in case to avoid any potential issues
+			// with string comparison.
+			return bytes.Equal(
+				evmtypes.HexAddressToBytes(versionInfo.PrecompileAddress),
+				evmtypes.HexAddressToBytes(evmtypes.AssetsBridgePrecompileAddress),
+			)
+		},
+	)
+
+	// 4 is the value of evmtypes.AssetsBridgePrecompileLatestVersion at
+	// the time of this upgrade. We avoid using the constant directly
+	// as it will change in the future so the actual value of the version
+	// used during this upgrade would perish over time.
+	params.PrecompilesVersions[bridgeVersionInfoIndex].Version = 4
+
+	err := evmKeeper.SetParams(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	ctx.Logger().Info(
+		"bridge precompile version updated",
+		"precompilesVersions",
+		evmKeeper.GetParams(ctx).PrecompilesVersions,
+	)
+
+	return nil
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -184,6 +184,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v1.0.0-rc1` | 3712500 | Planned upgrade with chain halt    | Patch for mixed precompile addresses.                                                                                                           |
 | `v2.0.2` | 5559500 | Planned upgrade with chain halt    | Bring back parity with mainnet.                                                                                                           |
 | `v3.0.0` | 5695000 | Planned upgrade with chain halt    | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |
+| `v4.0.0` | 6854500 | Planned upgrade with chain halt    | [v4.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v4.0.0) |
 
 ### Mainnet
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -184,7 +184,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v1.0.0-rc1` | 3712500 | Planned upgrade with chain halt    | Patch for mixed precompile addresses.                                                                                                           |
 | `v2.0.2` | 5559500 | Planned upgrade with chain halt    | Bring back parity with mainnet.                                                                                                           |
 | `v3.0.0` | 5695000 | Planned upgrade with chain halt    | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |
-| `v4.0.0` | 6854500 | Planned upgrade with chain halt    | [v4.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v4.0.0) |
+| `v4.0.0` | 6853500 | Planned upgrade with chain halt    | [v4.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v4.0.0) |
 
 ### Mainnet
 


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1627/the-v400-mezod-release-candidate-testnet

### Introduction

Here we add the v4.0.0 upgrade handler that will be executed on testnet and mainnet. Based on https://github.com/mezo-org/mezod/compare/v3.0.1...main, the breaking change that requires action in the upgrade handler is bumping the version of `AssetsBridge` precompile to expose bridge out capabilities.

Tentative plan is to execute this upgrade as follows:
- Testnet: On block 6853500 which is expected on August 28, around 11:00 UTC
- Mainnet: In the week of September 8, block to be determined

### Changes

Did the necessary changes as described in [upgrades.md](https://github.com/mezo-org/mezod/blob/main/docs/upgrades.md#planned-upgrade-with-chain-halt)

### Testing

1. Checkout the v3.0.1 tag currently used on testnet and mainnet.
2. Spin up a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Start at least three nodes using `make localnet-bin-start`.
4. Get PoA owner address using `npx hardhat validatorPool:owner` from `precompile/hardhat`.
5. Schedule an upgrade using `npx hardhat upgrade:submitPlan --signer <poa-owner> --name v4.0.0 --height <H+20>  --info ''` where `H` is the current block of your localnet.
6. Wait until the upgrade block. Nodes should stop consensus and ask for an upgrade.
7. Switch to this PR's branch (`v4-upgrade-handler`) and stop all your nodes. 
8. Run `make build`.
9. Restart your nodes.
10. They should print "running v4.0.0 upgrade handler" and start producing blocks after a short while.
11. Ensure the features enabled in the upgrade handler work (new bridge out methods of the `AssetsBridge` precompile)

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
