### PR TITLE
Basic Bridge Worker monitoring

### DIFF
--- a/bridge-worker/btc_withdrawal.go
+++ b/bridge-worker/btc_withdrawal.go
@@ -353,6 +353,8 @@ func (bw *BridgeWorker) enqueueBtcWithdrawal(
 		"enqueued BTC withdrawal",
 		"unlock_sequence", event.UnlockSequenceNumber.String(),
 	)
+
+	pendingBTCWithdrawalsGauge.Inc()
 }
 
 // dequeueBtcWithdrawal removes an AssetsUnlockConfirmed event representing
@@ -371,6 +373,8 @@ func (bw *BridgeWorker) dequeueBtcWithdrawal() *portal.MezoBridgeAssetsUnlockCon
 		"dequeued BTC withdrawal",
 		"unlock_sequence", event.UnlockSequenceNumber.String(),
 	)
+
+	pendingBTCWithdrawalsGauge.Dec()
 
 	return &event
 }

--- a/bridge-worker/config.go
+++ b/bridge-worker/config.go
@@ -36,6 +36,8 @@ type ConfigProperties struct {
 	MezoAssetsUnlockEndpoint string
 
 	JobBTCWithdrawalQueueCheckFrequency time.Duration
+
+	PrometheusPort uint
 }
 
 type Config struct {

--- a/bridge-worker/prometheus.go
+++ b/bridge-worker/prometheus.go
@@ -1,0 +1,29 @@
+package bridgeworker
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var pendingBTCWithdrawalsGauge = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "pending_btc_withdrawals",
+		Help: "the number of pending BTC withdrawals",
+	},
+)
+
+func startPrometheus(port uint) {
+	log.Printf("starting prometheus")
+
+	http.Handle("/metrics", promhttp.Handler())
+
+	err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil) //nolint:gosec
+	if err != nil {
+		log.Fatalf("couldn't start prometheus http server: [%v]", err)
+	}
+}

--- a/bridge-worker/start.go
+++ b/bridge-worker/start.go
@@ -47,6 +47,8 @@ func Start(properties ConfigProperties) error {
 		"account_address", accountAddress,
 	)
 
+	go startPrometheus(properties.PrometheusPort)
+
 	return RunBridgeWorker(
 		logger,
 		*cfg,

--- a/cmd/bridge-worker/flags.go
+++ b/cmd/bridge-worker/flags.go
@@ -22,6 +22,8 @@ const (
 	flagMezoAssetsUnlockEndpoint = "mezo.assets-unlock-endpoint"
 
 	flagJobBTCWithdrawalQueueCheckFrequency = "job.btc-withdrawal.queue-check-frequency"
+
+	flagPrometheusPort = "prometheus-port"
 )
 
 // Flags default values
@@ -33,6 +35,8 @@ const (
 	flagEthereumRequestsPerMinuteDefault = bridgeworker.DefaultEthereumRequestsPerMinute
 
 	flagJobBTCWithdrawalQueueCheckFrequencyDefault = bridgeworker.DefaultBTCWithdrawalQueueCheckFrequency
+
+	flagPrometheusPortDefault = 2112
 )
 
 func newFlagSet() *flag.FlagSet {
@@ -102,6 +106,12 @@ func newFlagSet() *flag.FlagSet {
 		flagJobBTCWithdrawalQueueCheckFrequency,
 		flagJobBTCWithdrawalQueueCheckFrequencyDefault,
 		"Frequency of the queue check made by the BTC withdrawal job",
+	)
+
+	fs.Uint(
+		flagPrometheusPort,
+		flagPrometheusPortDefault,
+		"Port to expose Prometheus metrics on",
 	)
 
 	return fs

--- a/cmd/bridge-worker/main.go
+++ b/cmd/bridge-worker/main.go
@@ -129,6 +129,14 @@ func parseFlags(cmd *cobra.Command) (bridgeworker.ConfigProperties, error) {
 		return bridgeworker.ConfigProperties{}, fmt.Errorf("BTC withdrawal job queue check frequency must be greater than 0")
 	}
 
+	prometheusPort, err := cmd.Flags().GetUint(flagPrometheusPort)
+	if err != nil {
+		return bridgeworker.ConfigProperties{}, fmt.Errorf("failed to get prometheus port: [%w]", err)
+	}
+	if prometheusPort == 0 {
+		return bridgeworker.ConfigProperties{}, fmt.Errorf("prometheus port must be greater than 0")
+	}
+
 	return bridgeworker.ConfigProperties{
 		LogLevel:                            logLevel,
 		LogFormatJSON:                       logFormatJSON,
@@ -142,6 +150,7 @@ func parseFlags(cmd *cobra.Command) (bridgeworker.ConfigProperties, error) {
 		BitcoinElectrumURL:                  bitcoinElectrumURL,
 		MezoAssetsUnlockEndpoint:            mezoAssetsUnlockEndpoint,
 		JobBTCWithdrawalQueueCheckFrequency: jobBTCWithdrawalQueueCheckFrequency,
+		PrometheusPort:                      prometheusPort,
 	}, nil
 }
 

--- a/infrastructure/kubernetes/common/bridge-worker/deployment.yaml
+++ b/infrastructure/kubernetes/common/bridge-worker/deployment.yaml
@@ -55,6 +55,8 @@ spec:
                 secretKeyRef:
                   name: bridge-worker-config
                   key: mezo-assets-unlock-endpoint
+          ports:
+            - containerPort: 2112        
           resources:
             limits:
               cpu: 500m

--- a/infrastructure/kubernetes/common/bridge-worker/deployment.yaml
+++ b/infrastructure/kubernetes/common/bridge-worker/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: bridge-worker
-          image: mezo/bridge-worker@sha256:5ecdf177a50adc881554acad8db5da44d73a3cfe20317c357e0f3ba7a3c9e338
+          image: mezo/bridge-worker@sha256:1dbec1b54e5c8c5bf439790884aa5549ecaec59db984f51946e0c2368ba62ef9
           imagePullPolicy: Always
           args:
             - --log.format-json

--- a/infrastructure/kubernetes/common/bridge-worker/kustomization.yaml
+++ b/infrastructure/kubernetes/common/bridge-worker/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - deployment.yaml
+  - service.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/infrastructure/kubernetes/common/bridge-worker/service.yaml
+++ b/infrastructure/kubernetes/common/bridge-worker/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bridge-worker
+spec:
+  selector:
+    app: bridge-worker
+  ports:
+    - port: 2112
+      targetPort: 2112
+  type: ClusterIP

--- a/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/bridge.json
+++ b/infrastructure/kubernetes/mezo-production/monitoring/grafana/dashboards/bridge.json
@@ -438,6 +438,182 @@
       ],
       "title": "tBTC redeemer bank balance",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "up{job=\"bridge-worker\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Up",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge worker health",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pending_btc_withdrawals",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge worker pending BTC withdrawals",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -447,12 +623,12 @@
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Bridge",
   "uid": "8a94397b-b8d8-43cd-8f03-08e0dee842ab",
-  "version": 6
+  "version": 7
 }

