### PR TITLE
Bridge-worker: batch attestation job

### DIFF
--- a/bridge-worker/batch_attestation.go
+++ b/bridge-worker/batch_attestation.go
@@ -27,7 +27,7 @@ const (
 	batchAttestationSubmissionBackoff = 1 * time.Minute
 )
 
-// batchAttestationFinalityCheck is a struct that contains an AssetsUnlock event
+// batchAttestationFinalityCheck is a struct that contains an AssetsUnlocked event
 // and the Ethereum height at which the batch attestation finality check for it
 // was scheduled.
 type batchAttestationFinalityCheck struct {
@@ -90,7 +90,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 			if err != nil {
 				baj.env.logger.Error(
 					"failed to get unlock sequences for batch attestation",
-					"err", err,
+					"error", err,
 				)
 				continue
 			}
@@ -111,7 +111,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 				if err != nil {
 					batchAttestationLogger.Error(
 						"failed to get batch attestation data",
-						"err", err,
+						"error", err,
 					)
 					continue
 				}
@@ -130,7 +130,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 				if err != nil {
 					batchAttestationLogger.Error(
 						"failed to check if unlock entry is already confirmed",
-						"err", err,
+						"error", err,
 					)
 					continue
 				}
@@ -144,7 +144,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 					if err != nil {
 						batchAttestationLogger.Error(
 							"failed to set batch attestation status",
-							"err", err,
+							"error", err,
 						)
 					}
 
@@ -161,7 +161,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 				if err != nil {
 					batchAttestationLogger.Error(
 						"failed to get attestation threshold",
-						"err", err,
+						"error", err,
 					)
 					continue
 				}
@@ -184,7 +184,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 				if err != nil {
 					batchAttestationLogger.Error(
 						"failed to concatenate signatures",
-						"err", err,
+						"error", err,
 					)
 					continue
 				}
@@ -230,7 +230,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 						batchAttestationSubmissionLogger.Error(
 							"failed to check if unlock is still unconfirmed; "+
 								"retrying",
-							"err", err,
+							"error", err,
 						)
 						continue
 					}
@@ -246,7 +246,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 						if err != nil {
 							batchAttestationSubmissionLogger.Error(
 								"failed to set batch attestation status",
-								"err", err,
+								"error", err,
 							)
 						}
 
@@ -271,7 +271,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 						batchAttestationSubmissionLogger.Error(
 							"batch attestation transaction submission failed; "+
 								"retrying",
-							"err", err,
+							"error", err,
 						)
 						continue
 					}
@@ -281,7 +281,7 @@ func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
 					if err != nil {
 						batchAttestationSubmissionLogger.Error(
 							"failed to set batch attestation status",
-							"err", err,
+							"error", err,
 						)
 					}
 
@@ -381,7 +381,7 @@ func (baj *batchAttestationJob) processBatchAttestationFinalityChecks(ctx contex
 				baj.env.logger.Error(
 					"cannot get finalized block during batch attestation "+
 						"finality checks - skipping current iteration",
-					"err", err,
+					"error", err,
 				)
 				continue
 			}
