### PR TITLE
Set mainnet block for the v4.0.0 upgrade

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -193,3 +193,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v1.0.0` | 1       | N/A                                  | Initial genesis version.                                                      |
 | `v2.0.0` | 706500  | Planned upgrade with chain halt      | [v2.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v2.0.0) |
 | `v3.0.0` | 1735000 | Planned upgrade with chain halt      | [v3.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v3.0.0) |
+| `v4.0.0` | 3194000 | Planned upgrade with chain halt      | [v4.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v4.0.0) |


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1638/the-v400-mezod-release-mainnet

### Introduction

Here we add the v4.0.0 upgrade block to the documentation.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
