### PR TITLE
Add PCV debt = 0 alert and dashboard to production

### DIFF
--- a/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
@@ -9,3 +9,5 @@ data:
   addresses-ethereum.txt: |
     bridge-reimbursement-pool:0x700C8840aCDd035cFE35847bFD928C576f9C92A7
     bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8
+  contracts.txt: |
+    PCV|0x391EcC7ffEFc48cff41D0F2Bb36e38b82180B993|[{"inputs":[],"name":"debtToPay","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]|debtToPay

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/pcv-rebalancing.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/pcv-rebalancing.json
@@ -1,0 +1,220 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "mezo_contract_function_result{contract=\"PCV\",function=\"debtToPay\"} / 1000000000000000000",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "PCV Debt to Pay",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PCV Debt to Pay",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "mezo_contract_function_result{contract=\"PCV\",function=\"debtToPay\"} / 1000000000000000000",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Current Debt",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current PCV Debt",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "PCV",
+    "Rebalancing",
+    "Monitoring"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PCV Rebalancing Dashboard",
+  "uid": "pcv-rebalancing-dashboard",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
@@ -9,6 +9,9 @@ data:
       scrape_interval: 2s
       evaluation_interval: 2s
 
+    rule_files:
+      - "alert_rules.yml"
+
     scrape_configs:
       - job_name: 'metrics-scraper'
         static_configs:
@@ -35,3 +38,17 @@ data:
         metrics_path: /metrics
         static_configs:
           - targets: ['balance-exporter:9115', 'balance-exporter:9116']
+
+  alert_rules.yml: |
+    groups:
+      - name: musd_alerts
+        rules:
+          - alert: PCVDebtToPayZero
+            expr: mezo_contract_function_result{contract="PCV",function="debtToPay"} == 0
+            for: 1m
+            labels:
+              severity: warning
+              contract: PCV
+            annotations:
+              summary: "PCV contract debt to pay is zero"
+              description: "The PCV contract debtToPay function returned 0."


### PR DESCRIPTION
<!-- 
Pin the issue this PR 'References' to. 

You can use both GitHub and Linear issues. If an issue exists in both 
systems, always prefer the GitHub issue as it lives closer to the pull request.

For GitHub, use the issue number (e.g. #100) or the full issue URL 
(e.g. https://github.com/<organization>/<repository>/issues/100).

For Linear, use the issue ID (e.g. ENG-100) or the full issue URL
(e.g. https://linear.app/<workspace>/issue/ENG-123/<title>).

Use 'Closes' instead of 'References' if this PR should close the issue when 
merged.
-->
References: [CRED-1622](https://linear.app/thesis-co/issue/CRED-1622/add-alerts-for-pcv-debttopay-==-0)

<!--
Add 'Depends on' if this PR depends on another PR. Remember about setting this 
PR's base branch to the branch of the PR it depends on. Keep this PR as draft
until the PR it depends on is merged.
-->

<!--
If this PR is a work in progress, mark it as a draft. In such a case, 
the minimum is filling out the 'Introduction' section. If possible, placing a 
TODO list with planned changes and current progress in the 'Changes' section
is strongly recommended.
-->

### Introduction

<!-- 
Add a short introduction describing the context and the goal of this PR.
-->
This PR includes the same changes as https://github.com/mezo-org/mezod/pull/566 (monitoring for MUSD's PCV contract debtToPay function to detect when debt becomes zero) but now for production.


### Changes

<!--
Describe specific changes made in this PR. Use level-4 headings to separate
different sections of changes. For example:

#### The new XXX component
(...)

#### Changes in the YYY module
(...)
-->

#### Monitoring Changes
 - Updated production balance-exporter to use rtwatts/contracts-exporter:v2.0 image (backward compatible)
 -  Added PCV contract monitoring via contracts.txt configuration file with PCV contract
 - Added Prometheus alert rule PCVDebtToPayZero that triggers when mezo_contract_function_result{contract="PCV",function="debtToPay"} == 0
 - Added PCV Rebalancing Grafana dashboard with time series chart and current debt stat panel
 - Updated Prometheus configuration to include alert rules file and continue scraping balance-exporter endpoints

### Testing

<!--
Describe how the presented changes can be tested. Execute some basic tests
on your own and provide a short summary of the results in this section.
-->

The previous PR included the changes to staging:
- PCV dashboard showing live contract data in "PCV Rebalancing Dashboard"
- Alert rules showing up at https://monitoring.test.mezo.org/grafana/alerting/list

I did not deploy this to production yet but once the PR is approved we should be able to see the changes there as well.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
