### PR TITLE
Configurable addresses cap in the filter query for logs calls

### DIFF
--- a/rpc/backend/node_info.go
+++ b/rpc/backend/node_info.go
@@ -347,3 +347,9 @@ func (b *Backend) RPCMinGasPrice() int64 {
 
 	return amt
 }
+
+// RPCLogsFilterAddrCap returns the maximum number of contract addresses in the filter query for
+// logs calls (`eth_getLogs` and `eth_subscribe` with `logs` parameter).
+func (b *Backend) RPCLogsFilterAddrCap() int32 {
+	return b.cfg.JSONRPC.LogsFilterAddrCap
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -114,6 +114,10 @@ const (
 	// DefaultConnectOraclePriceTTL is the maximum age of the latest price
 	// response before it is considered stale.
 	DefaultConnectOraclePriceTTL = 10 * time.Second
+
+	// DefaultLogsFilterAddrCap is the default maximum number of contract addresses in the
+	// filter query for logs calls (`eth_getLogs` and `eth_subscribe` with `logs` parameter).
+	DefaultLogsFilterAddrCap = 30
 )
 
 var evmTracers = []string{"json", "markdown", "struct", "access_list"}
@@ -179,6 +183,9 @@ type JSONRPCConfig struct {
 	MetricsAddress string `mapstructure:"metrics-address"`
 	// FixRevertGasRefundHeight defines the upgrade height for fix of revert gas refund logic when transaction reverted
 	FixRevertGasRefundHeight int64 `mapstructure:"fix-revert-gas-refund-height"`
+	// LogsFilterAddrCap returns the maximum number of contract addresses in the filter query for
+	// logs calls (`eth_getLogs` and `eth_subscribe` with `logs` parameter).
+	LogsFilterAddrCap int32 `mapstructure:"logs-filter-addr-cap"`
 }
 
 // TLSConfig defines the certificate and matching private key for the server.
@@ -305,6 +312,7 @@ func DefaultJSONRPCConfig() *JSONRPCConfig {
 		EnableIndexer:            false,
 		MetricsAddress:           DefaultJSONRPCMetricsAddress,
 		FixRevertGasRefundHeight: DefaultFixRevertGasRefundHeight,
+		LogsFilterAddrCap:        DefaultLogsFilterAddrCap,
 	}
 }
 
@@ -344,6 +352,10 @@ func (c JSONRPCConfig) Validate() error {
 
 	if c.HTTPIdleTimeout < 0 {
 		return errors.New("JSON-RPC HTTP idle timeout duration cannot be negative")
+	}
+
+	if c.LogsFilterAddrCap < 0 {
+		return errors.New("JSON-RPC logs filter address cap cannot be negative")
 	}
 
 	// check for duplicates
@@ -451,6 +463,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			MetricsAddress:           v.GetString("json-rpc.metrics-address"),
 			FixRevertGasRefundHeight: v.GetInt64("json-rpc.fix-revert-gas-refund-height"),
 			AllowUnprotectedTxs:      v.GetBool("json-rpc.allow-unprotected-txs"),
+			LogsFilterAddrCap:        v.GetInt32("json-rpc.logs-filter-addr-cap"),
 		},
 		TLS: TLSConfig{
 			CertificatePath: v.GetString("tls.certificate-path"),

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -95,6 +95,10 @@ metrics-address = "{{ .JSONRPC.MetricsAddress }}"
 # Upgrade height for fix of revert gas refund logic when transaction reverted.
 fix-revert-gas-refund-height = {{ .JSONRPC.FixRevertGasRefundHeight }}
 
+# LogsFilterAddrCap defines the maximum number of contract addresses in the filter query for
+# logs calls ('eth_getLogs' and 'eth_subscribe' with 'logs' parameter). Value 0 means no cap.
+logs-filter-addr-cap = {{ .JSONRPC.LogsFilterAddrCap }}
+
 ###############################################################################
 ###                             TLS Configuration                           ###
 ###############################################################################

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -71,6 +71,7 @@ const (
 	JSONRPCEnableMetrics            = "metrics"
 	JSONRPCMetricsAddress           = "json-rpc.metrics-address"
 	JSONRPCFixRevertGasRefundHeight = "json-rpc.fix-revert-gas-refund-height"
+	JSONRPCLogsFilterAddrCap        = "json-rpc.logs-filter-addr-cap"
 )
 
 // EVM flags

--- a/server/start.go
+++ b/server/start.go
@@ -215,6 +215,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Bool(srvflags.JSONRPCEnableIndexer, false, "Enable the custom tx indexer for json-rpc")
 	cmd.Flags().Bool(srvflags.JSONRPCEnableMetrics, false, "Define if EVM rpc metrics server should be enabled")
 	cmd.Flags().String(srvflags.JSONRPCMetricsAddress, config.DefaultJSONRPCMetricsAddress, "the JSON-RPC metrics server address to listen on")
+	cmd.Flags().Int32(srvflags.JSONRPCLogsFilterAddrCap, config.DefaultLogsFilterAddrCap, "Sets the maximum number of contract addresses in the filter query for logs calls. Value 0 means no cap")
 
 	cmd.Flags().String(srvflags.EVMTracer, config.DefaultEVMTracer, "the EVM tracer type to collect execution traces from the EVM transaction execution (json|struct|access_list|markdown)") //nolint:lll
 	cmd.Flags().Uint64(srvflags.EVMMaxTxGasWanted, config.DefaultMaxTxGasWanted, "the gas wanted for each eth tx returned in ante handler in check tx mode")                                 //nolint:lll


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1666/goldsky-subgraphs-indexing-problem

### Introduction

So far, we used a global limit of 10 addresses that could be used in the filter query while calling `eth_getLogs` and `eth_subscribe` with `logs` parameter.  However, this turned out to be very problematic for Goldsky indexers that query logs from multiple contracts at once. To workaround this problem, we are making this limit configurable through the `json-rpc.logs-filter-addr-cap` config parameter (`app.toml`) and flag. We are also raising the default limit to 30.

### Testing

Easiest way is use a fresh localnet, set the limit to a low value, and invoke `eth_getLogs` (using `curl`) and/or `eth_subscribe` to `logs` (using `wscat`) to ensure the configured limit value is respected.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
