### PR TITLE
fix eth_getLogs panic when block hash lookup returns no block

### DIFF
--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -117,6 +117,12 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch header by hash %s: %w", f.criteria.BlockHash, err)
 		}
+		// TendermintBlockByHash returns (nil, nil) when the block is not found; do not
+		// dereference resBlock (fixes panic in eth_getLogs, see mezo-org/mezod#595).
+		if resBlock == nil || resBlock.Block == nil {
+			f.logger.Debug("block not found for filter block hash", "hash", f.criteria.BlockHash.Hex())
+			return nil, nil
+		}
 
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&resBlock.Block.Height)
 		if err != nil {

--- a/rpc/namespaces/ethereum/eth/filters/filters_logs_test.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters_logs_test.go
@@ -1,0 +1,88 @@
+package filters
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/log"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	gethfilters "github.com/ethereum/go-ethereum/eth/filters"
+	"github.com/stretchr/testify/require"
+
+	rpctypes "github.com/mezo-org/mezod/rpc/types"
+	mezodtypes "github.com/mezo-org/mezod/types"
+)
+
+// nilResultBlockByHashBackend simulates TendermintBlockByHash when the node returns
+// no block for the hash without an RPC error (see rpc/backend/blocks.go).
+type nilResultBlockByHashBackend struct{}
+
+func (nilResultBlockByHashBackend) GetBlockByNumber(rpctypes.BlockNumber, bool) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) HeaderByNumber(rpctypes.BlockNumber) (*ethtypes.Header, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) HeaderByHash(common.Hash) (*ethtypes.Header, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) GetPseudoTransactionResult(*coretypes.ResultBlock) *mezodtypes.TxResult {
+	return nil
+}
+
+func (nilResultBlockByHashBackend) TendermintBlockByHash(common.Hash) (*coretypes.ResultBlock, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) TendermintBlockByNumber(rpctypes.BlockNumber) (*coretypes.ResultBlock, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) TendermintBlockResultByNumber(*int64) (*coretypes.ResultBlockResults, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) GetLogs(common.Hash) ([][]*ethtypes.Log, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) GetLogsByHeight(*int64) ([][]*ethtypes.Log, error) {
+	return nil, nil
+}
+
+func (nilResultBlockByHashBackend) BlockBloom(*coretypes.ResultBlockResults) (ethtypes.Bloom, error) {
+	return ethtypes.Bloom{}, nil
+}
+
+func (nilResultBlockByHashBackend) BloomStatus() (uint64, uint64) {
+	return 0, 0
+}
+
+func (nilResultBlockByHashBackend) RPCFilterCap() int32   { return 0 }
+func (nilResultBlockByHashBackend) RPCLogsCap() int32     { return 10000 }
+func (nilResultBlockByHashBackend) RPCBlockRangeCap() int32 { return 10000 }
+func (nilResultBlockByHashBackend) RPCLogsFilterAddrCap() int32 {
+	return 0
+}
+
+func TestFilterLogs_blockHashMissingDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000abc")
+	criteria := gethfilters.FilterCriteria{
+		BlockHash: &hash,
+		FromBlock: big.NewInt(-1),
+		ToBlock:   big.NewInt(-1),
+	}
+
+	f := NewBlockFilter(log.NewNopLogger(), nilResultBlockByHashBackend{}, criteria)
+	logs, err := f.Logs(context.Background(), 10000, 10000)
+	require.NoError(t, err)
+	require.Nil(t, logs)
+}


### PR DESCRIPTION
## what changed
TendermintBlockByHash can return (nil, nil) when the block is not in the local store (see \
pc/backend/blocks.go\). \Filter.Logs\ only checked the error value and then used \
esBlock.Block.Height\, which caused the nil pointer panic reported in #595.

This adds a nil guard and a regression test that reproduces the backend behavior.

## testing
- added \TestFilterLogs_blockHashMissingDoesNotPanic\
- \go\ was not available in this environment to run the test locally; please run \go test ./rpc/namespaces/ethereum/eth/filters/...\ before merge

made by mooncitydev