### PR TITLE
Adding pyth scheduler manifests

### DIFF
--- a/infrastructure/kubernetes/common/pyth-scheduler/README.md
+++ b/infrastructure/kubernetes/common/pyth-scheduler/README.md
@@ -1,0 +1,39 @@
+# Pyth Scheduler (Price Pusher) Deployment
+
+This directory contains Kubernetes deployment manifests for the Pyth Network price pusher service.
+
+## Overview
+
+The Pyth scheduler pushes price updates from the Pyth Network to the configured Mezo network. It monitors price feeds
+and submits updates based on time and price deviation thresholds.
+
+## Configuration
+
+The deployment requires a secret named `pyth-scheduler-config` with the following keys:
+
+- `endpoint`: RPC endpoint for Mezo network (e.g., "wss://rpc-ws.test.mezo.org")
+- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x2880aB155794e7179c9eE2e38200202908C17B43")
+- `price-service-endpoint`: Hermes price service endpoint (e.g., "https://hermes.pyth.network")
+- `mnemonic`: Mnemonic phrase for the wallet used to submit transactions
+
+## Files
+
+- `deployment.yaml`: Main Kubernetes deployment
+- `kustomization.yaml`: Kustomize configuration for resource management
+- `configmap.yaml`: ConfigMap for price feed configuration
+
+## Usage
+
+1. Create the required secret with your configuration
+2. Run:
+
+  ```Shell
+  kubectl create secret generic pyth-scheduler-config \
+    --from-literal=mnemonic="your twelve word mnemonic phrase here" \
+    --from-literal=endpoint="<rpc_endpoint>" \
+    --from-literal=pyth-contract-address="<pyth_contract_address>" \
+    --from-literal=price-service-endpoint="https://hermes.pyth.network" \
+    --namespace=default
+  ```
+
+3. Navigate to mezo-<environment> direcotry and apply the manifests: `kubectl apply -k .`

--- a/infrastructure/kubernetes/common/pyth-scheduler/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pyth-scheduler-price-config
+  labels:
+    app: pyth-scheduler
+data:
+  price-config.yaml: |
+    - alias: SolvBTC/USD
+      id: "0xf253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa"
+      time_difference: 3600
+      price_deviation: 1
+      confidence_ratio: 75

--- a/infrastructure/kubernetes/common/pyth-scheduler/deployment.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyth-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pyth-scheduler
+  template:
+    metadata:
+      labels:
+        app: pyth-scheduler
+    spec:
+      containers:
+        - name: pyth-scheduler
+          image: public.ecr.aws/pyth-network/xc-price-pusher:v10.2.0
+          imagePullPolicy: Always
+          command:
+            - "npm"
+            - "run"
+            - "start"
+            - "--evm"
+            - "--endpoint=$(MEZO_RPC_ENDPOINT)"
+            - "--mnemonic-file=$(MNEMONIC_FILE)"
+            - "--pyth-contract-address=$(PYTH_CONTRACT_ADDRESS)"
+            - "--price-service-endpoint=$(PRICE_SERVICE_ENDPOINT)"
+            - "--price-config-file=/etc/pyth-scheduler/config/price-config.yaml"
+          env:
+            - name: MEZO_RPC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-scheduler-config
+                  key: endpoint
+            - name: MNEMONIC_FILE
+              value: /etc/pyth-scheduler/secrets/mnemonic
+            - name: PYTH_CONTRACT_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-scheduler-config
+                  key: pyth-contract-address
+            - name: PRICE_SERVICE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-scheduler-config
+                  key: price-service-endpoint
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: pyth-scheduler-config
+              mountPath: /etc/pyth-scheduler/secrets
+            - name: price-config
+              mountPath: /etc/pyth-scheduler/config
+      volumes:
+        - name: pyth-scheduler-config
+          secret:
+            secretName: pyth-scheduler-config
+            items:
+              - key: mnemonic
+                path: mnemonic
+        - name: price-config
+          configMap:
+            name: pyth-scheduler-price-config
+            items:
+              - key: price-config.yaml
+                path: price-config.yaml

--- a/infrastructure/kubernetes/common/pyth-scheduler/kustomization.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - configmap.yaml
+
+commonLabels:
+  component: pyth-scheduler
+  app: pyth-scheduler
+
+namespace: default

--- a/infrastructure/kubernetes/mezo-staging/pyth-scheduler/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-staging/pyth-scheduler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common/pyth-scheduler


### PR DESCRIPTION
Added [Pyth scheduler](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/price_pusher) manifests files that run [docker image](https://gallery.ecr.aws/pyth-network/xc-price-pusher) provided by the Pyth team. Pyth scheduler retrieves price feed from [Pyth hermes API](https://docs.pyth.network/price-feeds/how-pyth-works/hermes) and updates [Pyth oracle contract](https://mezo.org/docs/developers/architecture/oracles#pyth) on Mezo network (testnet and mainnet). Price update happens when the price deviates 1% or every 1 hour, whatever comes first.

Added README describing Pyth scheduler setup.

### Testing

Testnet: Pyth contract is not verified. Custom local script is needed to check if the price were updated successfully.

Mainnet: Navigate to https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43?tab=read_proxy and call `getPriceNoOlderThan(0xf253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa, 2000)` for `SolvBTC/USD` price feed. 

TODO:
- [ ] Update `mezo-production`

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests N/A
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
