### PR TITLE
Enable MEZO/USD price feed on Mezo and Ethereum

### DIFF
--- a/infrastructure/kubernetes/common/pyth-scheduler-ethereum/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-ethereum/configmap.yaml
@@ -16,3 +16,8 @@ data:
       time_difference: 14400
       price_deviation: 0.1
       confidence_ratio: 100
+    - alias: MEZO/USD
+      id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
+      time_difference: 600
+      price_deviation: 1
+      confidence_ratio: 75

--- a/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
@@ -66,3 +66,8 @@ data:
       time_difference: 3600
       price_deviation: 1
       confidence_ratio: 75
+    - alias: MEZO/USD
+      id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
+      time_difference: 600
+      price_deviation: 1
+      confidence_ratio: 75


### PR DESCRIPTION
Update MEZO/USD price feed every 600sec (10min) or if the price changes by 1%.

### Testing

Can be tested on [Mezo](https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43?tab=read_proxy) and [Ethereum](https://etherscan.io/address/0x4305FB66699C3B2702D4d05CF36551390A4c69C6#readProxyContract#F6) with the following params:
- MEZO/USD id: 0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df
- age: 600 (this is in sec)

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [-] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [-] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
