### PR TITLE
Monitor balance of bridge worker and reimbursement pool

### DIFF
--- a/infrastructure/kubernetes/common/monitoring/balance-exporter/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/balance-exporter/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
         runAsNonRoot: true
       containers:
-        - name: balance-exporter
+        - name: balance-exporter-mezo
           # TODO: Use the mezo/balance-exporter image once it is published
           image: nkuba/balance-exporter
           ports:
@@ -31,7 +31,7 @@ spec:
             - name: PORT
               value: "9115"
             - name: ADDRESSES_FILE
-              value: /etc/balance-exporter/addresses.txt
+              value: /etc/balance-exporter/addresses-mezo.txt
             - name: PREFIX
               value: mezo_
             - name: CHAIN_RPC_URL
@@ -39,6 +39,25 @@ spec:
                 secretKeyRef:
                   name: rpc-url
                   key: MEZO
+        - name: balance-exporter-ethereum
+          image: nkuba/balance-exporter
+          ports:
+            - containerPort: 9116
+          volumeMounts:
+            - name: balance-exporter-config
+              mountPath: /etc/balance-exporter
+          env:
+            - name: PORT
+              value: "9116"
+            - name: ADDRESSES_FILE
+              value: /etc/balance-exporter/addresses-ethereum.txt
+            - name: PREFIX
+              value: ethereum_
+            - name: CHAIN_RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: rpc-url
+                  key: ETHEREUM          
 
       volumes:
         - name: balance-exporter-config

--- a/infrastructure/kubernetes/common/monitoring/balance-exporter/service.yaml
+++ b/infrastructure/kubernetes/common/monitoring/balance-exporter/service.yaml
@@ -7,6 +7,10 @@ spec:
   selector:
     app: balance-exporter
   ports:
-    - port: 9115
+    - name: mezo
+      port: 9115
       targetPort: 9115
+    - name: ethereum
+      port: 9116
+      targetPort: 9116
   type: ClusterIP

--- a/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
@@ -4,5 +4,8 @@ metadata:
   name: balance-exporter-config
   namespace: monitoring
 data:
-  addresses.txt: |
+  addresses-mezo.txt: |
     passport-mezo-relayer:0xf35c1a20303ddcA464Ebf5b3b023588Cf3181c8a
+  addresses-ethereum.txt: |
+    bridge-reimbursement-pool:0x700C8840aCDd035cFE35847bFD928C576f9C92A7
+    bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/accounts.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/accounts.json
@@ -72,7 +72,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -89,8 +90,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 26,
-        "w": 10,
+        "h": 10,
+        "w": 24,
         "x": 0,
         "y": 0
       },
@@ -110,7 +111,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -130,6 +131,117 @@
       ],
       "title": "Account Balances on Mezo",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "unit": "ETH"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ethereum_account_balance",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Account Balances on Ethereum",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -139,12 +251,12 @@
     "list": []
   },
   "time": {
-    "from": "now-5d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Accounts",
   "uid": "1677fdcb-9c1c-499e-ae90-28f0654a74f7",
-  "version": 5
+  "version": 10
 }

--- a/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
@@ -34,4 +34,4 @@ data:
       - job_name: 'balance-exporter'
         metrics_path: /metrics
         static_configs:
-          - targets: ['balance-exporter:9115']
+          - targets: ['balance-exporter:9115', 'balance-exporter:9116']

--- a/infrastructure/kubernetes/mezo-staging/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/balance-exporter/configmap.yaml
@@ -4,5 +4,8 @@ metadata:
   name: balance-exporter-config
   namespace: monitoring
 data:
-  addresses.txt: |
+  addresses-mezo.txt: |
     testertesting:0x6e80164ea60673D64d5d6228beb684a1274Bb017
+  addresses-ethereum.txt: |
+    bridge-reimbursement-pool:0xF6A9d3B42615ACcc70A4e60b389c851C8FB1524d
+    bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/accounts.json
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/accounts.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -89,8 +89,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 26,
-        "w": 10,
+        "h": 10,
+        "w": 24,
         "x": 0,
         "y": 0
       },
@@ -110,7 +110,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -130,6 +130,116 @@
       ],
       "title": "Account Balances on Mezo",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "unit": "ETH"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ethereum_account_balance",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Account Balances on Ethereum",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -139,12 +249,12 @@
     "list": []
   },
   "time": {
-    "from": "now-5d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Accounts",
   "uid": "1677fdcb-9c1c-499e-ae90-28f0654a74f7",
-  "version": 5
+  "version": 8
 }

--- a/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
@@ -34,5 +34,5 @@ data:
       - job_name: 'balance-exporter'
         metrics_path: /metrics
         static_configs:
-          - targets: ['balance-exporter:9115']
+          - targets: ['balance-exporter:9115', 'balance-exporter:9116']
 


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1203/integrate-the-native-bridge-with-the-monitoring-system

### Introduction

Here we add monitoring of ETH balance for the Bridge Worker and `ReimbursementPool` accounts.

### Testing

Deployed on:
- https://monitoring.test.mezo.org/grafana/goto/x7wYxkCHg?orgId=1
- https://monitoring.mezo.org/grafana/goto/ajdEbkjNR?orgId=1

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