@@ -457,7 +457,7 @@ func (baj *batchAttestationJob) processBatchAttestationFinalityChecks(ctx contex
 					if err != nil {
 						checkLogger.Error(
 							"failed to set batch attestation status",
-							"err", err,
+							"error", err,
 						)
 					}
 

--- a/bridge-worker/batch_attestation.go
+++ b/bridge-worker/batch_attestation.go
@@ -1,0 +1,321 @@
+package bridgeworker
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/mezo-org/mezod/ethereum/bindings/portal"
+	"github.com/mezo-org/mezod/x/bridge/types"
+)
+
+const (
+	// TODO: Consider making this variable configurable.
+	defaultBatchAttestationSubmissionReadyEventsFetchFrequency = 30 * time.Second
+
+	// batchAttestationSubmissionBackoff is a backoff time used between retries
+	// when submitting a attestBridgeOutWithSignatures transaction.
+	batchAttestationSubmissionBackoff = 1 * time.Minute
+)
+
+type batchAttestationJob struct {
+	env *environment
+
+	server *Server
+
+	submissionReadyEventsFetchFrequency time.Duration
+}
+
+func newBatchAttestationJob(
+	env *environment,
+	server *Server,
+) *batchAttestationJob {
+	return &batchAttestationJob{
+		env:                                 env,
+		server:                              server,
+		submissionReadyEventsFetchFrequency: defaultBatchAttestationSubmissionReadyEventsFetchFrequency,
+	}
+}
+
+func (baj *batchAttestationJob) run(ctx context.Context) {
+	runCtx, cancelRunCtx := context.WithCancel(ctx)
+	defer cancelRunCtx()
+
+	go func() {
+		defer cancelRunCtx()
+		baj.submitBatchAttestations(runCtx)
+		baj.env.logger.Warn("batch attestations submitting routine stopped")
+	}()
+
+	go func() {
+		defer cancelRunCtx()
+		baj.processBatchAttestationFinalityChecks(runCtx)
+		baj.env.logger.Warn("batch attestation finality checks routine stopped")
+	}()
+
+	<-runCtx.Done()
+	baj.env.logger.Info("batch attestation job stopped")
+}
+
+// nolint:unused
+func (baj *batchAttestationJob) submitBatchAttestations(ctx context.Context) {
+	ticker := time.NewTicker(baj.submissionReadyEventsFetchFrequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// TODO: Check if splitting getting unlock sequences and getting
+			//       attestation data (`AssetsUnlock` entry + signatures) is faster
+			//       than getting attestation data with just a single command.
+			readySequences, err := baj.server.getBatchAttestationReadyUnlockSequences()
+			if err != nil {
+				baj.env.logger.Error(
+					"failed to get unlock sequences for batch attestation",
+					"err", err,
+				)
+				continue
+			}
+
+			if len(readySequences) == 0 {
+				baj.env.logger.Info(
+					"no unlock sequences ready for batch attestations",
+				)
+				continue
+			}
+
+			for _, unlockSequence := range readySequences {
+				batchAttestationLogger := baj.env.logger.With(
+					"unlock_sequence", unlockSequence,
+				)
+
+				entry, signatures, err := baj.server.getBatchAttestationData(unlockSequence)
+				if err != nil {
+					batchAttestationLogger.Error(
+						"failed to get batch attestation data",
+						"err", err,
+					)
+					continue
+				}
+
+				assetsUnlockedEvent := portal.MezoBridgeAssetsUnlocked{
+					UnlockSequenceNumber: entry.UnlockSequence.BigInt(),
+					Recipient:            entry.Recipient,
+					Token:                common.HexToAddress(entry.Token),
+					Amount:               entry.Amount.BigInt(),
+					Chain:                uint8(entry.Chain),
+				}
+
+				isConfirmed, err := baj.env.mezoBridgeContract.ConfirmedUnlocks(
+					unlockSequence.BigInt(),
+				)
+				if err != nil {
+					batchAttestationLogger.Error(
+						"failed to check if unlock is already confirmed",
+						"err", err,
+					)
+					continue
+				}
+
+				if isConfirmed {
+					batchAttestationLogger.Info("unlock is already confirmed")
+					// Set status to "processed" in the database. The unlock
+					// has already been confirmed, either through individual
+					// attestations or batch attestation.
+					err := baj.server.setBatchAttestationStatus(unlockSequence, "processed")
+					if err != nil {
+						batchAttestationLogger.Error(
+							"failed to set batch attestation status",
+							"err", err,
+						)
+					}
+
+					// Schedule finality check. If the transaction is reverted,
+					// the unlock entry can still return to a state where it
+					// must be submitted again.
+					baj.queueWithdrawalFinalityCheck(
+						assetsUnlockedEvent.UnlockSequenceNumber,
+						entry,
+					)
+
+					continue
+				}
+
+				batchAttestationLogger.Info("starting batch attestation execution")
+
+				attestationThreshold, err := baj.env.mezoBridgeContract.AttestationThreshold()
+				if err != nil {
+					batchAttestationLogger.Error(
+						"failed to get attestation threshold",
+						"err", err,
+					)
+					continue
+				}
+
+				if uint64(len(signatures)) < attestationThreshold.Uint64() {
+					batchAttestationLogger.Error(
+						"number of signatures below attestation threshold",
+						"number_signatures", len(signatures),
+						"attestation_threshold", attestationThreshold.Uint64(),
+					)
+					continue
+				}
+
+				// The server storing signatures should return the exact number of
+				// signatures needed. Truncate just in case the attestation threshold
+				// changed.
+				signatures = signatures[:attestationThreshold.Uint64()]
+
+				concatenatedSignatures, err := concatenateSignatures(signatures)
+				if err != nil {
+					batchAttestationLogger.Error(
+						"failed to concatenate signatures",
+						"err", err,
+					)
+					continue
+				}
+
+				// Run a retry loop with a few attempts.
+				for i := 0; i < 5; i++ {
+					batchAttestationSubmissionLogger := batchAttestationLogger.With("iteration", i)
+
+					if i > 0 {
+						// use a backoff for subsequent iterations as they are
+						// most likely retries
+						select {
+						case <-time.After(batchAttestationSubmissionBackoff):
+						case <-ctx.Done():
+							batchAttestationSubmissionLogger.Warn(
+								"stopping batch attestation submission backoff " +
+									"wait due to context cancellation",
+							)
+							return
+						}
+					}
+
+					// check if the unlock is still unconfirmed
+					isConfirmed, err := baj.env.mezoBridgeContract.ConfirmedUnlocks(
+						unlockSequence.BigInt(),
+					)
+					if err != nil {
+						batchAttestationSubmissionLogger.Error(
+							"failed to check if unlock is still unconfirmed; "+
+								"retrying",
+							"err", err,
+						)
+						continue
+					}
+					if isConfirmed {
+						batchAttestationSubmissionLogger.Info(
+							"unlock is already confirmed; skipping",
+						)
+
+						// TODO: Set status to "processed" in the database. The unlock
+						//       has already been confirmed, either through individual
+						//       attestations or batch attestation. However, we have
+						//       no guarantee it's finalized so we should schedule it
+						//       for checking.
+						err := baj.server.setBatchAttestationStatus(unlockSequence, "processed")
+						if err != nil {
+							batchAttestationSubmissionLogger.Error(
+								"failed to set batch attestation status",
+								"err", err,
+							)
+						}
+
+						break
+					}
+
+					batchAttestationSubmissionLogger.Info(
+						"submitting batch attestation transaction",
+					)
+
+					tx, err := baj.env.mezoBridgeContract.AttestBridgeOutWithSignatures(
+						assetsUnlockedEvent,
+						concatenatedSignatures,
+					)
+					if err != nil {
+						batchAttestationSubmissionLogger.Error(
+							"batch attestation transaction submission failed; "+
+								"retrying",
+							"err", err,
+						)
+						continue
+					}
+
+					// Consider the attestation as processed.
+					err = baj.server.setBatchAttestationStatus(unlockSequence, "processed")
+					if err != nil {
+						batchAttestationSubmissionLogger.Error(
+							"failed to set batch attestation status",
+							"err", err,
+						)
+					}
+
+					// Schedule finality check. If the transaction is reverted,
+					// the unlock entry can still return to a state where it
+					// must be submitted again.
+					baj.queueWithdrawalFinalityCheck(
+						assetsUnlockedEvent.UnlockSequenceNumber,
+						entry,
+					)
+
+					batchAttestationSubmissionLogger.Info(
+						"submitted attest bridge-out with signatures transaction",
+						"tx_hash", tx.Hash().Hex(),
+					)
+
+					break
+				}
+			}
+		case <-ctx.Done():
+			baj.env.logger.Warn(
+				"stopping batch attestation submission loop due to context " +
+					"cancellation",
+			)
+			return
+		}
+	}
+}
+
+// concatenateSignatures takes signatures stored as hex-strings and returns their
+// byte representations concatenated into a single array of bytes. The input
+// signatures should be prepended with `0x` and be 132-char long.
+func concatenateSignatures(signatures []string) ([]byte, error) {
+	buffer := make([]byte, len(signatures)*65)
+
+	for i, s := range signatures {
+		decoded, err := hexutil.Decode(s)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(decoded) != 65 {
+			return nil, fmt.Errorf(
+				"incorrect length of signature (%d); expected 65 bytes",
+				len(decoded),
+			)
+		}
+		copy(buffer[i*65:(i+1)*65], decoded)
+	}
+
+	return buffer, nil
+}
+
+// nolint:unused
+func (baj *batchAttestationJob) queueWithdrawalFinalityCheck(
+	_ *big.Int,
+	_ *types.AssetsUnlockedEvent,
+) {
+	// TODO: Implement
+}
+
+// nolint:unused
+func (baj *batchAttestationJob) processBatchAttestationFinalityChecks(ctx context.Context) {
+	// TODO: Implement the same way as in BTC withdrawal job.
+	<-ctx.Done()
+}

