### PR TITLE
Fix Dockerfile after tBTC bindings addition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --parents ./**/.keep ./
 COPY --parents ./**/*.json ./
 COPY --parents ./**/*.go ./
 COPY --parents ethereum/bindings/portal/*/gen/_address/MezoBridge ./
+COPY --parents ethereum/bindings/tbtc/*/gen/_address/Bridge ./
 
 RUN make bindings
 RUN make build


### PR DESCRIPTION
### Introduction

We added tBTC bindings but forgot to copy the Bridge address in the Dockerfile which causes failure during image build. Here we fix that.

### Testing

Confirmed with `make build-docker-linux` locally.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
