### PR TITLE
Bump testnet nodes to v4.0.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.2
+    version: 5.0.0-rc0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.2
+    version: 5.0.0-rc0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.2
+    version: 5.0.0-rc0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.2
+    version: 5.0.0-rc0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 3.0.2
+    version: 5.0.0-rc0
     labels:
       type: validator
     values:

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.1-rc3
+tag: v4.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.1-rc3
+tag: v4.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.1-rc3
+tag: v4.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.1-rc3
+tag: v4.0.0-rc0
 
 env:
   NETWORK: testnet

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,5 +1,5 @@
 image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v3.0.1-rc3
+tag: v4.0.0-rc0
 
 env:
   NETWORK: testnet


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1627/the-v400-mezod-release-candidate-testnet

### Introduction

Here we bump our testnet nodes to v4.0.0-rc0

### Testing

Apply using `helmfile apply -l type=validator --context 1 --concurrency 1` at the v4.0.0 testnet halt block.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
