### PR TITLE
Monitor bridge validator balances on Ethereum

### DIFF
--- a/infrastructure/kubernetes/common/monitoring/metrics-scraper/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/metrics-scraper/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: metrics-scraper
-          image: mezo/metrics-scraper:latest
+          image: mezo/metrics-scraper@sha256:93ce8b41f4bc520324f9415e297fba96c08a6fadfbc5f5c6d022c2fd4d425bea
           imagePullPolicy: Always
           args:
             - --chain-id=$(CHAIN_ID)

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/bridge.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/bridge.json
@@ -116,7 +116,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -214,13 +214,125 @@
           "expr": "pending_assets_unlocked{chain_id=\"mezo_31612-1\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Pending bridge-outs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "decimals": 6,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "unit": "ETH"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ethereum_bridge_val_balance{chain_id=\"mezo_31612-1\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{address}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge validators",
       "type": "timeseries"
     }
   ],
@@ -238,5 +350,5 @@
   "timezone": "browser",
   "title": "Bridge",
   "uid": "8a94397b-b8d8-43cd-8f03-08e0dee842ab",
-  "version": 3
+  "version": 5
 }

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/bridge.json
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/bridge.json
@@ -115,7 +115,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -208,13 +208,124 @@
           "expr": "pending_assets_unlocked{chain_id=\"mezo_31611-1\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Pending bridge-outs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "decimals": 6,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "unit": "ETH"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "ethereum_bridge_val_balance{chain_id=\"mezo_31611-1\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{address}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge validators",
       "type": "timeseries"
     }
   ],
@@ -232,5 +343,5 @@
   "timezone": "browser",
   "title": "Bridge",
   "uid": "8a94397b-b8d8-43cd-8f03-08e0dee842ab",
-  "version": 3
+  "version": 6
 }

--- a/metrics-scraper/bridge_monitoring.go
+++ b/metrics-scraper/bridge_monitoring.go
@@ -244,6 +244,7 @@ func pendingAssetsLocked(
 ) (err error) {
 	defer func() {
 		if err != nil {
+			log.Printf("error while determining pending AssetsLocked: [%v]", err)
 			// set gauge to -1 to indicate error
 			pendingAssetsLockedGauge.WithLabelValues(mezoChainID).Set(-1)
 		}
@@ -285,6 +286,7 @@ func pendingAssetsUnlocked(
 ) (err error) {
 	defer func() {
 		if err != nil {
+			log.Printf("error while determining pending AssetsUnlocked: [%v]", err)
 			// set gauge to -1 to indicate error
 			pendingAssetsUnlockedGauge.WithLabelValues(mezoChainID).Set(-1)
 		}
@@ -292,10 +294,11 @@ func pendingAssetsUnlocked(
 
 	requestedUnlockSeqnos, err := mezo.requestedUnlockSeqnos(ctx)
 	if err != nil {
-		return fmt.Errorf(
+		err = fmt.Errorf(
 			"failed to get requested unlock sequence numbers from Mezo: [%w]",
 			err,
 		)
+		return
 	}
 
 	// Populate the cache with all requested unlock seqnos.
@@ -305,10 +308,11 @@ func pendingAssetsUnlocked(
 
 	processedUnlockSeqnos, err := ethereum.processedUnlockSeqnos(ctx)
 	if err != nil {
-		return fmt.Errorf(
+		err = fmt.Errorf(
 			"failed to get processed unlock sequence numbers from Ethereum: [%w]",
 			err,
 		)
+		return
 	}
 
 	// Remove processed unlock seqnos from the cache.
@@ -340,7 +344,7 @@ func pendingAssetsUnlocked(
 
 	pendingAssetsUnlockedGauge.WithLabelValues(mezoChainID).Set(float64(pending))
 
-	return nil
+	return
 }
 
 func (mc *mezoChain) requestedUnlockSeqnos(ctx context.Context) ([]*big.Int, error) {

--- a/metrics-scraper/bridge_monitoring.go
+++ b/metrics-scraper/bridge_monitoring.go
@@ -519,6 +519,7 @@ func ethereumBridgeValsBalance(
 	ethereumBridgeValBalanceGauge.Reset()
 
 	for i := uint64(0); i < validatorsCount.Uint64(); i++ {
+		//nolint:gosec
 		validator, err := ethereum.mezoBridge.BridgeValidators(big.NewInt(int64(i)))
 		if err != nil {
 			return fmt.Errorf(

--- a/metrics-scraper/prometheus.go
+++ b/metrics-scraper/prometheus.go
@@ -74,6 +74,14 @@ var (
 		},
 		[]string{"chain_id"},
 	)
+
+	ethereumBridgeValBalanceGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ethereum_bridge_val_balance",
+			Help: "the Ethereum balance of the bridge validator",
+		},
+		[]string{"address", "chain_id"},
+	)
 )
 
 func startPrometheus(port uint) {


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1203/integrate-the-native-bridge-with-the-monitoring-system

### Introduction

Here we expose the `ethereum_bridge_val_balance` metric that shows the current balance of all bridge validators registered in the `MezoBridge` contract on Ethereum. This metric automatically detects validator set changes.

### Testing

Already deployed on `mezo-staging` and `mezo-production` Kube clusters. I updated the following dashboards on both environments respectively:
- https://monitoring.mezo.org/grafana/goto/ViwrG5jNg?orgId=1
- https://monitoring.test.mezo.org/grafana/goto/r82rGcjHR?orgId=1

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
