### PR TITLE
Add v9.0.0 upgrade entries to docs

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -189,6 +189,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v6.0.0`       | 10325250  | Planned upgrade with chain halt      | [v6.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v6.0.0)                                                                                                           |
 | `v7.0.0`       | 11688500  | Planned upgrade with chain halt      | [v7.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v7.0.0)                                                                                                           |
 | `v8.0.0`       | 11854127  | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0)                                                                                                           |
+| `v9.0.0`       | 12193600  | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0)                                                                                                           |
 
 ### Mainnet
 
@@ -202,3 +203,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v6.0.0` | 6773500 | Planned upgrade with chain halt      | [v6.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v6.0.0) |
 | `v7.0.0` | 7691500 | Planned upgrade with chain halt      | [v7.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v7.0.0) |
 | `v8.0.0` | 7739500 | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0) |
+| `v9.0.0` | 8194500 | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0) |


### PR DESCRIPTION
References: [MEZO-4171](https://linear.app/aspect-build/issue/MEZO-4171)

### Introduction

The upgrade documentation does not yet include v9.0.0 entries. This PR adds the v9.0.0 planned upgrade records to both the testnet and mainnet historical upgrade tables.

### Changes

The `docs/upgrades.md` historical upgrades tables now include v9.0.0 as a planned upgrade with chain halt at testnet block 12193600 and mainnet block 8194500, with links to the v9.0.0 release notes.

### Testing

Verified the Markdown table renders correctly and the row format is consistent with existing entries.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment