### PR TITLE
Adding monitoring addresses for Pyth oracle configs

### DIFF
--- a/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   addresses-mezo.txt: |
     passport-mezo-relayer:0xf35c1a20303ddcA464Ebf5b3b023588Cf3181c8a
+    pyth-updater:0x2585618FD0b5656C72918CC7b92207e5B6022DfD
+    safety-buffer-keeper:0x1cBbC5f210031fF947F4a17D87fcFbBe02A7a8f7
   addresses-ethereum.txt: |
     bridge-reimbursement-pool:0x700C8840aCDd035cFE35847bFD928C576f9C92A7
     bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8
+    pyth-updater:0x2585618FD0b5656C72918CC7b92207e5B6022DfD


### PR DESCRIPTION
Adding addresses to monitor Pyth price feed updaters and Safety buffer keeper.

### Testing

Grafana is already configured and sending alerts

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
