### PR TITLE
Fix binding generation

### DIFF
--- a/Dockerfile.bridge-worker
+++ b/Dockerfile.bridge-worker
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3018
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24.0-alpine AS builder
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile.metrics-scraper
+++ b/Dockerfile.metrics-scraper
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3018
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24.0-alpine AS builder
 
 WORKDIR /app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ replace (
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
 	// use mezo-org fork of keep-common
-	github.com/keep-network/keep-common => github.com/mezo-org/keep-common v1.8.0
+	github.com/keep-network/keep-common => github.com/mezo-org/keep-common v1.9.0
 
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -1623,8 +1623,8 @@ github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo h1:1UptFWudKEtlp8yrZ90QrXpK7X4Y
 github.com/mezo-org/cosmos-sdk/store v1.1.1-mezo/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
 github.com/mezo-org/go-ethereum v1.16.9-mezo0 h1:A+/ld8ZlOxIOyT5exQPB+KWdb0OEGW5Mt55Z3pkSsyw=
 github.com/mezo-org/go-ethereum v1.16.9-mezo0/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
-github.com/mezo-org/keep-common v1.8.0 h1:UWTYmXbEuqWqo6j8L2H9tzSnHoJ8/kV4JsrvytL4hTg=
-github.com/mezo-org/keep-common v1.8.0/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
+github.com/mezo-org/keep-common v1.9.0 h1:80c+VjX0JcLfvO9KhbdmQAA17elUh4pwDnXxTh100bU=
+github.com/mezo-org/keep-common v1.9.0/go.mod h1:KIOKBjIN1ep26VKd+T9L2eR/qipQEdB6DU7jmNKh2hA=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miguelmota/go-ethereum-hdwallet v0.1.1 h1:zdXGlHao7idpCBjEGTXThVAtMKs+IxAgivZ75xqkWK0=


### PR DESCRIPTION
Note that this PR should be merged into the `geth-upgrade` feature branch.

### Introduction

Due to the breaking changes that came with `go-ethereum` `1.16.9` we had to update `mezo-org/keep-common` library.

### Changes

- Updated the `mezo-org/keep-common` library to a newly released version `1.9.0`.
- Additionally, updated the version of Go to `1.24.0` in two dockerfiles

### Testing

1) Confirm the binding generation error exists on `geth-upgrade` branch:
```
git checkout geth-upgrade
make bindings
```
2) Verify this PR fixes the problem and the re-generated bindings are not changed:

```
git checkout -- .
git checkout bindings-generation-fix
go mod tidy
make bindings
git diff
```
---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