--- a/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
@@ -13,6 +13,9 @@ data:
       - job_name: 'metrics-scraper'
         static_configs:
           - targets: ['metrics-scraper:2112']
+      - job_name: 'bridge-worker'
+        static_configs:
+          - targets: ['bridge-worker:2112']    
       - job_name: 'api-metrics'
         metrics_path: /api/v2/metrics
         static_configs:

--- a/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/prometheus/configmap.yaml
@@ -15,7 +15,7 @@ data:
           - targets: ['metrics-scraper:2112']
       - job_name: 'bridge-worker'
         static_configs:
-          - targets: ['bridge-worker:2112']    
+          - targets: ['bridge-worker.default.svc.cluster.local:2112']    
       - job_name: 'api-metrics'
         metrics_path: /api/v2/metrics
         static_configs:

--- a/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/bridge.json
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/grafana/dashboards/bridge.json
@@ -430,6 +430,180 @@
       ],
       "title": "tBTC redeemer bank balance",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "up{job=\"bridge-worker\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Up",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge worker health",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pending_btc_withdrawals",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Bridge worker pending BTC withdrawals",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -439,12 +613,12 @@
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Bridge",
   "uid": "8a94397b-b8d8-43cd-8f03-08e0dee842ab",
-  "version": 8
+  "version": 11
 }

--- a/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
@@ -16,6 +16,9 @@ data:
       - job_name: 'metrics-scraper'
         static_configs:
           - targets: ['metrics-scraper:2112']
+      - job_name: 'bridge-worker'
+        static_configs:
+          - targets: ['bridge-worker:2112']    
       - job_name: 'api-metrics'
         metrics_path: /api/v2/metrics
         static_configs:

--- a/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
@@ -18,7 +18,7 @@ data:
           - targets: ['metrics-scraper:2112']
       - job_name: 'bridge-worker'
         static_configs:
-          - targets: ['bridge-worker:2112']    
+          - targets: ['bridge-worker.default.svc.cluster.local:2112']    
       - job_name: 'api-metrics'
         metrics_path: /api/v2/metrics
         static_configs:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1203/integrate-the-native-bridge-with-the-monitoring-system

### Introduction

Here we configure a basic monitoring for the Bridge Worker instance. We do so by exposing metrics from the Bridge Worker and pointing the Prometheus config to scrape them.

### Changes

The Bridge Worker now exposes the `pending_btc_withdrawals` metric that allows to determine the count of pending BTC withdrawals. This metric can be used to detect issues with the BTC withdrawals process - if it doesn't drop in a given period of time, it likely means the Bridge Worker doesn't process new withdrawals.

Moreover, we can now monitor the overall health of the Bridge Worker process and detect if it's down.

### Testing

Already deployed on `mezo-staging` and `mezo-production` clusters. Updated the dashboards:
- https://monitoring.test.mezo.org/grafana/goto/H1UODJjHg?orgId=1
- https://monitoring.mezo.org/grafana/goto/VpGFvJjHg?orgId=1

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