--- a/bridge-worker/bridge_worker.go
+++ b/bridge-worker/bridge_worker.go
@@ -146,6 +146,11 @@ func RunBridgeWorker(
 			cfg.Mezo.AssetsUnlockEndpoint,
 			cfg.Job.BTCWithdrawal.QueueCheckFrequency,
 		),
+		newBatchAttestationJob(
+			env,
+			// TODO: Make sure that `Server` is properly set up and started.
+			NewServer(logger, cfg.Server.Port, chain.ChainID(), mezoBridgeContract, store, assetsUnlockEndpoint),
+		),
 	}
 
 	for _, job := range jobs {

--- a/bridge-worker/server.go
+++ b/bridge-worker/server.go
@@ -228,22 +228,29 @@ func (s *Server) recoverAddress(entry *bridgetypes.AssetsUnlockedEvent, signatur
 
 func (s *Server) getBatchAttestationReadyUnlockSequences() ([]math.Int, error) {
 	// TODO: Return unlock sequences of all `AssetsUnlock` entries that have
-	//       gathered enough signatures and that have not yet been market as processed.
+	//       gathered enough signatures and that have not yet been marked as processed.
+	//       Check if splitting getting unlock sequences and getting
+	//       attestation data (`AssetsUnlock` entry + signatures) is faster
+	//       than getting attestation data with just a single command. If it's
+	//       so just use a single function.
 	return nil, fmt.Errorf("unimplemented")
 }
 
 func (s *Server) getBatchAttestationData(_ math.Int) (*bridgetypes.AssetsUnlockedEvent, []string, error) {
 	// TODO: Get data (`AssetsUnlock` entry + signatures) for the given unlock
-	//       sequence.
+	//       sequence. Notice that the signatures must be in an order enforced
+	//       by the `attestBridgeOutWithSignatures` function from the `MezoBridge`
+	//       contract: the signer addresses extracted from signatures must be in
+	//       strictly increasing order.
 	return nil, nil, fmt.Errorf("unimplemented")
 }
 
 func (s *Server) setBatchAttestationStatus(_ math.Int, _ string) error {
 	// TODO: Implement setting status for the given `AssetsUnlock` for the given
 	//       unlock sequence. The possible values for the status could be:
-	//       - `gathering_signatures`: for entries still gathering signatures
-	//       - `ready_for_submission`: for entries having enough signatures
-	//       - `processed`: for entries that where attested and having enough confirmations
+	//       - "gathering_signatures": for entries still gathering signatures
+	//       - "ready_for_submission": for entries having enough signatures
+	//       - "processed": for entries that were attested and having enough confirmations
 	return fmt.Errorf("unimplemented")
 }
 

--- a/bridge-worker/server.go
+++ b/bridge-worker/server.go
@@ -226,6 +226,27 @@ func (s *Server) recoverAddress(entry *bridgetypes.AssetsUnlockedEvent, signatur
 	return crypto.PubkeyToAddress(*publicKeyBytes), nil
 }
 
+func (s *Server) getBatchAttestationReadyUnlockSequences() ([]math.Int, error) {
+	// TODO: Return unlock sequences of all `AssetsUnlock` entries that have
+	//       gathered enough signatures and that have not yet been market as processed.
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (s *Server) getBatchAttestationData(_ math.Int) (*bridgetypes.AssetsUnlockedEvent, []string, error) {
+	// TODO: Get data (`AssetsUnlock` entry + signatures) for the given unlock
+	//       sequence.
+	return nil, nil, fmt.Errorf("unimplemented")
+}
+
+func (s *Server) setBatchAttestationStatus(_ math.Int, _ string) error {
+	// TODO: Implement setting status for the given `AssetsUnlock` for the given
+	//       unlock sequence. The possible values for the status could be:
+	//       - `gathering_signatures`: for entries still gathering signatures
+	//       - `ready_for_submission`: for entries having enough signatures
+	//       - `processed`: for entries that where attested and having enough confirmations
+	return fmt.Errorf("unimplemented")
+}
+
 func toPortalAssetsUnlock(entry *bridgetypes.AssetsUnlockedEvent) *portal.MezoBridgeAssetsUnlocked {
 	return &portal.MezoBridgeAssetsUnlocked{
 		UnlockSequenceNumber: entry.UnlockSequence.BigInt(),


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1194/bridge-worker-batch-attestation-job
Depends on: https://github.com/mezo-org/mezod/pull/546

### Introduction

This PR adds a job responsible for handling batch attestation submission.
The job relies on the `Server` holding signature as the source of information.

NOTE that this PR must be followed with a PR that expands the `Server` holding unlock entries / signatures (see TODOs in this PR).

### Changes

- added batch attestation job
- added function stubs to `Server` that has to be implemented

### Testing

Testing will only be possible while we integrate this PR with `Server` holding `AssetsUnlock` entries / signatures.

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
