### PR TITLE
Multi-call/block eth_simulateV1

### DIFF
--- a/.claude/MEZO-4227-eth-simulate-v1/plan.md
+++ b/.claude/MEZO-4227-eth-simulate-v1/plan.md
@@ -3,7 +3,7 @@
 
 # Implementation plan: `eth_simulateV1` in mezod
 
-**Status.** Phases 1-5 shipped: [#658](https://github.com/mezo-org/mezod/pull/658) (scaffold), [#660](https://github.com/mezo-org/mezod/pull/660) (`MovePrecompileTo`), [#662](https://github.com/mezo-org/mezod/pull/662) (keeper seams + proto + single-call execution). Next up: **Phase 6** (multi-call within one block).
+**Status.** Phases 1-7 shipped: [#658](https://github.com/mezo-org/mezod/pull/658) (scaffold), [#660](https://github.com/mezo-org/mezod/pull/660) (`MovePrecompileTo`), [#662](https://github.com/mezo-org/mezod/pull/662) (keeper seams + proto + single-call execution), [#664](https://github.com/mezo-org/mezod/pull/664) (multi-call + multi-block + simulated `GetHashFn`). Next up: **Phase 8** (DoS guards + kill switch).
 
 ## Context
 
@@ -33,47 +33,52 @@ The port cost measured against `git diff v1.14.8..v1.16.9` on the interfaces sim
 | EIPs (Part 1, v1.14.8) | Skip EIP-4844 / 4788 / 2935 / 7685 (not in chain config); reject explicit overrides for those fields |
 | EIPs (Part 2, post-upgrade) | Add EIP-2935 pre-block hook, EIP-7702 SetCode, EIP-7825 per-tx gas cap, `MaxUsedGas` field. Continue rejecting EIP-4844 / 4788 / 7685 / 6110 / 7002 / 7251 (no beacon chain, no DA layer, no EL↔CL requests) |
 
-## Already shipped (Phases 1-5)
+## Already shipped (Phases 1-7)
 
-The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/keeper/`**. The driver lives in the `keeper` package because it needs unexported access to `applyStateOverrides` and `applyMessageWithConfig`. **There is no `simulate/` sub-package** — driver and helpers live in a single file, `x/evm/keeper/simulate_v1.go`.
+The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/keeper/`**. The driver lives in the `keeper` package because it needs unexported access to `applyStateOverrides` and `applyMessageWithConfig`. **There is no `simulate/` sub-package** — driver and helpers live in a single file, `x/evm/keeper/simulate_v1.go`. All request/response JSON shapes live under `x/evm/types/` — `rpc/types/simulate_v1.go` is gone; there is no duplicate RPC-side shape.
 
 ### File map and symbols
 
 | File | Symbols / role |
 |---|---|
-| `x/evm/types/simulate_v1.go` | Bare types + JSON: `SimOpts`, `SimBlock`, `SimBlockOverrides`, `SimCallResult`, `SimBlockResult`, `(SimBlockResult).MarshalJSON`, `UnmarshalSimOpts` (strict-validates input — rejects `BlockOverrides.BeaconRoot/Withdrawals/BlobBaseFee`), `BuildSimCallResult` |
-| `x/evm/types/state_overrides.go` | `StateOverride`, `OverrideAccount` (incl. `MovePrecompileTo *common.Address`) — keeper-facing override types |
-| `x/evm/types/simulate_v1_errors.go` | `SimError{Code, Message, Data}` implementing geth's `Error()/ErrorCode()/ErrorData()`; `SimErrCode*` constants for every spec-reserved code; `NewSim*` constructors: `NewSimInvalidParams`, `NewSimInvalidBlockNumber`, `NewSimInvalidBlockTimestamp`, `NewSimClientLimitExceeded`, `NewSimMovePrecompileSelfRef`, `NewSimMovePrecompileDupDest`, `NewSimStateAndStateDiff`, `NewSimAccountTainted`, `NewSimDestAlreadyOverridden`, `NewSimMoveMezoCustom`, `NewSimNotAPrecompile`, `NewSimReverted`, `NewSimVMError` |
-| `x/evm/keeper/simulate_v1.go` | All driver + helpers (private): `simulateV1`, `sanitizeSimChain`, `makeSimHeader`, `assembleSimBlock`, `computeSimTxHash` |
+| `x/evm/types/simulate_v1.go` | All JSON shapes and helpers: `SimOpts`, `SimBlock`, `SimBlockOverrides`, `SimCallResult` (+ `MarshalJSON` forcing `Logs: []` over `null`), `SimBlockResult` (+ `MarshalJSON` / `UnmarshalJSON` that flatten block fields alongside `calls`), `UnmarshalSimOpts` (strict-validates input — rejects `BlockOverrides.BeaconRoot/Withdrawals/BlobBaseFee`), `BuildSimCallResult`. Single shape used by both keeper and backend; no RPC-side duplicate |
+| `x/evm/types/state_overrides.go` | `StateOverride`, `OverrideAccount` (incl. `MovePrecompileTo *common.Address`) — unified override types used by both `eth_call` and `eth_simulateV1`; no RPC-side duplicate |
+| `x/evm/types/simulate_v1_errors.go` | `SimError{Code, Message, Data}` implementing geth's `Error()/ErrorCode()/ErrorData()`; `SimErrCode*` constants for every spec-reserved code; `NewSim*` constructors: `NewSimInvalidParams`, `NewSimInvalidBlockNumber`, `NewSimInvalidBlockTimestamp`, `NewSimClientLimitExceeded`, `NewSimBlockGasLimitReached` (-38015), `NewSimMovePrecompileSelfRef`, `NewSimMovePrecompileDupDest`, `NewSimStateAndStateDiff`, `NewSimAccountTainted`, `NewSimDestAlreadyOverridden`, `NewSimMoveMezoCustom`, `NewSimNotAPrecompile`, `NewSimReverted`, `NewSimVMError` |
+| `x/evm/keeper/simulate_v1.go` | All driver + helpers (private): `simulateV1` (top-level entry; one shared `*statedb.StateDB` for the whole request), `processSimBlock` (per-block execution; StateOverrides + BlockContext + per-call loop + envelope assembly), `sanitizeSimChain` (chain ordering + gap fill + `-38020` / `-38021` / `-38026`), `sanitizeSimCall` (per-call defaults: nonce from shared StateDB, gas from `header.GasLimit - cumGasUsed`; `-38015` preflight), `makeSimHeader`, `assembleSimBlock`, `computeSimTxHash`, `newSimGetHashFn` (simulate-aware `BLOCKHASH`: canonical via `k.GetHashFn(ctx)`, simulated siblings via in-memory height map, zero-hash otherwise — canonical range unforgeable by any `BlockOverrides`), `sameForks` (fork-boundary sentinel; compares base vs. last-sim `params.Rules` exhaustively and rejects spans that would cross a fork) |
 | `x/evm/keeper/state_override.go` | `applyStateOverrides(db, overrides, rules) (map[addr]addr, error)` — returns the validated `MovePrecompileTo` move set; mutates `db` in place; uses `vm.DefaultPrecompiles(rules)` to identify stdlib precompiles and `mezoCustomPrecompileAddrs` for the deny-list. Returns `*types.SimError` via `NewSim*` constructors on every spec-coded failure |
-| `x/evm/keeper/state_transition.go` | New seams: `EVMOverrides{BlockContext *vm.BlockContext, Precompiles map[addr]vm.PrecompiledContract, NoBaseFee *bool}`, `NewEVMWithOverrides(ctx, msg, cfg, tracer, stateDB, *EVMOverrides) *vm.EVM`, `precompilesWithMoves`, `activePrecompiles`. `applyMessageWithConfig` takes `*EVMOverrides`. `NewEVM` and the public `ApplyMessageWithConfig` delegate with `nil` — consensus path is byte-identical to main. `SimulateMessage` calls `applyMessageWithConfig` with overrides built from `precompilesWithMoves(...)` when `MovePrecompileTo` entries are present |
-| `x/evm/statedb/statedb.go` | `FinaliseBetweenCalls()` at L769 — clears per-call ephemeral state (logs, refund, transient storage) and resets the precompile-call counter while preserving state objects, access list, and journal across sequential calls in a shared StateDB |
+| `x/evm/keeper/state_transition.go` | Seams: `EVMOverrides{BlockContext *vm.BlockContext, Precompiles map[addr]vm.PrecompiledContract, NoBaseFee *bool}`, `NewEVMWithOverrides(ctx, msg, cfg, tracer, stateDB, *EVMOverrides) *vm.EVM`, `precompilesWithMoves`, `activePrecompiles`. `applyMessageWithConfig` takes `*EVMOverrides`. `NewEVM` and the public `ApplyMessageWithConfig` delegate with `nil` — consensus path is byte-identical to main. The simulate driver calls `applyMessageWithConfig` with overrides carrying `BlockContext` (simulate-aware `GetHashFn`), `Precompiles` (with any `MovePrecompileTo` moves), and `NoBaseFee = &!opts.Validation` |
+| `x/evm/statedb/statedb.go` | `FinaliseBetweenCalls()` — clears per-call ephemeral state (logs, refund, transient storage) and resets the precompile-call counter while preserving state objects, access list, and journal across sequential calls in a shared StateDB. `SetTxConfig(cfg)` — replaces tx-scoped metadata in place so each simulated call stamps distinct `TxHash` / `TxIndex` on its emitted logs |
 | `proto/ethermint/evm/v1/query.proto` (+ `x/evm/types/query.pb.go`) | `rpc SimulateV1(SimulateV1Request) returns (SimulateV1Response)`. `SimulateV1Request{opts bytes, block_number_or_hash bytes, gas_cap uint64, proposer_address ConsAddress, chain_id int64, timeout_ms int64}`. `SimulateV1Response{result bytes, error SimError}`. `SimError{code int32, message string, data string}` |
-| `x/evm/keeper/grpc_query.go` | `Keeper.SimulateV1` handler — validates request, parses chain ID / gas cap, unmarshals `req.Opts`, calls `k.simulateV1(...)`, marshals block results to JSON. Helper `simulateV1ErrResponse(err)` does `errors.As(err, &simErr)` to route typed failures to `response.Error` and genuine internals to `status.Error(codes.Internal, …)` |
-| `rpc/types/simulate_v1.go` | RPC JSON shapes: `SimOpts`, `SimBlock`, `BlockOverrides`, `SimCallResult`, `SimBlockResult` with custom marshal/unmarshal forcing `Logs: []` over `null` (spec-compliant) |
-| `rpc/types/types.go` | `OverrideAccount.MovePrecompileTo *common.Address` (RPC-side spec shape, mirrors the keeper-side `OverrideAccount`) |
-| `rpc/backend/simulate_v1.go` | Real adapter: marshals `SimOpts` to JSON, sets up timeout context (`b.RPCEVMTimeout()`), invokes gRPC, reconstructs `*evmtypes.SimError` from `response.Error` and returns it directly — geth's RPC server emits `{code, message, data}` via the error-interface methods. Unmarshals `response.Result` to `[]*rpctypes.SimBlockResult` on success |
+| `x/evm/keeper/grpc_query.go` | `Keeper.SimulateV1` handler — calls `validateSimulateV1Anchor` (defense-in-depth for direct-gRPC callers that bypass `rpc/backend`), parses chain ID / gas cap, unmarshals `req.Opts`, derives the base header via `baseHeaderFromContext` (falls back to `req.GasCap` when `mezotypes.BlockGasLimit(ctx)` returns 0), calls `k.simulateV1(...)`, marshals block results to JSON. Helper `simulateV1ErrResponse(err)` does `errors.As(err, &simErr)` to route typed failures to `response.Error` and genuine internals to `status.Error(codes.Internal, …)` |
+| `rpc/backend/simulate_v1.go` | Real adapter: marshals `SimOpts` to JSON, resolves caller-supplied `BlockNumberOrHash` to a concrete numeric height via `BlockNumberFromTendermint` + `TendermintBlockByNumber`, emits that concrete height in the request (sentinel `BlockNumber`s do not round-trip through JSON, so resolving here keeps the keeper anchor validator consistent), sets up timeout context (`b.RPCEVMTimeout()`) anchored via `rpctypes.ContextWithHeight(resolvedHeight)`, invokes gRPC. On `response.Error`, returns the `*evmtypes.SimError` directly so geth's RPC server emits `{code, message, data}`. Unmarshals `response.Result` to `[]*evmtypes.SimBlockResult` on success |
 | `rpc/namespaces/ethereum/eth/simulate_v1.go` | `PublicAPI.SimulateV1` — passthrough to the backend |
 | `rpc/namespaces/ethereum/eth/api.go` | `SimulateV1` on the `EthereumAPI` interface |
 | `rpc/backend/backend.go` | `SimulateV1` on the `EVMBackend` interface |
 
 ### Test layout (established convention)
 
-- **Public-handler tests** live in `x/evm/keeper/grpc_query_test.go` and exercise the full stack against a fully-wired `KeeperTestSuite`. Six cases shipped: `TestSimulateV1_EmptyOpts`, `TestSimulateV1_SingleCallHappyPath`, `TestSimulateV1_StateOverrideSentinelBubblesUp`, `TestSimulateV1_MovePrecompileToSha256`, `TestSimulateV1_NilRequest`, `TestSimulateV1_UnsupportedOverrideRejected`. Build opts as raw JSON so tests never touch private driver types.
-- **Helper unit tests** belong in `x/evm/keeper/simulate_v1_test.go` (`package keeper`, white-box for stateless helpers like `sanitizeSimChain` / `makeSimHeader`). Currently a single placeholder pointing at the gRPC tests.
+- **Public-handler tests** live in `x/evm/keeper/grpc_query_test.go` and exercise the full stack against a fully-wired `KeeperTestSuite`. Shipped cases: the Phase 1-5 set (`TestSimulateV1_EmptyOpts`, `TestSimulateV1_SingleCallHappyPath`, `TestSimulateV1_StateOverrideSentinelBubblesUp`, `TestSimulateV1_MovePrecompileToSha256`, `TestSimulateV1_NilRequest`, `TestSimulateV1_UnsupportedOverrideRejected`) plus the Phase 6-7 set (`TestSimulateV1_MultiCall_StateChainsAcrossCalls`, `TestSimulateV1_MultiCall_RevertDoesNotLeak`, `TestSimulateV1_MultiCall_BlockGasLimit`, `TestSimulateV1_MultiCall_NonceAutoIncrement`, `TestSimulateV1_MultiBlock_StateChains`, `TestSimulateV1_MultiBlock_ChainLinkage`, `TestSimulateV1_MultiBlock_PrecompileStateChains`). Build opts as raw JSON so tests never touch private driver types.
+- **Helper unit tests** in `x/evm/keeper/simulate_v1_test.go` (`package keeper`, white-box) cover every stateless helper: `sanitizeSimChain` (gap fill, monotonic number/timestamp, span bound, `*SimError` surface), `makeSimHeader` (defaults from parent, post-merge difficulty, base-fee override, validation-derived base fee, field overrides), `sanitizeSimCall` (default vs. explicit nonce, default Gas, `-38015` preflight, zero-gas-limit behavior), `newSimGetHashFn` (hit-base, below-base canonical, above-base sibling, not-found, canonical-unforgeability).
 - **Override unit tests** in `x/evm/keeper/state_override_test.go` cover `MovePrecompileTo` validation and the mezo-custom deny-list.
 - **State-transition unit tests** in `x/evm/keeper/state_transition_test.go` cover `NewEVMWithOverrides` byte-equivalence with `NewEVM` and override behavior.
-- **StateDB tests** in `x/evm/statedb/statedb_test.go` cover `FinaliseBetweenCalls`.
-- **Backend tests** in `rpc/backend/simulate_v1_test.go` use a mocked query client to assert proto request shape + timeout context.
-- **System tests** under `tests/system/test/SimulateV1_*.test.ts` are TypeScript Hardhat suites run via `./tests/system/system-tests.sh`.
+- **StateDB tests** in `x/evm/statedb/statedb_test.go` cover `FinaliseBetweenCalls` and `SetTxConfig`.
+- **Backend tests** in `rpc/backend/simulate_v1_test.go` use a mocked query client to assert proto request shape (including the resolved numeric height in `BlockNumberOrHash`) + timeout context.
+- **Types unit tests** in `x/evm/types/simulate_v1_test.go` cover JSON round-trip for every shape — `SimOpts`, `SimBlockResult`, `SimCallResult` — and the explicit rejections baked into `UnmarshalSimOpts`.
+- **System tests** under `tests/system/test/SimulateV1_*.test.ts` are TypeScript Hardhat suites run via `./tests/system/system-tests.sh`. Current files: `SimulateV1_SingleCall`, `SimulateV1_MultiCall`, `SimulateV1_MultiBlock`, `SimulateV1_MovePrecompile_ethCall`, `SimulateV1_RejectedOverrides`. Phase 12 collapses these into conformance + divergence suites.
 
 ### What works end-to-end today
 
-- `provider.send("eth_simulateV1", [opts, "latest"])` runs through with one block, one call.
-- State overrides honored (balance, nonce, code, state, stateDiff).
+- Multi-call, multi-block `eth_simulateV1` round-trips end-to-end over JSON-RPC, with a single `*statedb.StateDB` threaded through every call of every block. Ephemeral writes, `commit=false`.
+- State mutations propagate across calls within a block and across blocks within a request — for both the EVM journal (accounts, storage) and mezo's StateDB-scoped cached-ctx layer (custom precompile Cosmos-side writes). Covered by the `TestSimulateV1_MultiBlock_PrecompileStateChains` keeper test and the `SimulateV1_MultiCall` / `SimulateV1_MultiBlock` system tests' `btctoken` cases.
+- State overrides honored per-block (balance, nonce, code, state, stateDiff).
 - `MovePrecompileTo` works for stdlib precompiles (0x01-0x0A); blocks all 8 mezo custom precompiles at `0x7b7c…` with structured `-32602`.
-- Per-call results: `returnData`, `logs`, `gasUsed`, `status`.
-- Reverts → per-call `error.code = 3`; VM errors → per-call `error.code = -32015`.
+- Per-call results: `returnData`, `logs` (with distinct `TxHash` / `TxIndex` / `BlockHash` per call via `SetTxConfig` + post-block back-stamp), `gasUsed`, `status`.
+- Reverts → per-call `error.code = 3`; VM errors → per-call `error.code = -32015`; per-call gas budget exhaustion → per-call `error.code = -38015` (preceding valid calls still land in the envelope).
+- `sanitizeSimChain` enforces strictly-increasing block numbers (`-38020`), strictly-increasing timestamps (`-38021`), and the hard 256-block span bound (`-38026`) — the latter enforced *before* gap-fill allocation to prevent pathological inputs from driving oversized header allocations.
+- `sameForks` sentinel rejects simulated spans that would cross a fork boundary: `applyMessageWithConfig` reads `ctx.BlockHeight` / `ctx.BlockTime` internally for fork-gated behavior, so a span straddling forks would silently execute with the base ruleset. Conservative rejection rather than silent wrong-fork output.
+- `BLOCKHASH` inside a simulated block resolves correctly over both tiers: canonical range (`height <= base.Number`) delegates to `k.GetHashFn(ctx)` which returns `ctx.HeaderHash` for the base height and consults `stakingKeeper.GetHistoricalInfo` below that; simulated-sibling range (`height > base.Number`) looks up an O(1) height-indexed map of already-finalized past siblings. Canonical-range hashes are unforgeable by any `BlockOverrides` field because `sanitizeSimChain` refuses simulated blocks whose `Number <= base.Number`.
+- `rpc/backend/simulate_v1.go` resolves the caller's `BlockNumberOrHash` to a concrete numeric height before marshaling; the keeper's `validateSimulateV1Anchor` rejects direct-gRPC callers whose numeric `BlockNumberOrHash` disagrees with the anchored context.
+- `baseHeaderFromContext` derives `GasLimit` from `mezotypes.BlockGasLimit(ctx)` with a fallback to `req.GasCap` — a gRPC query context anchored at a past height may carry no consensus params, which would otherwise collapse every default-Gas call to `0`.
 - Strict input validation rejects `BeaconRoot`, `Withdrawals`, `BlobBaseFee` overrides as user-observable errors.
 - All errors flow as `*types.SimError` from constructor → keeper → gRPC `SimulateV1Response.Error` → backend → geth's RPC server emits `{code, message, data}`.
 
@@ -97,116 +102,38 @@ The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/k
 
 # Part 1 — remaining phases (against v1.14.8)
 
-## Phase 6 — Multi-call within one block
-
-**Goal.** N calls execute in sequence inside one simulated block. State mutations from call N are visible to call N+1. Block gas limit enforced cumulatively.
-
-**Design.** ONE `*statedb.StateDB` for the whole request. Between calls: `stateDB.FinaliseBetweenCalls()` clears logs/refund/transient and resets the precompile-call counter without touching state objects. Per-call `stateDB.Snapshot()` / `RevertToSnapshot()` if the call reverts at EVM level — outer simulate state is preserved either way (reverts reported per-call, execution continues).
-
-New private helper `sanitizeSimCall` in `simulate_v1.go`: defaults nonce via `stateDB.GetNonce(from)`; defaults gas via `blockCtx.GasLimit - cumGasUsed`; block-gas-limit check returns `-38015`.
-
-**Files.**
-- EDIT `x/evm/keeper/simulate_v1.go` — add multi-call loop inside the single-block path; shared StateDB; cumulative `gasUsedInBlock`; add `sanitizeSimCall` helper.
-- EDIT `x/evm/types/simulate_v1_errors.go` — add `NewSimBlockGasLimitReached(...)` for `-38015`.
-
-**Risks.**
-- **Shared StateDB journal growth.** A 1000-call request producing 4KB storage per call = 4MB journaled. Phase 8's global block cap × per-block gas limit bound this. Add an internal cumulative-journal sanity cap (e.g. 100MB hard fail).
-- **Precompile call counter.** Reset between calls so legitimate 30-call sims don't trip `maxPrecompilesCallsPerExecution`. Done via `FinaliseBetweenCalls`.
-- **Per-call revert must not leak state** — covered by snapshot/revert; test explicitly.
-
-**Verification.**
-- `grpc_query_test.go`: `TestSimulateV1_MultiCall_StateChainsAcrossCalls` — call 1 `transfer(B, X)`, call 2 `balanceOf(B)` returns X.
-- `grpc_query_test.go`: `TestSimulateV1_MultiCall_RevertDoesNotLeak` — call 1 reverts, call 2 reads pre-call-1 state unchanged.
-- `grpc_query_test.go`: `TestSimulateV1_MultiCall_BlockGasLimit` — cumulative gas exceeds block gas limit → offending call gets `-38015`; preceding calls remain valid.
-- `grpc_query_test.go`: `TestSimulateV1_MultiCall_NonceAutoIncrement` — same sender, no `Nonce` in args; nonce advances automatically.
-- System: `tests/system/test/SimulateV1_MultiCall.test.ts` — deploy counter contract, 3 calls each incrementing, assert final value = 3.
-
-**DoD.**
-- Multi-call works within a single simulated block.
-- State chains call-to-call.
-- Block gas limit strictly enforced.
-- Multi-block still returns "not yet implemented".
-
----
-
-## Phase 7 — Multi-block chaining + simulated `GetHashFn` ⚠️ SECURITY-CRITICAL KERNEL
-
-**Goal.** N simulated blocks in sequence. Each block's state visible to later blocks. `BLOCKHASH` inside block 3 returns hashes of simulated blocks 1 and 2.
-
-**Design.** Block loop: `for bi, block := range sanitized { process(bi, block, headers[:bi]) }`. Shared StateDB across blocks. Between blocks: `stateDB.FinaliseBetweenCalls()`. Per-block processing extracted into a private helper `processSimBlock` in `simulate_v1.go`.
-
-Custom `GetHashFn` closure (private helper `newSimGetHashFn` in `simulate_v1.go`):
-
-```go
-func (k *Keeper) newSimGetHashFn(ctx sdk.Context, base *ethtypes.Header,
-    sim []*ethtypes.Header) vm.GetHashFunc
-```
-
-**Resolution order** (mirror go-ethereum `simulate.go:510-563`, **load-bearing for security**):
-1. `height == base.Number` → `base.Hash()`.
-2. `height < base.Number` → delegate to `k.GetHashFn(ctx)` (canonical chain via `stakingKeeper.GetHistoricalInfo`).
-3. `height > base.Number` → scan `sim[]` for a match. Only past siblings (slice is `headers[:bi]` from call site).
-4. Not found → zero hash (matches go-ethereum and existing mezod fallback).
-
-Pre-execution: compute preliminary headers for all sanitized blocks so `GetHashFn` can resolve future-block hashes during execution. Post-execution of each block: repair `GasUsed`, finalize hash, replace the preliminary header in place.
-
-**Consume `BlockNumberOrHash` from the request** (carry-over from Phase 5). The backend already serializes `BlockNumberOrHash` into `SimulateV1Request.BlockNumberOrHash`, but Phase 5's driver synthesized the base header from the SDK ctx height and ignored the field. Phase 7 must parse it at the gRPC handler, fetch the real base block via `TendermintBlockByNumber` / hash lookup, and pass that as `base` into the driver — otherwise the custom `GetHashFn` cannot resolve canonical-range hashes consistently with the caller-specified anchor.
-
-**Files.**
-- EDIT `x/evm/keeper/simulate_v1.go` — add block loop, preliminary header construction, post-exec repair, `newSimGetHashFn`, `processSimBlock` helper.
-- EDIT `x/evm/keeper/grpc_query.go` — resolve `BlockNumberOrHash` → real base header; stop synthesizing from ctx.
-
-**Risks (THIS IS THE KERNEL).**
-- **Forged BLOCKHASH oracle.** Simulator-provided BLOCKHASH for future blocks is fine (by design). The critical invariant: for any **canonical** (below-base) height, MUST delegate to real `k.GetHashFn(ctx)` and MUST NOT honor any `BlockOverrides` field. Audit every block-override field for whether it could leak into the canonical range.
-- **`BlockOverrides.Number < baseHeight`** is rejected by Phase 4's `-38020` monotonic-number check in `sanitizeSimChain`; no additional guard needed here.
-- **Stale `sdk.Context.BlockHeight()`.** The context is fixed to base; the simulated block executes at `base + N` but any code reading `ctx.BlockHeight()` inside the EVM pipeline gets the wrong value. Audit: grep `ctx.BlockHeight()` within the call graph reachable from `applyMessageWithConfig` on the simulate path. Any leak must use `blockCtx.BlockNumber` instead.
-- **State sprawl across blocks.** 256 blocks × 1000 calls × unbounded storage per call. Bounded by Phase 8.
-- **BLOCKHASH depth cap at 256.** Per standard EVM semantics; matches go-ethereum.
-
-**Verification.**
-- `grpc_query_test.go`: `TestSimulateV1_MultiBlock_StateChains` — block 1 SSTORE slot, block 2 SLOAD same slot.
-- `grpc_query_test.go`: `TestSimulateV1_MultiBlock_ChainLinkage` — block 3 contract reads `BLOCKHASH(1)`, `BLOCKHASH(2)`, `BLOCKHASH(0)` (base). All three match expected simulated/base hashes. (Port go-ethereum `TestSimulateV1ChainLinkage`.)
-- `simulate_v1_test.go`: `TestNewSimGetHashFn_*` — `BLOCKHASH(base-N)` for `N ≤ 256` returns canonical hash; `N > 256` returns zero.
-- System: `tests/system/test/SimulateV1_MultiBlock.test.ts` — 5-block simulation; contract asserts `block.number` increments correctly.
-- **Manual localnet verification (LAST RESORT, justified):** run against a chain with ≥100 historical blocks; issue simulate that BLOCKHASHes a canonical block below base; cross-check against `eth_getBlockByNumber(height).hash`. Catches IAVL/query-at-height edge cases that mocks cannot.
-- **`/security-review` on the branch before merge.**
-
-**DoD.**
-- Chained multi-block state works.
-- BLOCKHASH consistent across canonical + simulated range.
-- Canonical-range BLOCKHASH not influenceable by any block override.
-- Manual localnet check green.
-- Security review clean.
-
----
-
 ## Phase 8 — DoS guards + kill switch ⚠️ SECURITY-CRITICAL
 
 **Goal.** Layered defense-in-depth bounding. One operator kill switch.
 
-**Design.**
+**Already in place (carried over from Phases 1-7).**
+- **256-block span cap** — `maxSimulateBlocks = 256` in `simulate_v1.go`; enforced inside `sanitizeSimChain` *before* gap-fill allocation (`NewSimClientLimitExceeded` → `-38026`). Pathological inputs like `[{Number: base+1}, {Number: base+10_000_000}]` fail without materializing headers.
+- **Per-block gas limit** — `sanitizeSimCall` rejects any call whose requested gas would push cumulative block gas past `header.GasLimit` with `NewSimBlockGasLimitReached` → `-38015`. Emitted per-call so preceding valid calls still land in the envelope.
+- **Timeout context** — `context.WithTimeout(ctx, b.RPCEVMTimeout())` already wired at `rpc/backend/simulate_v1.go`. What's missing is an internal `ctx.Err()` / `evm.Cancel()` check loop inside the keeper driver.
+
+**Design (remaining work).**
 - **Kill switch.** New field `SimulateDisabled bool` on `JSONRPCConfig` (`server/config/config.go`). Default `false`. Checked in `PublicAPI.SimulateV1` before reaching the backend. Returns `-32601 "the method eth_simulateV1 does not exist/is not available"` when set — intentionally impersonates "method absent" so the operator can hide the endpoint wholesale.
-- **Block cap.** Hard-code `maxSimulateBlocks = 256` in `simulate_v1.go`. Enforced twice: at the RPC layer (fast fail) and inside `sanitizeSimChain` (span check, defense-in-depth).
-- **Gas pool.** One `uint64 gasRemaining` initialized from `b.RPCGasCap()`. Deducted on every call's `res.GasUsed`. Exhaustion → top-level `-38015`-shaped fatal error.
-- **Timeout.** `context.WithTimeout(ctx, b.RPCEVMTimeout())` at the backend entry (already in place from Phase 5). Inside the keeper loop, check `ctx.Err()` before every call. Mirror go-ethereum's `applyMessageWithEVM` goroutine that calls `evm.Cancel()` on ctx-done. On ctx-done return top-level `-32016 "execution aborted (timeout = Xs)"` (`SimErrCodeTimeout`).
-- **Per-block gas limit.** Already from Phase 6 via `sanitizeSimCall`.
+- **Block-cap RPC-layer fast fail.** The 256 bound is enforced inside `sanitizeSimChain` today; add a mirror check at the RPC entry so a hostile 10k-block request fails before the driver allocates anything. Defense-in-depth for the existing sanitize-side check.
+- **Gas pool.** One `uint64 gasRemaining` initialized from `b.RPCGasCap()`, threaded through `simulateV1` and `processSimBlock`. Deducted on every call's `res.GasUsed`. Exhaustion → top-level `-38015`-shaped fatal error. Distinct from the per-block `sanitizeSimCall` preflight (that gates a single call against its block; this gates the whole request against node config).
+- **Timeout inside the loop.** Check `ctx.Err()` before every call; mirror go-ethereum's `applyMessageWithEVM` goroutine that calls `evm.Cancel()` on ctx-done. On ctx-done return top-level `-32016 "execution aborted (timeout = Xs)"` (`SimErrCodeTimeout`).
 - **Cumulative call count.** Soft cap of 1000 calls per request (hard-coded constant, not configurable for v1).
 
 **Files.**
 - EDIT `server/config/config.go` — `SimulateDisabled bool` on `JSONRPCConfig`; update TOML template + defaults.
 - EDIT `rpc/backend/backend.go` — `SimulateDisabled() bool` accessor.
-- EDIT `rpc/backend/simulate_v1.go` — kill-switch check; `RPCGasCap` plumbing into the gRPC request.
+- EDIT `rpc/backend/simulate_v1.go` — kill-switch check; plumb `RPCGasCap` into the gas pool (already marshaled into the request; driver needs to consume it as a pool, not just a per-call cap).
 - EDIT `rpc/namespaces/ethereum/eth/simulate_v1.go` — kill-switch check at entry (short-circuit before backend).
-- EDIT `x/evm/keeper/simulate_v1.go` — enforce 256 block cap, 1000 call cap, shared gas pool; `ctx.Err()` checks; `evm.Cancel()` on ctx-done.
-- EDIT `x/evm/types/simulate_v1_errors.go` — add `NewSimTimeout(...)` for `-32016`.
+- EDIT `x/evm/keeper/simulate_v1.go` — 1000 call cap, shared gas pool deduction, `ctx.Err()` checks, `evm.Cancel()` on ctx-done, top-level span check at driver entry (mirror of the sanitize-side bound).
+- EDIT `x/evm/types/simulate_v1_errors.go` — add `NewSimTimeout(...)` for `-32016` (constant `SimErrCodeTimeout` already declared).
 
 **Risks.**
 - **Failure-open gaps.** Each guard must terminate independently. Test each in isolation.
 - **Resource leak on cancel.** Deferred cancel; goroutine exits cleanly; no dangling state in StateDB.
 - **Concurrent-request saturation.** Each request has its own StateDB snapshot; in-process single-threaded execution. Multiple concurrent requests bounded by RPC server's thread pool. Document in ops guide.
+- **Gas-pool double-accounting.** The per-block `sanitizeSimCall` budget and the request-wide gas pool are independent: a call must pass both. Make sure a call that fails the request pool does not also land as a per-call envelope entry (top-level fatal, not per-call).
 
 **Verification.**
-- `grpc_query_test.go`: `TestSimulateV1_DoS_BlockCap` — >256 blocks → `-38026`.
+- `grpc_query_test.go`: `TestSimulateV1_DoS_BlockCap` — >256 blocks → `-38026` (already passing via `sanitizeSimChain`; add explicit regression).
 - `grpc_query_test.go`: `TestSimulateV1_DoS_CallCap` — ≥1000 calls → structured error.
 - `grpc_query_test.go`: `TestSimulateV1_DoS_GasPool` — exhausts `gasRemaining` → top-level fatal `-38015`-shaped error; aborts immediately.
 - `rpc/backend/simulate_v1_test.go`: `TestSimulateV1_Timeout` — long call hits ctx-done → `-32016` `"execution aborted (timeout = 5s)"` within 5.2s.
@@ -268,20 +195,21 @@ In the driver: when `TraceTransfers=true`, wrap StateDB via `state.NewHookedStat
 
 **Goal.** Implement `validation=true` semantics per the execution-apis spec: tx-level validation failures are **fatal top-level errors** that abort the whole simulate request.
 
-**Design.** In the driver:
+**Already in place.** `makeSimHeader` derives the header's `BaseFee` via `eip1559.CalcBaseFee(chainCfg, parent)` when `validation && rules.IsLondon`, otherwise zero. `processSimBlock` sets `EVMOverrides.NoBaseFee = &!opts.Validation`, so `validation=false` already relaxes base-fee checks and `validation=true` already forces them.
+
+**Design (remaining work).** In the driver:
 - `validation=true` → before each call: nonce check (`-38010`/`-38011`), balance check for `gasLimit*gasPrice + value` (`-38014`), intrinsic-gas check (`-38013`), init-code-size check (`-38025`). Any failure aborts the request and returns the top-level structured error.
-- `validation=true` + no `BaseFee` override → compute via `eip1559.CalcBaseFee(cfg, parent)`; if `msg.GasFeeCap < baseFee` → top-level `-32005` (`SimErrCodeFeeCapTooLow`).
+- `validation=true` + derived base fee → if `msg.GasFeeCap < baseFee` → top-level `-32005` (`SimErrCodeFeeCapTooLow`).
 - `validation=true` + `BlockOverrides.BaseFeePerGas` lower than the chain would accept → top-level `-38012` (`SimErrCodeBaseFeeTooLow`). Distinct from `-32005`: `-32005` is about the *transaction's* fee cap; `-38012` is about the *block's* overridden baseFee.
-- `validation=true` → `EVMOverrides.NoBaseFee = &false` (force real base-fee checks regardless of fee-market `NoBaseFee` param).
 - `validation=true` → `msg.SkipNonceChecks = false`.
-- `validation=false` (default) → `BaseFee = 0`, `NoBaseFee = true`, `SkipNonceChecks = true`.
+- `validation=false` (default) → `msg.SkipNonceChecks = true`. (Base-fee / `NoBaseFee` handling is already branched by `opts.Validation` in `makeSimHeader` and `processSimBlock`.)
 - Revert / VM errors stay per-call regardless of validation mode (revert → code `3`; VM → `-32015`).
 
 `SkipAccountChecks = true` always (EoA check off — custom overrides may well be a contract at the from address).
 
 **Files.**
-- EDIT `x/evm/keeper/simulate_v1.go` — two mode branches; pre-call validation gates; `skipNonceCheck` flag into the message builder; base-fee derivation branch in `makeSimHeader`.
-- EDIT `x/evm/types/simulate_v1_errors.go` — add `NewSimNonceTooLow`, `NewSimNonceTooHigh`, `NewSimInsufficientFunds`, `NewSimIntrinsicGas`, `NewSimInitcodeTooLarge`, `NewSimFeeCapTooLow`, `NewSimBaseFeeTooLow` constructors as needed.
+- EDIT `x/evm/keeper/simulate_v1.go` — pre-call validation gates inside `processSimBlock`; `skipNonceCheck` flag into the message builder.
+- EDIT `x/evm/types/simulate_v1_errors.go` — add `NewSimNonceTooLow`, `NewSimNonceTooHigh`, `NewSimInsufficientFunds`, `NewSimIntrinsicGas`, `NewSimInitcodeTooLarge`, `NewSimFeeCapTooLow`, `NewSimBaseFeeTooLow` constructors as needed (constants `SimErrCodeNonceTooLow`, `SimErrCodeNonceTooHigh`, `SimErrCodeBaseFeeTooLow`, `SimErrCodeIntrinsicGas`, `SimErrCodeInsufficientFunds`, `SimErrCodeMaxInitCodeSizeExceeded` already declared).
 
 **Risks.**
 - **Divergence from fee-market `NoBaseFee` param.** `validation=true` MUST override regardless of node config. Test explicitly.
@@ -313,24 +241,24 @@ In the driver: when `TraceTransfers=true`, wrap StateDB via `state.NewHookedStat
 **Goal.** Response shape parity with spec. `returnFullTransactions=true` emits fully-populated tx objects with `from` patched from an internal `senders` map.
 
 **Design.** Simulated txs are unsigned (no sender recoverable from signature). The driver tracks `senders map[common.Hash]common.Address` keyed by tx hash. On response marshaling:
-- `returnFullTransactions=false` (default) → tx hashes only.
+- `returnFullTransactions=false` (default) → tx hashes only (current behavior — `assembleSimBlock` builds the `transactions` list from `txHashes`).
 - `returnFullTransactions=true` → full tx objects with `from` patched in `MarshalJSON`.
 
 Custom `MarshalJSON` for the block envelope: invokes `RPCMarshalBlock` (existing in `rpc/backend/blocks.go`), injects `calls` field, patches `from` (mirrors go-ethereum `simulate.go:85`).
 
 **Files.**
-- EDIT `rpc/types/simulate_v1.go` — extend `MarshalJSON` for `SimBlockResult` with `from` patching.
-- EDIT `x/evm/keeper/simulate_v1.go` — populate `senders` map in `assembleSimBlock`; construct assembled block with unsigned txs.
-- EDIT `rpc/backend/simulate_v1.go` — apply patching on the unmarshaled response.
+- EDIT `x/evm/types/simulate_v1.go` — extend `SimBlockResult.MarshalJSON` with `from` patching; thread a `ReturnFullTransactions bool` + `Senders map[common.Hash]common.Address` through the response shape (or collapse senders into the already-flattened `Block` map).
+- EDIT `x/evm/keeper/simulate_v1.go` — populate `senders` map in `processSimBlock`; hand unsigned-tx objects (not just hashes) to `assembleSimBlock` when `opts.ReturnFullTransactions` is set.
+- EDIT `rpc/backend/simulate_v1.go` — no new logic expected (the keeper-side marshaller already emits the right shape); add a regression test that the value round-trips through the gRPC `response.Result` envelope.
 
 **Risks.** Low (cosmetic). Watch for:
-- `Logs: []` vs `Logs: null` (force `[]` per spec — already handled by Phase 1's marshaler).
+- `Logs: []` vs `Logs: null` (force `[]` per spec — already handled by `SimCallResult.MarshalJSON`).
 - Tx hash stability: unsigned tx `Hash()` depends on all fields — don't mutate tx between hashing and block assembly.
 
 **Verification.**
-- `rpc/types/simulate_v1_test.go`: `TestSimBlockResult_FullTx_FromPatched` — `returnFullTransactions=true` → tx objects with correct `from`.
-- `rpc/types/simulate_v1_test.go`: `TestSimBlockResult_HashOnly` — `returnFullTransactions=false` → tx hashes only.
-- `rpc/types/simulate_v1_test.go`: `TestSimCallResult_EmptyLogsAsArray` — empty `logs` serialized as `[]` not `null`.
+- `x/evm/types/simulate_v1_test.go`: `TestSimBlockResult_FullTx_FromPatched` — `returnFullTransactions=true` → tx objects with correct `from`.
+- `x/evm/types/simulate_v1_test.go`: `TestSimBlockResult_HashOnly` — `returnFullTransactions=false` → tx hashes only (existing default behavior).
+- `x/evm/types/simulate_v1_test.go`: existing `TestSimCallResult_MarshalsEmptyLogsAsArray` already covers the `Logs: []` invariant — no change needed, but verify it still passes under the new patch.
 - System: `tests/system/test/SimulateV1_FullTx.test.ts` — assert full tx shape round-trips.
 
 **DoD.**
@@ -346,10 +274,9 @@ Custom `MarshalJSON` for the block envelope: invokes `RPCMarshalBlock` (existing
 **Tasks.**
 - NEW `x/evm/keeper/simulate_v1_fuzz_test.go` — Go fuzz target `FuzzSimulateV1Opts` mutating JSON inputs; invariant: never panic, always returns either valid response or structured error.
 - NEW `tests/system/test/SimulateV1_Conformance.test.ts` — port high-signal scenarios from `ethereum/execution-apis/tests/eth_simulateV1/`: multi-block chaining, state/block overrides, `MovePrecompileTo` (stdlib only), `validation=true` fatal aborts (-38014, -38011), `traceTransfers`, block-gas-limit overflow (-38015), span > 256 (-38026).
-- **System-test consolidation pass.** Phases 1-11 each land a focused `tests/system/test/SimulateV1_*.test.ts` for easy attribution. With Phase 12's conformance suite in place, collapse:
-  - DELETE `SimulateV1_Stub.test.ts` if still present — Phase 5 made the stub return real data, so the test asserts a lie.
-  - DELETE each `SimulateV1_*.test.ts` whose cases the conformance suite already covers (likely: `SingleCall`, `MultiCall`, `MultiBlock`, `MovePrecompile_ethCall`, `Validation`, `TraceTransfers`, `Limits`, `FullTx`). Do this only after confirming the conformance suite asserts the same response shapes.
-  - KEEP `SimulateV1_MezoDivergences.test.ts` (NEW — may be lifted from existing files) for behavior the execution-apis fixtures cannot cover: custom-precompile immovability, `MinGasMultiplier` gas reporting, kill-switch returning `-32601`, rejected overrides for unsupported EIPs (`BeaconRoot`, `Withdrawals`, blob fields).
+- **System-test consolidation pass.** Phases 1-11 each land a focused `tests/system/test/SimulateV1_*.test.ts` for easy attribution. Current files on disk: `SimulateV1_SingleCall`, `SimulateV1_MultiCall`, `SimulateV1_MultiBlock`, `SimulateV1_MovePrecompile_ethCall`, `SimulateV1_RejectedOverrides` (plus the Phase 8-11 additions: `SimulateV1_Limits`, `SimulateV1_TraceTransfers`, `SimulateV1_Validation`, `SimulateV1_FullTx`). With Phase 12's conformance suite in place, collapse:
+  - DELETE each `SimulateV1_*.test.ts` whose cases the conformance suite already covers: `SingleCall`, `MultiCall`, `MultiBlock`, `MovePrecompile_ethCall`, `Validation`, `TraceTransfers`, `Limits`, `FullTx`. Do this only after confirming the conformance suite asserts the same response shapes.
+  - KEEP/CREATE `SimulateV1_MezoDivergences.test.ts` for behavior the execution-apis fixtures cannot cover: custom-precompile immovability, custom-precompile `cachedCtx` continuity across calls and blocks (currently in `SimulateV1_MultiCall` / `SimulateV1_MultiBlock` — must be lifted before those are dropped), `MinGasMultiplier` gas reporting, kill-switch returning `-32601`, rejected overrides for unsupported EIPs (`BeaconRoot`, `Withdrawals`, blob fields — currently in `SimulateV1_RejectedOverrides`, fold here).
   - Target end state: **2 files** — `SimulateV1_Conformance.test.ts` + `SimulateV1_MezoDivergences.test.ts`.
 - EDIT `CHANGELOG.md`, `docs/` — document:
   - New `eth_simulateV1` method.
@@ -426,7 +353,7 @@ Skipping this check will silently break any simulate request that exceeds `maxPr
 
 **Verification.**
 - All Phase 1-12 tests pass unchanged.
-- Multi-call simulate tests from Phase 6 (≥2 calls touching custom precompiles) still pass — canary for the counter-reset gap.
+- The multi-call / multi-block tests that touch custom precompiles (`TestSimulateV1_MultiBlock_PrecompileStateChains`; system-side `btctoken` cases in `SimulateV1_MultiCall` / `SimulateV1_MultiBlock`) still pass — canary for the counter-reset gap.
 - `go build ./...` clean; `make test-unit` green.
 
 **DoD.**
@@ -440,7 +367,7 @@ Skipping this check will silently break any simulate request that exceeds `maxPr
 
 **Goal.** Post-Prague, `BLOCKHASH` can be served from the system contract at `0x…fffffffffffffffffffffffffffffffffffffffe` for up to the last 8192 blocks. Simulate must invoke `core.ProcessParentBlockHash` at the top of each simulated block (matches go-ethereum `simulate.go:267-272`) so BLOCKHASH works across the full 1..8192 range.
 
-**Design.** In `processSimBlock` (from Phase 7), after EVM construction and before executing user calls:
+**Design.** In `processSimBlock`, after EVM construction and before executing user calls:
 
 ```go
 if cfg.ChainConfig.IsPrague(header.Number, header.Time) {
@@ -448,7 +375,7 @@ if cfg.ChainConfig.IsPrague(header.Number, header.Time) {
 }
 ```
 
-Phase 7's `newSimGetHashFn` closure stays — it covers the `[base, base+N]` simulated-sibling range that the parent-hash contract cannot serve. Post-Prague split:
+The existing `newSimGetHashFn` closure stays — it covers the `[base, base+N]` simulated-sibling range that the parent-hash contract cannot serve. Post-Prague split:
 - `height > base` (simulated siblings) — `newSimGetHashFn` from in-memory headers.
 - `height == base` — `newSimGetHashFn`.
 - `height ∈ [base-256, base-1]` (recent canonical) — EVM `BLOCKHASH` opcode via `GetHashFn` delegating to `k.GetHashFn(ctx)`.
@@ -486,7 +413,7 @@ Phase 7's `newSimGetHashFn` closure stays — it covers the `[base, base+N]` sim
 **Files.**
 - EDIT `x/evm/keeper/simulate_v1.go` — recognize `authList` in the call loop; invoke per-call auth validation when `validation=true`.
 - EDIT `x/evm/types/simulate_v1.go` — allow `authorizationList` in `SimBlock` calls JSON unmarshal.
-- EDIT `rpc/types/simulate_v1.go` — surface `AuthorizationList` in the serializable call-args shape if not already from the upgrade.
+- EDIT `x/evm/types/transaction_args.go` (or equivalent owned by the upgrade project) — surface `AuthorizationList` in the serializable call-args shape if not already from the upgrade.
 - EDIT `x/evm/types/simulate_v1_errors.go` — add EIP-7702 auth-invalid error codes + `NewSim*` constructors.
 
 **Risks.**
@@ -517,20 +444,19 @@ Phase 7's `newSimGetHashFn` closure stays — it covers the `[base, base+N]` sim
 **Goal.** Add Osaka's per-tx gas cap (16,777,216) as an additional DoS layer. Add `MaxUsedGas` to `SimCallResult`.
 
 **Design.**
-- **Per-tx gas cap.** In `sanitizeSimCall` (Phase 6), after defaulting, assert `call.Gas <= 16_777_216`. Violation → structured error (await upstream code assignment; reserve slot in `-380xx` range).
+- **Per-tx gas cap.** In `sanitizeSimCall`, after defaulting, assert `call.Gas <= 16_777_216`. Violation → structured error (await upstream code assignment; reserve slot in `-380xx` range).
 - **`MaxUsedGas`.** Post-call, populate from the `ExecutionResult.MaxUsedGas` field introduced in geth v1.16.9 (PR #32789). Add to `SimCallResult` struct + JSON marshaling.
 
 **Files.**
 - EDIT `x/evm/keeper/simulate_v1.go` — per-tx 16M gas cap check in `sanitizeSimCall`; populate `MaxUsedGas` from `ExecutionResult`.
-- EDIT `rpc/types/simulate_v1.go` — add `MaxUsedGas hexutil.Uint64` to `SimCallResult`.
-- EDIT `x/evm/types/simulate_v1.go` — add `MaxUsedGas` to the keeper-side type.
+- EDIT `x/evm/types/simulate_v1.go` — add `MaxUsedGas hexutil.Uint64` to `SimCallResult`.
 - EDIT `x/evm/types/simulate_v1_errors.go` — add per-tx cap violation code + `NewSim*` constructor.
 
 **Risks.** Negligible — the cap is a bound, not new surface.
 
 **Verification.**
 - `grpc_query_test.go`: `TestSimulateV1_PerTxGasCap` — `call.Gas = 20_000_000` → structured error.
-- `rpc/types/simulate_v1_test.go`: `TestSimCallResult_MaxUsedGas_RoundTrip`.
+- `x/evm/types/simulate_v1_test.go`: `TestSimCallResult_MaxUsedGas_RoundTrip`.
 - System: extend `SimulateV1_Limits.test.ts` with the per-tx cap case.
 
 **DoD.**

--- a/.claude/MEZO-4227-eth-simulate-v1/plan.md
+++ b/.claude/MEZO-4227-eth-simulate-v1/plan.md
@@ -47,7 +47,7 @@ The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/k
 | `x/evm/keeper/simulate_v1.go` | All driver + helpers (private): `simulateV1` (top-level entry; one shared `*statedb.StateDB` for the whole request), `processSimBlock` (per-block execution; StateOverrides + BlockContext + per-call loop + envelope assembly), `sanitizeSimChain` (chain ordering + gap fill + `-38020` / `-38021` / `-38026`), `sanitizeSimCall` (per-call defaults: nonce from shared StateDB, gas from `header.GasLimit - cumGasUsed`; `-38015` preflight), `makeSimHeader`, `assembleSimBlock`, `computeSimTxHash`, `newSimGetHashFn` (simulate-aware `BLOCKHASH`: canonical via `k.GetHashFn(ctx)`, simulated siblings via in-memory height map, zero-hash otherwise — canonical range unforgeable by any `BlockOverrides`), `sameForks` (fork-boundary sentinel; compares base vs. last-sim `params.Rules` exhaustively and rejects spans that would cross a fork) |
 | `x/evm/keeper/state_override.go` | `applyStateOverrides(db, overrides, rules) (map[addr]addr, error)` — returns the validated `MovePrecompileTo` move set; mutates `db` in place; uses `vm.DefaultPrecompiles(rules)` to identify stdlib precompiles and `mezoCustomPrecompileAddrs` for the deny-list. Returns `*types.SimError` via `NewSim*` constructors on every spec-coded failure |
 | `x/evm/keeper/state_transition.go` | Seams: `EVMOverrides{BlockContext *vm.BlockContext, Precompiles map[addr]vm.PrecompiledContract, NoBaseFee *bool}`, `NewEVMWithOverrides(ctx, msg, cfg, tracer, stateDB, *EVMOverrides) *vm.EVM`, `precompilesWithMoves`, `activePrecompiles`. `applyMessageWithConfig` takes `*EVMOverrides`. `NewEVM` and the public `ApplyMessageWithConfig` delegate with `nil` — consensus path is byte-identical to main. The simulate driver calls `applyMessageWithConfig` with overrides carrying `BlockContext` (simulate-aware `GetHashFn`), `Precompiles` (with any `MovePrecompileTo` moves), and `NoBaseFee = &!opts.Validation` |
-| `x/evm/statedb/statedb.go` | `FinaliseBetweenCalls()` — clears per-call ephemeral state (logs, refund, transient storage) and resets the precompile-call counter while preserving state objects, access list, and journal across sequential calls in a shared StateDB. `SetTxConfig(cfg)` — replaces tx-scoped metadata in place so each simulated call stamps distinct `TxHash` / `TxIndex` on its emitted logs |
+| `x/evm/statedb/statedb.go` | `FinaliseBetweenCalls()` — clears per-call ephemeral state (logs, refund, transient storage) and resets the precompile-call counter while preserving state objects, access list, and journal across sequential calls in a shared StateDB. `SetTxContext(thash common.Hash, ti int)` — geth-aligned setter that replaces the StateDB's per-tx hash and tx index in place, so each simulated call stamps distinct `TxHash` / `TxIndex` on its emitted logs |
 | `proto/ethermint/evm/v1/query.proto` (+ `x/evm/types/query.pb.go`) | `rpc SimulateV1(SimulateV1Request) returns (SimulateV1Response)`. `SimulateV1Request{opts bytes, block_number_or_hash bytes, gas_cap uint64, proposer_address ConsAddress, chain_id int64, timeout_ms int64}`. `SimulateV1Response{result bytes, error SimError}`. `SimError{code int32, message string, data string}` |
 | `x/evm/keeper/grpc_query.go` | `Keeper.SimulateV1` handler — calls `validateSimulateV1Anchor` (defense-in-depth for direct-gRPC callers that bypass `rpc/backend`), parses chain ID / gas cap, unmarshals `req.Opts`, derives the base header via `baseHeaderFromContext` (falls back to `req.GasCap` when `mezotypes.BlockGasLimit(ctx)` returns 0), calls `k.simulateV1(...)`, marshals block results to JSON. Helper `simulateV1ErrResponse(err)` does `errors.As(err, &simErr)` to route typed failures to `response.Error` and genuine internals to `status.Error(codes.Internal, …)` |
 | `rpc/backend/simulate_v1.go` | Real adapter: marshals `SimOpts` to JSON, resolves caller-supplied `BlockNumberOrHash` to a concrete numeric height via `BlockNumberFromTendermint` + `TendermintBlockByNumber`, emits that concrete height in the request (sentinel `BlockNumber`s do not round-trip through JSON, so resolving here keeps the keeper anchor validator consistent), sets up timeout context (`b.RPCEVMTimeout()`) anchored via `rpctypes.ContextWithHeight(resolvedHeight)`, invokes gRPC. On `response.Error`, returns the `*evmtypes.SimError` directly so geth's RPC server emits `{code, message, data}`. Unmarshals `response.Result` to `[]*evmtypes.SimBlockResult` on success |
@@ -61,7 +61,7 @@ The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/k
 - **Helper unit tests** in `x/evm/keeper/simulate_v1_test.go` (`package keeper`, white-box) cover every stateless helper: `sanitizeSimChain` (gap fill, monotonic number/timestamp, span bound, `*SimError` surface), `makeSimHeader` (defaults from parent, post-merge difficulty, base-fee override, validation-derived base fee, field overrides), `sanitizeSimCall` (default vs. explicit nonce, default Gas, `-38015` preflight, zero-gas-limit behavior), `newSimGetHashFn` (hit-base, below-base canonical, above-base sibling, not-found, canonical-unforgeability).
 - **Override unit tests** in `x/evm/keeper/state_override_test.go` cover `MovePrecompileTo` validation and the mezo-custom deny-list.
 - **State-transition unit tests** in `x/evm/keeper/state_transition_test.go` cover `NewEVMWithOverrides` byte-equivalence with `NewEVM` and override behavior.
-- **StateDB tests** in `x/evm/statedb/statedb_test.go` cover `FinaliseBetweenCalls` and `SetTxConfig`.
+- **StateDB tests** in `x/evm/statedb/statedb_test.go` cover `FinaliseBetweenCalls` and `SetTxContext`.
 - **Backend tests** in `rpc/backend/simulate_v1_test.go` use a mocked query client to assert proto request shape (including the resolved numeric height in `BlockNumberOrHash`) + timeout context.
 - **Types unit tests** in `x/evm/types/simulate_v1_test.go` cover JSON round-trip for every shape — `SimOpts`, `SimBlockResult`, `SimCallResult` — and the explicit rejections baked into `UnmarshalSimOpts`.
 - **System tests** under `tests/system/test/SimulateV1_*.test.ts` are TypeScript Hardhat suites run via `./tests/system/system-tests.sh`. Current files: `SimulateV1_SingleCall`, `SimulateV1_MultiCall`, `SimulateV1_MultiBlock`, `SimulateV1_MovePrecompile_ethCall`, `SimulateV1_RejectedOverrides`. Phase 12 collapses these into conformance + divergence suites.
@@ -72,7 +72,7 @@ The architectural seam is **bare types in `x/evm/types/`, flow logic in `x/evm/k
 - State mutations propagate across calls within a block and across blocks within a request — for both the EVM journal (accounts, storage) and mezo's StateDB-scoped cached-ctx layer (custom precompile Cosmos-side writes). Covered by the `TestSimulateV1_MultiBlock_PrecompileStateChains` keeper test and the `SimulateV1_MultiCall` / `SimulateV1_MultiBlock` system tests' `btctoken` cases.
 - State overrides honored per-block (balance, nonce, code, state, stateDiff).
 - `MovePrecompileTo` works for stdlib precompiles (0x01-0x0A); blocks all 8 mezo custom precompiles at `0x7b7c…` with structured `-32602`.
-- Per-call results: `returnData`, `logs` (with distinct `TxHash` / `TxIndex` / `BlockHash` per call via `SetTxConfig` + post-block back-stamp), `gasUsed`, `status`.
+- Per-call results: `returnData`, `logs` (with distinct `TxHash` / `TxIndex` / `BlockHash` per call via `SetTxContext` + post-block back-stamp), `gasUsed`, `status`.
 - Reverts → per-call `error.code = 3`; VM errors → per-call `error.code = -32015`; per-call gas budget exhaustion → per-call `error.code = -38015` (preceding valid calls still land in the envelope).
 - `sanitizeSimChain` enforces strictly-increasing block numbers (`-38020`), strictly-increasing timestamps (`-38021`), and the hard 256-block span bound (`-38026`) — the latter enforced *before* gap-fill allocation to prevent pathological inputs from driving oversized header allocations.
 - `sameForks` sentinel rejects simulated spans that would cross a fork boundary: `applyMessageWithConfig` reads `ctx.BlockHeight` / `ctx.BlockTime` internally for fork-gated behavior, so a span straddling forks would silently execute with the base ruleset. Conservative rejection rather than silent wrong-fork output.
@@ -238,31 +238,66 @@ In the driver: when `TraceTransfers=true`, wrap StateDB via `state.NewHookedStat
 
 ## Phase 11 — `ReturnFullTransactions` + sender patching + full block envelope
 
-**Goal.** Response shape parity with spec. `returnFullTransactions=true` emits fully-populated tx objects with `from` patched from an internal `senders` map.
+**Goal.** Response shape parity with spec on **two axes**:
+1. `returnFullTransactions=true` emits fully-populated tx objects with `from` patched from an internal `senders` map.
+2. Block-envelope fields that today are zero / placeholder / empty-tree-root scaffolding are populated correctly: `logsBloom`, `transactionsRoot`, `receiptsRoot`, `size`. `stateRoot` is the one exception — it stays zero by design (see Phase 12 known-divergence note).
 
-**Design.** Simulated txs are unsigned (no sender recoverable from signature). The driver tracks `senders map[common.Hash]common.Address` keyed by tx hash. On response marshaling:
+The current driver hand-builds a `map[string]interface{}` in `assembleSimBlock` and never derives the post-execution roots, bloom, or block size. This phase replaces that scaffolding with a real `*types.Block` envelope so the remaining fields fall out naturally.
+
+**Design.**
+
+*Sender patching.* Simulated txs are unsigned (no sender recoverable from signature). The driver tracks `senders map[common.Hash]common.Address` keyed by tx hash. On response marshaling:
 - `returnFullTransactions=false` (default) → tx hashes only (current behavior — `assembleSimBlock` builds the `transactions` list from `txHashes`).
 - `returnFullTransactions=true` → full tx objects with `from` patched in `MarshalJSON`.
 
-Custom `MarshalJSON` for the block envelope: invokes `RPCMarshalBlock` (existing in `rpc/backend/blocks.go`), injects `calls` field, patches `from` (mirrors go-ethereum `simulate.go:85`).
+*Block-envelope completeness.* Replace the `map[string]interface{}` shortcut with a real `*types.Block`:
+- Materialize a per-call `*ethtypes.Transaction` (the legacy tx already constructed by `computeSimTxHash` — reuse rather than re-hash) and accumulate them into `txs []*ethtypes.Transaction`.
+- Materialize a per-call `*ethtypes.Receipt` carrying `Status`, `CumulativeGasUsed` (running total of `res.GasUsed`), `Logs` (the per-call slice already attached to `SimCallResult`), `Bloom = ethtypes.CreateBloom(types.Receipts{r})`, `TxHash`, `BlockHash` (post back-stamp), `TransactionIndex`, and `BlockNumber`. Accumulate into `receipts []*ethtypes.Receipt`.
+- After the per-call loop and back-stamp, derive header fields:
+  - `header.TxHash = ethtypes.DeriveSha(ethtypes.Transactions(txs), trie.NewStackTrie(nil))`
+  - `header.ReceiptHash = ethtypes.DeriveSha(ethtypes.Receipts(receipts), trie.NewStackTrie(nil))`
+  - `header.Bloom = ethtypes.CreateBloom(receipts)` (merged bloom across all receipts in the block)
+- Build `block := ethtypes.NewBlock(header, &ethtypes.Body{Transactions: txs}, receipts, trie.NewStackTrie(nil))` so `block.Size()` returns a real RLP-encoded body length.
+- Custom `MarshalJSON` for the block envelope: invokes `RPCMarshalBlock` (existing in `rpc/backend/blocks.go`), injects `calls` field, patches `from` (mirrors go-ethereum `simulate.go:85-100`).
+
+**Out of scope for this phase — `stateRoot`.** Mezod's `statedb.StateDB` wraps a Cosmos cached multistore; there is no MPT to call `IntermediateRoot()` on. `header.Root` stays the zero hash, surfacing in JSON as `0x000…000`. Document this in Phase 12's "Known divergences" section. Echoing `base.Root` would be misleading (ignores everything the simulation did) and is explicitly rejected.
 
 **Files.**
-- EDIT `x/evm/types/simulate_v1.go` — extend `SimBlockResult.MarshalJSON` with `from` patching; thread a `ReturnFullTransactions bool` + `Senders map[common.Hash]common.Address` through the response shape (or collapse senders into the already-flattened `Block` map).
-- EDIT `x/evm/keeper/simulate_v1.go` — populate `senders` map in `processSimBlock`; hand unsigned-tx objects (not just hashes) to `assembleSimBlock` when `opts.ReturnFullTransactions` is set.
-- EDIT `rpc/backend/simulate_v1.go` — no new logic expected (the keeper-side marshaller already emits the right shape); add a regression test that the value round-trips through the gRPC `response.Result` envelope.
+- EDIT `x/evm/keeper/simulate_v1.go`:
+  - In `processSimBlock`: build per-call `*ethtypes.Transaction` and `*ethtypes.Receipt` alongside the existing `SimCallResult`. Reuse the `LegacyTx` already constructed by `computeSimTxHash` to avoid hashing twice.
+  - After the back-stamp loop, derive `header.TxHash`, `header.ReceiptHash`, `header.Bloom` from the synthetic txs/receipts.
+  - Replace `assembleSimBlock`'s hand-built map with a real `*ethtypes.Block` constructed via `ethtypes.NewBlock(...)`. Plug it into the existing `SimBlockResult.Block` shape (or replace the `map[string]interface{}` field with `*ethtypes.Block`, with `MarshalJSON` doing the flattening + `calls` injection via `RPCMarshalBlock`).
+  - Populate `senders` map keyed by synthetic tx hash; thread it through to the marshaller.
+- EDIT `x/evm/types/simulate_v1.go`:
+  - Update `SimBlockResult` to carry the real `*ethtypes.Block` (or keep `map[string]interface{}` populated from `RPCMarshalBlock(block, …)`).
+  - Extend `SimBlockResult.MarshalJSON` with `from` patching and `calls` injection; mirror go-ethereum `simulate.go:simBlockResult.MarshalJSON`.
+  - Thread `ReturnFullTransactions bool` + `Senders map[common.Hash]common.Address` through the response shape.
+  - Update `UnmarshalJSON` to round-trip the new shape (the existing flatten/unflatten logic still applies).
+- EDIT `rpc/backend/simulate_v1.go`: no new logic expected; add a regression test asserting the populated envelope fields round-trip through the gRPC `response.Result` envelope unchanged.
 
-**Risks.** Low (cosmetic). Watch for:
-- `Logs: []` vs `Logs: null` (force `[]` per spec — already handled by `SimCallResult.MarshalJSON`).
-- Tx hash stability: unsigned tx `Hash()` depends on all fields — don't mutate tx between hashing and block assembly.
+**Risks.**
+- **Synthetic-receipt fidelity.** `Receipt.PostState` stays nil (we don't have a state root); `Receipt.ContractAddress` is set only on CREATE; `Receipt.GasUsed` is the per-call `res.GasUsed`; `Receipt.CumulativeGasUsed` is the running block total. Verify against `core.MakeReceipt` in go-ethereum for any field we might miss.
+- **`DeriveSha` stack trie**: passing `trie.NewStackTrie(nil)` matches geth's `simulate.go`. Double-check that the v1.14.8 `DeriveSha` signature accepts the StackTrie; if not, fall back to `ethtypes.DeriveSha(list, trie.NewEmpty(...))`.
+- **`Logs: []` vs `Logs: null`** — already handled by `SimCallResult.MarshalJSON`; verify it still applies to the per-receipt logs list.
+- **Tx hash stability**: unsigned tx `Hash()` depends on all fields — don't mutate tx between hashing and block assembly.
+- **Memory cost.** Receipts and synthetic txs are kept in memory for the whole request. Bounded by Phase 8 caps; document in code comments next to the per-call loop.
 
 **Verification.**
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_BloomMatchesLogs` — call emits a `Transfer` log → `logsBloom` contains the expected indexed-topic bits; computed via `ethtypes.LogsBloom(logs)` cross-check.
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_TxRootNonEmpty` — single CALL → `transactionsRoot != EmptyTxsHash`; matches `ethtypes.DeriveSha(Transactions{tx}, …)` over the same synthetic tx that produces `transactions[0]`.
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_ReceiptsRootNonEmpty` — single CALL → `receiptsRoot != EmptyReceiptsHash`.
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_SizeNonZero` — single CALL → `size > 0` and equals `block.Size()`.
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_StateRootZero` — `stateRoot == 0x0…0`; pinned as the deliberate Mezo divergence (would fail loudly if a future change accidentally populated it from base or anywhere else).
+- `x/evm/keeper/grpc_query_test.go`: `TestSimulateV1_BlockEnvelope_EmptyBlockUsesEmptyRoots` — block with zero calls (gap-fill block) → roots are the empty constants and bloom is zero. Sanity counterpart to the above tests.
 - `x/evm/types/simulate_v1_test.go`: `TestSimBlockResult_FullTx_FromPatched` — `returnFullTransactions=true` → tx objects with correct `from`.
 - `x/evm/types/simulate_v1_test.go`: `TestSimBlockResult_HashOnly` — `returnFullTransactions=false` → tx hashes only (existing default behavior).
 - `x/evm/types/simulate_v1_test.go`: existing `TestSimCallResult_MarshalsEmptyLogsAsArray` already covers the `Logs: []` invariant — no change needed, but verify it still passes under the new patch.
 - System: `tests/system/test/SimulateV1_FullTx.test.ts` — assert full tx shape round-trips.
+- System: `tests/system/test/SimulateV1_BlockEnvelope.test.ts` — execute the exact ERC-20 transfer scenario from <https://github.com/mezo-org/mezod/pull/664#issuecomment-4333600375> against a localnode and assert: `logsBloom` non-zero and contains the Transfer topic bits, `transactionsRoot != EmptyTxsHash`, `receiptsRoot != EmptyReceiptsHash`, `size > 0`. The agent implementing this phase MUST resolve every concern raised in that comment except `stateRoot` (which moves to Phase 12 documented divergences).
 
 **DoD.**
-- Response JSON shape matches go-ethereum byte-for-byte on identical inputs (excluding fields tied to EIPs mezod doesn't support).
+- Response JSON shape matches go-ethereum byte-for-byte on identical inputs **except** for the documented Mezo divergences (`stateRoot` zero, fields tied to EIPs mezod doesn't support).
+- All five envelope fields flagged in <https://github.com/mezo-org/mezod/pull/664#issuecomment-4333600375> are addressed: `logsBloom`, `transactionsRoot`, `receiptsRoot`, and `size` are correctly derived; `stateRoot` is documented as a known divergence in Phase 12.
 - All Phase 1-10 tests still green.
 
 ---
@@ -482,12 +517,13 @@ The existing `newSimGetHashFn` closure stays — it covers the `[base, base+N]` 
 1. **EIP-4844 / 4788 / 2935 / 7685 not supported.** Overrides for `BeaconRoot`, `Withdrawals`, blob gas fields are rejected.
 2. **Custom mezo precompiles immovable.** `MovePrecompileTo` for any of the 8 addresses at `0x7b7c…` returns a structured `-32602` error (spec does not assign a dedicated -38xxx code; geth uses the same mapping for "source is not a precompile").
 3. **`GasUsed` honors `MinGasMultiplier`.** Reported gas matches mezod on-chain receipts, not raw EVM gas. Documented for callers comparing across chains.
+4. **`stateRoot` is always the zero hash.** Mezod's `statedb.StateDB` wraps a Cosmos cached multistore and has no Merkle Patricia Trie, so there is no `IntermediateRoot()` to call after a simulated block executes. Geth's reference implementation populates this field from `state.IntermediateRoot()`; mezod cannot replicate that without a chain-level architecture change. Echoing `base.Root` would be misleading (ignores everything the simulation did) and is explicitly rejected. Callers parsing the simulate response MUST NOT treat `stateRoot` as semantically meaningful on mezod. Pinned by `TestSimulateV1_BlockEnvelope_StateRootZero` so any accidental future change surfaces loudly.
 
 ### Part 2 (post-upgrade, Prague + Osaka)
 
 - **Divergence (1) narrows.** EIP-2935 (Phase 14) and EIP-7702 (Phase 15) become supported. **EIP-4844, EIP-4788, EIP-7685, EIP-6110, EIP-7002, EIP-7251 stay rejected permanently** because mezod has no DA layer, no beacon chain (uses CometBFT), and no EL↔CL messaging. Rejection reason text updated to reflect mezo-specific rationale (not "EIP inactive" but "mezod chain model does not include [beacon chain / DA layer / validator queues]").
 - **BLOCKHASH range extends to 8192.** EIP-2935's parent-hash contract serves the 257..8192 canonical range in simulated blocks, lifting the standard 256-block `BLOCKHASH` cap. Zero-hash fallback only for `N > 8192`.
-- **Divergences (2) and (3) unchanged.** Custom precompiles stay immovable; `MinGasMultiplier` gas reporting continues.
+- **Divergences (2), (3), and (4) unchanged.** Custom precompiles stay immovable; `MinGasMultiplier` gas reporting continues; `stateRoot` stays zero.
 
 # Follow-ups / out of scope
 

--- a/rpc/backend/simulate_v1.go
+++ b/rpc/backend/simulate_v1.go
@@ -27,10 +27,6 @@ func (b *Backend) SimulateV1(
 	if blockNrOrHash != nil && (blockNrOrHash.BlockNumber != nil || blockNrOrHash.BlockHash != nil) {
 		effectiveBnh = *blockNrOrHash
 	}
-	bnhBz, err := json.Marshal(effectiveBnh)
-	if err != nil {
-		return nil, err
-	}
 
 	blockNr, err := b.BlockNumberFromTendermint(effectiveBnh)
 	if err != nil {
@@ -39,6 +35,18 @@ func (b *Backend) SimulateV1(
 	header, err := b.TendermintBlockByNumber(blockNr)
 	if err != nil {
 		return nil, fmt.Errorf("header not found: %w", err)
+	}
+
+	// Resolve the sentinel / hash form to a concrete height before
+	// marshaling so the keeper's anchor validator compares the same
+	// numeric value it anchors ctx at. BlockNumber's JSON round-trip
+	// does not preserve sentinels, so emitting them here would
+	// misfire the anchor check.
+	resolvedBn := rpctypes.BlockNumber(header.Block.Height)
+	resolvedBnh := rpctypes.BlockNumberOrHash{BlockNumber: &resolvedBn}
+	bnhBz, err := json.Marshal(resolvedBnh)
+	if err != nil {
+		return nil, err
 	}
 
 	// Use the canonical CometBFT block hash so the envelope's
@@ -68,7 +76,7 @@ func (b *Backend) SimulateV1(
 		BaseBlockHash:     baseBlockHash,
 	}
 
-	ctx := rpctypes.ContextWithHeight(blockNr.Int64())
+	ctx := rpctypes.ContextWithHeight(header.Block.Height)
 	var cancel context.CancelFunc
 	if timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, timeout)

--- a/tests/system/test/SimulateV1_MultiBlock.test.ts
+++ b/tests/system/test/SimulateV1_MultiBlock.test.ts
@@ -1,0 +1,218 @@
+import { expect } from "chai"
+import hre, { ethers } from "hardhat"
+import { SimpleToken } from "../typechain-types/SimpleToken"
+import { getDeployedContract } from "./helpers/contract"
+import btcabi from "../../../precompile/btctoken/abi.json"
+
+// SimulateV1_MultiBlock covers multiple simulated blocks sharing a
+// single StateDB so state mutations from one block are visible in the
+// next, and BLOCKHASH resolves consistently across both the canonical
+// base block and the simulated-sibling range.
+describe("SimulateV1_MultiBlock", function () {
+  const { deployments } = hre
+
+  const BTC_TOKEN_PRECOMPILE = "0x7b7c000000000000000000000000000000000000"
+
+  // Raw bytecode that reads calldata[0..32] as a uint256 height and
+  // returns BLOCKHASH(height) padded to 32 bytes. Installed via
+  // stateOverrides in block 1 so block 3 can call it.
+  //
+  //   PUSH1 0 CALLDATALOAD BLOCKHASH PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+  const BLOCKHASH_READER_BYTECODE = "0x6000354060005260206000F3"
+
+  let simpleToken: SimpleToken
+  let tokenAddr: string
+  let senderAddr: string
+  let recipientAddr: string
+
+  before(async function () {
+    await deployments.fixture(["BridgeOutDelegate"])
+    simpleToken = await getDeployedContract<SimpleToken>("SimpleToken")
+    tokenAddr = await simpleToken.getAddress()
+
+    const [deployer] = await ethers.getSigners()
+    senderAddr = deployer.address
+    recipientAddr = ethers.Wallet.createRandom().address
+  })
+
+  context("state chains across blocks", function () {
+    it("block 1 mint is visible to block 2 balanceOf", async function () {
+      const mintAmount = ethers.parseUnits("777", 18)
+      const mintData = simpleToken.interface.encodeFunctionData("mint", [
+        recipientAddr,
+        mintAmount,
+      ])
+      const balanceOfData = simpleToken.interface.encodeFunctionData(
+        "balanceOf",
+        [recipientAddr],
+      )
+
+      const opts = {
+        blockStateCalls: [
+          {
+            stateOverrides: {
+              [senderAddr]: { balance: ethers.toQuantity(ethers.parseEther("100")) },
+            },
+            calls: [{ from: senderAddr, to: tokenAddr, data: mintData }],
+          },
+          {
+            calls: [{ from: senderAddr, to: tokenAddr, data: balanceOfData }],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      expect(blocks).to.have.lengthOf(2)
+
+      const [block1, block2] = blocks
+      expect(block1.calls[0].status).to.equal("0x1", "block 1 mint must succeed")
+
+      const block2Call = block2.calls[0]
+      expect(block2Call.status).to.equal("0x1", "block 2 balanceOf must succeed")
+      const [balance] = ethers.AbiCoder.defaultAbiCoder().decode(
+        ["uint256"],
+        block2Call.returnData,
+      )
+      expect(balance).to.equal(
+        mintAmount,
+        "block 2 must observe block 1's mint through the shared StateDB",
+      )
+    })
+  })
+
+  context("BLOCKHASH chains canonical + simulated-sibling ranges", function () {
+    it("block 3 resolves BLOCKHASH(base+1) and BLOCKHASH(base+2) to the simulated headers", async function () {
+      const latest = await ethers.provider.getBlock("latest")
+      if (!latest) throw new Error("no latest block")
+      const baseHeight = BigInt(latest.number)
+
+      const readerAddr = ethers.getAddress(
+        "0x" + "c0de".repeat(10),
+      )
+      const heightToCalldata = (h: bigint) =>
+        ethers.zeroPadValue(ethers.toBeHex(h), 32)
+
+      const opts = {
+        blockStateCalls: [
+          {
+            stateOverrides: {
+              [senderAddr]: { balance: ethers.toQuantity(ethers.parseEther("100")) },
+              [readerAddr]: { code: BLOCKHASH_READER_BYTECODE },
+            },
+            calls: [],
+          },
+          { calls: [] },
+          {
+            calls: [
+              {
+                from: senderAddr,
+                to: readerAddr,
+                data: heightToCalldata(baseHeight + 1n),
+              },
+              {
+                from: senderAddr,
+                to: readerAddr,
+                data: heightToCalldata(baseHeight + 2n),
+              },
+            ],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      expect(blocks).to.have.lengthOf(3)
+
+      const block3Calls = blocks[2].calls
+      expect(block3Calls).to.have.lengthOf(2)
+
+      // Both reads succeed.
+      expect(block3Calls[0].status).to.equal("0x1")
+      expect(block3Calls[1].status).to.equal("0x1")
+
+      // Each simulated-sibling BLOCKHASH must match the corresponding
+      // block envelope's `hash` field — a simulated block N can observe
+      // a past simulated sibling M's hash via BLOCKHASH, and the
+      // response envelope surfaces the same hash.
+      expect(block3Calls[0].returnData.toLowerCase()).to.equal(
+        blocks[0].hash.toLowerCase(),
+        "BLOCKHASH(base+1) must match block[0].hash",
+      )
+      expect(block3Calls[1].returnData.toLowerCase()).to.equal(
+        blocks[1].hash.toLowerCase(),
+        "BLOCKHASH(base+2) must match block[1].hash",
+      )
+    })
+  })
+
+  // Custom Mezo precompiles (btctoken, mezotoken, …) write through the
+  // Cosmos bank keeper, not the EVM journal — their mutations ride in
+  // the StateDB's cached Cosmos context, which must survive the block
+  // boundary. balance stateOverrides only touch the EVM state object
+  // and do not propagate to bankKeeper, so this case leans on the
+  // localnode dev0 signer's real pre-funded BTC balance.
+  context("custom Mezo precompile state chains across blocks", function () {
+    it("block 1 btctoken.transfer is visible to block 2 btctoken.balanceOf", async function () {
+      const btcToken: any = new hre.ethers.Contract(
+        BTC_TOKEN_PRECOMPILE,
+        btcabi,
+        ethers.provider,
+      )
+      const transferAmount = ethers.parseEther("0.5")
+
+      const transferData = btcToken.interface.encodeFunctionData("transfer", [
+        recipientAddr,
+        transferAmount,
+      ])
+      const balanceOfData = btcToken.interface.encodeFunctionData("balanceOf", [
+        recipientAddr,
+      ])
+
+      const opts = {
+        blockStateCalls: [
+          {
+            calls: [
+              { from: senderAddr, to: BTC_TOKEN_PRECOMPILE, data: transferData },
+            ],
+          },
+          {
+            calls: [
+              { from: senderAddr, to: BTC_TOKEN_PRECOMPILE, data: balanceOfData },
+            ],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      expect(blocks).to.have.lengthOf(2)
+
+      const [block1, block2] = blocks
+      expect(block1.calls[0].status).to.equal(
+        "0x1",
+        "block 1 btctoken.transfer must succeed",
+      )
+
+      const block2Call = block2.calls[0]
+      expect(block2Call.status).to.equal(
+        "0x1",
+        "block 2 btctoken.balanceOf must succeed",
+      )
+      const [balance] = ethers.AbiCoder.defaultAbiCoder().decode(
+        ["uint256"],
+        block2Call.returnData,
+      )
+      expect(balance).to.equal(
+        transferAmount,
+        "block 2 must observe block 1's btctoken.transfer through the StateDB's cached Cosmos context",
+      )
+    })
+  })
+})

--- a/tests/system/test/SimulateV1_MultiCall.test.ts
+++ b/tests/system/test/SimulateV1_MultiCall.test.ts
@@ -1,0 +1,180 @@
+import { expect } from "chai"
+import hre, { ethers } from "hardhat"
+import { SimpleToken } from "../typechain-types/SimpleToken"
+import { getDeployedContract } from "./helpers/contract"
+import btcabi from "../../../precompile/btctoken/abi.json"
+
+// SimulateV1_MultiCall covers multiple calls in a single simulated
+// block against one shared StateDB. The contract state written by one
+// call must be visible to the next, block-gas-limit enforcement must be
+// cumulative, and a revert in one call must not leak state to the next.
+describe("SimulateV1_MultiCall", function () {
+  const { deployments } = hre
+
+  const BTC_TOKEN_PRECOMPILE = "0x7b7c000000000000000000000000000000000000"
+
+  const MINT_AMOUNT = ethers.parseUnits("1000", 18)
+  const TRANSFER_AMOUNT = ethers.parseUnits("500", 18)
+
+  let simpleToken: SimpleToken
+  let tokenAddr: string
+  let senderAddr: string
+  let recipientAddr: string
+
+  before(async function () {
+    await deployments.fixture(["BridgeOutDelegate"])
+    simpleToken = await getDeployedContract<SimpleToken>("SimpleToken")
+    tokenAddr = await simpleToken.getAddress()
+
+    const [deployer] = await ethers.getSigners()
+    senderAddr = deployer.address
+    recipientAddr = ethers.Wallet.createRandom().address
+  })
+
+  context("state chains across calls within a block", function () {
+    it("mint → transfer → balanceOf surfaces the transferred amount", async function () {
+      const mintData = simpleToken.interface.encodeFunctionData("mint", [
+        senderAddr,
+        MINT_AMOUNT,
+      ])
+      const transferData = simpleToken.interface.encodeFunctionData(
+        "transfer",
+        [recipientAddr, TRANSFER_AMOUNT],
+      )
+      const balanceOfData = simpleToken.interface.encodeFunctionData(
+        "balanceOf",
+        [recipientAddr],
+      )
+
+      const opts = {
+        blockStateCalls: [
+          {
+            stateOverrides: {
+              [senderAddr]: { balance: ethers.toQuantity(ethers.parseEther("100")) },
+            },
+            calls: [
+              { from: senderAddr, to: tokenAddr, data: mintData },
+              { from: senderAddr, to: tokenAddr, data: transferData },
+              { from: senderAddr, to: tokenAddr, data: balanceOfData },
+            ],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      expect(blocks).to.have.lengthOf(1)
+      const calls = blocks[0].calls
+      expect(calls).to.have.lengthOf(3)
+
+      // All three calls succeed.
+      expect(calls[0].status).to.equal("0x1", "mint must succeed")
+      expect(calls[1].status).to.equal("0x1", "transfer must succeed")
+      expect(calls[2].status).to.equal("0x1", "balanceOf must succeed")
+
+      // Call 3's return data decodes to the transferred amount — proves
+      // both prior calls' state mutations reached the balanceOf read.
+      const [balance] = ethers.AbiCoder.defaultAbiCoder().decode(
+        ["uint256"],
+        calls[2].returnData,
+      )
+      expect(balance).to.equal(TRANSFER_AMOUNT)
+    })
+  })
+
+  context("cumulative block gas limit enforced across calls", function () {
+    it("over-budget call is rejected with -38015 while preceding calls stand", async function () {
+      const recipient = ethers.Wallet.createRandom().address
+      const opts = {
+        blockStateCalls: [
+          {
+            blockOverrides: { gasLimit: ethers.toQuantity(50_000n) },
+            stateOverrides: {
+              [senderAddr]: { balance: ethers.toQuantity(ethers.parseEther("100")) },
+            },
+            calls: [
+              {
+                from: senderAddr,
+                to: recipient,
+                value: ethers.toQuantity(1n),
+              },
+              {
+                from: senderAddr,
+                to: recipient,
+                value: ethers.toQuantity(1n),
+                gas: ethers.toQuantity(30_000n),
+              },
+            ],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      const calls = blocks[0].calls
+      expect(calls).to.have.lengthOf(2)
+
+      expect(calls[0].status).to.equal("0x1")
+
+      expect(calls[1].error).to.exist
+      expect(calls[1].error.code).to.equal(-38015)
+    })
+  })
+
+  // Custom Mezo precompiles (btctoken, mezotoken, …) write through the
+  // Cosmos bank keeper, not the EVM journal — their mutations ride in
+  // the StateDB's cached Cosmos context and must survive call
+  // boundaries. balance stateOverrides only touch the EVM state object
+  // and do not propagate to bankKeeper, so this case leans on the
+  // localnode dev0 signer's real pre-funded BTC balance.
+  context("custom Mezo precompile state chains across calls", function () {
+    it("btctoken.transfer → btctoken.balanceOf surfaces the transferred amount", async function () {
+      const btcToken: any = new hre.ethers.Contract(
+        BTC_TOKEN_PRECOMPILE,
+        btcabi,
+        ethers.provider,
+      )
+      const transferAmount = ethers.parseEther("0.5")
+
+      const transferData = btcToken.interface.encodeFunctionData("transfer", [
+        recipientAddr,
+        transferAmount,
+      ])
+      const balanceOfData = btcToken.interface.encodeFunctionData("balanceOf", [
+        recipientAddr,
+      ])
+
+      const opts = {
+        blockStateCalls: [
+          {
+            calls: [
+              { from: senderAddr, to: BTC_TOKEN_PRECOMPILE, data: transferData },
+              { from: senderAddr, to: BTC_TOKEN_PRECOMPILE, data: balanceOfData },
+            ],
+          },
+        ],
+      }
+
+      const blocks: any[] = await ethers.provider.send(
+        "eth_simulateV1",
+        [opts, "latest"],
+      )
+      expect(blocks).to.have.lengthOf(1)
+      const calls = blocks[0].calls
+      expect(calls).to.have.lengthOf(2)
+
+      expect(calls[0].status).to.equal("0x1", "btctoken.transfer must succeed")
+      expect(calls[1].status).to.equal("0x1", "btctoken.balanceOf must succeed")
+
+      const [balance] = ethers.AbiCoder.defaultAbiCoder().decode(
+        ["uint256"],
+        calls[1].returnData,
+      )
+      expect(balance).to.equal(transferAmount)
+    })
+  })
+})

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	ethparams "github.com/ethereum/go-ethereum/params"
 
+	rpctypes "github.com/mezo-org/mezod/rpc/types"
 	mezotypes "github.com/mezo-org/mezod/types"
 	"github.com/mezo-org/mezod/x/evm/statedb"
 	"github.com/mezo-org/mezod/x/evm/types"
@@ -723,6 +724,17 @@ func (k Keeper) SimulateV1(c context.Context, req *types.SimulateV1Request) (*ty
 
 	ctx := sdk.UnwrapSDKContext(c)
 
+	// Defense-in-depth for callers reaching the keeper gRPC directly
+	// (bypassing rpc/backend, which ordinarily anchors ctx at the
+	// resolved base height via rpctypes.ContextWithHeight).
+	// rpc/backend.Backend.SimulateV1 (rpc/backend/simulate_v1.go)
+	// always populates BlockNumberOrHash, defaulting to "latest" when
+	// the caller omits it; an empty field at this point means we're on
+	// a direct-gRPC path and the ctx is authoritative.
+	if err := validateSimulateV1Anchor(ctx, req.BlockNumberOrHash); err != nil {
+		return simulateV1ErrResponse(err)
+	}
+
 	chainID, err := getChainID(ctx, req.ChainId)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -796,6 +808,46 @@ func getChainID(ctx sdk.Context, chainID int64) (*big.Int, error) {
 	return big.NewInt(chainID), nil
 }
 
+// validateSimulateV1Anchor performs a minimal consistency check between
+// the request's BlockNumberOrHash field and the SDK context's block
+// height. The backend (rpc/backend/simulate_v1.go) already resolves the
+// field into a concrete height and anchors ctx via
+// rpctypes.ContextWithHeight, so for the normal call path this is a
+// no-op. Direct gRPC callers that desynchronize the two surfaces hit
+// a spec-conformant -32602 instead of silently simulating against the
+// wrong base.
+//
+// Sentinel BlockNumber values (Latest / Earliest / Pending / Finalized
+// / Safe) and hash-only addressing skip the numeric comparison — the
+// backend's resolution is trusted for those cases.
+func validateSimulateV1Anchor(ctx sdk.Context, bnhBz []byte) error {
+	if len(bnhBz) == 0 {
+		return nil
+	}
+	var bnh rpctypes.BlockNumberOrHash
+	if err := json.Unmarshal(bnhBz, &bnh); err != nil {
+		return types.NewSimInvalidParams(fmt.Sprintf(
+			"simulate: malformed blockNumberOrHash: %s", err.Error(),
+		))
+	}
+	if bnh.BlockNumber == nil {
+		return nil
+	}
+	requested := bnh.BlockNumber.Int64()
+	if requested < 0 {
+		// Sentinel values (latest, earliest, pending, finalized, safe)
+		// are resolved in the backend; the ctx height is authoritative.
+		return nil
+	}
+	if requested != ctx.BlockHeight() {
+		return types.NewSimInvalidParams(fmt.Sprintf(
+			"simulate: blockNumberOrHash (%d) does not match anchored context height (%d)",
+			requested, ctx.BlockHeight(),
+		))
+	}
+	return nil
+}
+
 // simulateBaseGasLimit reads the consensus block gas limit via the
 // consensus keeper. baseapp.CreateQueryContext does not populate
 // ctx.ConsensusParams or attach a BlockGasMeter for query-side calls,
@@ -823,9 +875,12 @@ func (k Keeper) simulateBaseGasLimit(ctx sdk.Context) (uint64, error) {
 // baseHeaderFromContext synthesizes the execution-api base header from
 // the SDK context that the gRPC call was anchored at. The returned
 // header only populates the fields the simulate driver consumes
-// (Number, Time, GasLimit, BaseFee, Difficulty, Coinbase). Multi-block
-// support will swap this for a real block fetch so BLOCKHASH resolution
-// lines up with canonical chain history.
+// (Number, Time, GasLimit, BaseFee, Difficulty, Coinbase). The ctx has
+// already been anchored at the requested base height by the rpc/backend
+// layer (via rpctypes.ContextWithHeight); newSimGetHashFn delegates
+// canonical-range BLOCKHASH resolution to k.GetHashFn which reads the
+// same ctx, so all three sources (ctx, base header fields, BLOCKHASH
+// for base.Number) stay consistent.
 func baseHeaderFromContext(ctx sdk.Context, cfg *statedb.EVMConfig, gasLimit uint64) *ethtypes.Header {
 	return &ethtypes.Header{
 		Number:     big.NewInt(ctx.BlockHeight()),

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -1727,3 +1727,828 @@ func (suite *KeeperTestSuite) TestSimulateV1_UnsupportedOverrideRejected() {
 	suite.Require().Contains(resp.Error.Message, "BeaconRoot")
 	suite.Require().Empty(resp.Result)
 }
+
+// -----------------------------------------------------------------------------
+// SimulateV1 — multi-call / multi-block / BLOCKHASH end-to-end tests
+// -----------------------------------------------------------------------------
+
+// branchingSlot0Bytecode is a tiny in-test contract whose behavior forks
+// on CALLDATASIZE:
+//   - empty calldata → SLOAD slot 0, RETURN 32-byte value.
+//   - 32-byte calldata → SSTORE slot 0 = calldata, STOP.
+//
+// Assembly trace (offsets correspond to the hex below):
+//
+//	@00  CALLDATASIZE         stack=[size]
+//	@01  ISZERO               stack=[size==0]
+//	@02  PUSH1 0x0C           stack=[cond, 12]
+//	@04  JUMPI                jump to 12 iff calldata empty
+//	@05  PUSH1 0x00           write path: offset for CALLDATALOAD
+//	@07  CALLDATALOAD         stack=[value]
+//	@08  PUSH1 0x00           stack=[value, slot=0]
+//	@0A  SSTORE               storage[0]=value
+//	@0B  STOP
+//	@0C  JUMPDEST             read path
+//	@0D  PUSH1 0x00           slot
+//	@0F  SLOAD                stack=[value]
+//	@10  PUSH1 0x00           mem offset
+//	@12  MSTORE               memory[0..32]=value
+//	@13  PUSH1 0x20           size
+//	@15  PUSH1 0x00           offset
+//	@17  RETURN
+const branchingSlot0Bytecode = "0x3615600C57600035600055005B60005460005260206000F3"
+
+// blockhashReaderBytecode reads calldata[0:32] as a uint256 height,
+// returns BLOCKHASH(height) as 32 bytes.
+//
+//	PUSH1 0 CALLDATALOAD BLOCKHASH PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+const blockhashReaderBytecode = "0x6000354060005260206000F3"
+
+// revertAfterWriteSlot1Bytecode branches on CALLDATASIZE so the same
+// deployed contract covers both sides of the revert-isolation assertion:
+//   - non-empty calldata → SSTORE slot 1 = 42, then REVERT(0,0).
+//   - empty calldata     → SLOAD slot 1, RETURN 32-byte value.
+//
+// Having call 1 (writer+revert) and call 2 (reader) hit the same
+// address makes the test diagnostic: if the revert leaked, call 2
+// would return 42; with correct isolation it returns 0.
+//
+//	@00  CALLDATASIZE
+//	@01  ISZERO
+//	@02  PUSH1 0x0F
+//	@04  JUMPI                → jump to reader on empty calldata
+//	@05  PUSH1 0x2A           writer path: value 42
+//	@07  PUSH1 0x01           slot 1
+//	@09  SSTORE
+//	@0A  PUSH1 0x00
+//	@0C  PUSH1 0x00
+//	@0E  REVERT
+//	@0F  JUMPDEST             reader path
+//	@10  PUSH1 0x01
+//	@12  SLOAD
+//	@13  PUSH1 0x00
+//	@15  MSTORE
+//	@16  PUSH1 0x20
+//	@18  PUSH1 0x00
+//	@1A  RETURN
+const revertAfterWriteSlot1Bytecode = "0x3615600F57602A60015560006000FD5B60015460005260206000F3"
+
+// emptyCodeDeployer deploys a contract whose runtime code is zero bytes.
+// Per EIP-161 (Spurious Dragon) the newly-created account is still
+// initialized with nonce=1, which is what makes the deployed address
+// distinct from the sender's next CREATE target. Used by the
+// nonce-auto-increment test: two CREATEs from the same sender must
+// succeed at distinct addresses, which only happens if the sender's
+// nonce advances between calls (otherwise the second CREATE collides
+// at the first address).
+//
+//	PUSH1 0x00 PUSH1 0x00 RETURN
+const emptyCodeDeployer = "0x60006000F3"
+
+// TestSimulateV1_MultiCall_StateChainsAcrossCalls — call 1 writes slot 0
+// via the branching-slot-0 contract; call 2 reads slot 0 and must see
+// the written value. Proves the shared StateDB carries storage state
+// from one call to the next.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_StateChainsAcrossCalls() {
+	suite.SetupTest()
+
+	sender := suite.address
+	contract := common.HexToAddress("0xaaaa000000000000000000000000000000000100")
+
+	// 32-byte calldata for the write call encoding the value 255 in slot 0.
+	writeData := make([]byte, 32)
+	writeData[31] = 0xFF
+
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender:   {"balance": balance},
+				contract: {"code": branchingSlot0Bytecode},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &contract, Input: (*hexutil.Bytes)(&writeData)},
+				{From: &sender, To: &contract},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"], "call 1 should succeed")
+	suite.Require().Equal("0x1", calls[1].(map[string]interface{})["status"], "call 2 should succeed")
+
+	// Call 2's returnData must be the 32-byte encoding of 255 that call 1
+	// wrote — confirms the shared StateDB propagated storage.
+	readBack := calls[1].(map[string]interface{})["returnData"].(string)
+	suite.Require().Equal(
+		"0x00000000000000000000000000000000000000000000000000000000000000ff",
+		readBack,
+	)
+}
+
+// TestSimulateV1_MultiCall_RevertDoesNotLeak — call 1 writes slot 1 and
+// reverts; call 2 reads slot 1 on the SAME contract and must see zero.
+// Under a (hypothetical) bug where the per-call EVM revert failed to
+// roll the shared StateDB back, call 2 would return 42.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_RevertDoesNotLeak() {
+	suite.SetupTest()
+
+	sender := suite.address
+	contract := common.HexToAddress("0xaaaa000000000000000000000000000000000200")
+	writeCalldata := []byte{0x01} // any non-empty calldata takes the writer branch
+
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender:   {"balance": balance},
+				contract: {"code": revertAfterWriteSlot1Bytecode},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &contract, Input: (*hexutil.Bytes)(&writeCalldata)},
+				{From: &sender, To: &contract},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	call1 := calls[0].(map[string]interface{})
+	suite.Require().Equal("0x0", call1["status"])
+	suite.Require().NotNil(call1["error"])
+	suite.Require().EqualValues(float64(types.SimErrCodeReverted), call1["error"].(map[string]interface{})["code"])
+
+	call2 := calls[1].(map[string]interface{})
+	suite.Require().Equal("0x1", call2["status"])
+	suite.Require().Equal(
+		"0x0000000000000000000000000000000000000000000000000000000000000000",
+		call2["returnData"],
+		"reader on the same contract must observe slot 1 = 0 — the SSTORE in call 1 must have rolled back with the revert",
+	)
+}
+
+// TestSimulateV1_MultiCall_BlockGasLimit — three calls against a tight
+// block gas limit. First two each consume ~21k for a plain value
+// transfer; third requests gas over the remaining budget and surfaces
+// -38015 as a per-call error while the preceding calls still succeed.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_BlockGasLimit() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000001")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+	tightGasLimit := hexutil.Uint64(50_000)
+	overBudgetGas := hexutil.Uint64(30_000)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"blockOverrides": map[string]interface{}{
+				"gasLimit": tightGasLimit,
+			},
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &recipient, Value: value},
+				// This call's requested gas (30k) is larger than the
+				// remaining budget (50k - 21k = 29k) — expect -38015.
+				{From: &sender, To: &recipient, Value: value, Gas: &overBudgetGas},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	// Call 1 succeeds using the default (remaining budget) gas.
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"])
+
+	// Call 2 is rejected before execution: per-call Error with -38015,
+	// no status (defaults to 0).
+	call2 := calls[1].(map[string]interface{})
+	suite.Require().NotNil(call2["error"], "over-budget call must carry a SimError")
+	suite.Require().EqualValues(
+		float64(types.SimErrCodeBlockGasLimitReached),
+		call2["error"].(map[string]interface{})["code"],
+	)
+}
+
+// TestSimulateV1_MultiCall_NonceAutoIncrement — two CREATE calls from
+// the same sender with no explicit nonce. Both must succeed: if the
+// nonce didn't advance between calls, the second CREATE would resolve
+// to the same computed address as the first and fail with an address-
+// collision error.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_NonceAutoIncrement() {
+	suite.SetupTest()
+
+	sender := suite.address
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	initCode := hexutil.MustDecode(emptyCodeDeployer)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, Input: (*hexutil.Bytes)(&initCode)},
+				{From: &sender, Input: (*hexutil.Bytes)(&initCode)},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"],
+		"first CREATE must succeed")
+	suite.Require().Equal("0x1", calls[1].(map[string]interface{})["status"],
+		"second CREATE must succeed — fails with address collision if nonce stayed at 0")
+}
+
+// emptyLogDeployer is init code that emits an empty LOG0 and returns
+// zero-byte runtime. The emitted log's Address field is the deployed
+// contract's own address (set by the EVM as evm.Address during init
+// code execution), which lets a test observe which nonce the CREATE
+// consumed without a follow-up call to the predicted address.
+//
+// Bytecode (10 bytes):
+//
+//	@00  PUSH1 0x00   ; log data size = 0
+//	@02  PUSH1 0x00   ; log data offset = 0
+//	@04  LOG0
+//	@05  PUSH1 0x00   ; runtime size = 0
+//	@07  PUSH1 0x00   ; runtime offset = 0
+//	@09  RETURN
+const emptyLogDeployer = "0x60006000A060006000F3"
+
+// TestSimulateV1_MultiCall_CallNonceAdvances — two value transfers
+// from the same sender with no explicit nonce, identical in every
+// other field that feeds computeSimTxHash (Gas pinned to a fixed
+// value so the per-call default gas budget — which would otherwise
+// shrink between calls and accidentally diverge the hashes for an
+// unrelated reason — does not vary). The driver must bump the
+// StateDB nonce after every successful non-CREATE call; without
+// that bump both calls would default to the same nonce, the
+// synthesized tx hashes (computeSimTxHash, which folds nonce into
+// the LegacyTx hash) would collide, and the assembled block would
+// carry duplicate entries in its `transactions` array.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_CallNonceAdvances() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000010")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+	pinnedGas := hexutil.Uint64(30_000)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &recipient, Value: value, Gas: &pinnedGas},
+				{From: &sender, To: &recipient, Value: value, Gas: &pinnedGas},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"], "first CALL must succeed")
+	suite.Require().Equal("0x1", calls[1].(map[string]interface{})["status"], "second CALL must succeed")
+
+	txs := results[0]["transactions"].([]interface{})
+	suite.Require().Len(txs, 2)
+	suite.Require().NotEqual(txs[0], txs[1],
+		"synthetic tx hashes must differ — proves the StateDB nonce advanced between CALLs")
+}
+
+// TestSimulateV1_MultiCall_CallThenCreateAddressUsesPostCallNonce —
+// one CALL followed by one CREATE from the same sender, no explicit
+// nonces. The CREATE deploys at addr(sender, 1) only if the prior
+// CALL advanced the StateDB nonce; without the post-CALL bump it
+// would land at addr(sender, 0). The init code emits an empty LOG0
+// so the deployed contract's own address surfaces in the response
+// via Log.Address — independent of the synthetic tx-hash signal.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_CallThenCreateAddressUsesPostCallNonce() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000020")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+	initCode := hexutil.MustDecode(emptyLogDeployer)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &recipient, Value: value},
+				{From: &sender, Input: (*hexutil.Bytes)(&initCode)},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"], "CALL must succeed")
+	suite.Require().Equal("0x1", calls[1].(map[string]interface{})["status"], "CREATE must succeed")
+
+	createLogs := calls[1].(map[string]interface{})["logs"].([]interface{})
+	suite.Require().Len(createLogs, 1, "CREATE must emit one log")
+
+	gotAddr := common.HexToAddress(createLogs[0].(map[string]interface{})["address"].(string))
+	expectedAddr := crypto.CreateAddress(sender, 1)
+	suite.Require().Equal(expectedAddr, gotAddr,
+		"CREATE deployed at addr(sender, 1); the prior CALL must have advanced the StateDB nonce — "+
+			"would be addr(sender, 0) if the bump didn't fire")
+}
+
+// TestSimulateV1_MultiBlock_StateChains — block 1 writes slot 0 on a
+// contract; block 2 reads slot 0 on the same contract and sees the
+// block-1 write. Confirms both the shared StateDB and the per-block
+// finalize step preserve state across block boundaries.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiBlock_StateChains() {
+	suite.SetupTest()
+
+	sender := suite.address
+	contract := common.HexToAddress("0xaaaa000000000000000000000000000000000300")
+	writeData := make([]byte, 32)
+	writeData[31] = 0x7A // arbitrary non-zero
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{
+			{
+				"stateOverrides": map[common.Address]map[string]interface{}{
+					sender:   {"balance": balance},
+					contract: {"code": branchingSlot0Bytecode},
+				},
+				"calls": []types.TransactionArgs{
+					{From: &sender, To: &contract, Input: (*hexutil.Bytes)(&writeData)},
+				},
+			},
+			{
+				"calls": []types.TransactionArgs{
+					{From: &sender, To: &contract},
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 2, "two blocks in the response")
+
+	block0Calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(block0Calls, 1)
+	suite.Require().Equal("0x1", block0Calls[0].(map[string]interface{})["status"])
+
+	block1Calls := results[1]["calls"].([]interface{})
+	suite.Require().Len(block1Calls, 1)
+	block1Call := block1Calls[0].(map[string]interface{})
+	suite.Require().Equal("0x1", block1Call["status"])
+	suite.Require().Equal(
+		"0x000000000000000000000000000000000000000000000000000000000000007a",
+		block1Call["returnData"],
+		"block 2 read must observe block 1 write",
+	)
+}
+
+// TestSimulateV1_MultiBlock_ChainLinkage — block 3 calls a BLOCKHASH
+// reader with three heights (base.Number, base+1, base+2). The canonical
+// hash must match `suite.ctx.HeaderHash()` for base.Number; the
+// simulated-sibling hashes must match the in-memory headers for
+// base+1 / base+2 as reported by the response envelope.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiBlock_ChainLinkage() {
+	suite.SetupTest()
+
+	sender := suite.address
+	reader := common.HexToAddress("0xaaaa000000000000000000000000000000000400")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+
+	baseHeight := suite.ctx.BlockHeight()
+	heights := []int64{baseHeight, baseHeight + 1, baseHeight + 2}
+
+	callsBlock3 := make([]types.TransactionArgs, 0, len(heights))
+	for _, h := range heights {
+		hx := h
+		buf := make([]byte, 32)
+		big.NewInt(hx).FillBytes(buf)
+		calldata := make([]byte, 32)
+		copy(calldata, buf)
+		callsBlock3 = append(callsBlock3, types.TransactionArgs{
+			From: &sender, To: &reader, Input: (*hexutil.Bytes)(&calldata),
+		})
+	}
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{
+			{ // block 1: install reader code + fund sender
+				"stateOverrides": map[common.Address]map[string]interface{}{
+					sender: {"balance": balance},
+					reader: {"code": blockhashReaderBytecode},
+				},
+				"calls": []types.TransactionArgs{},
+			},
+			{ // block 2: no-op
+				"calls": []types.TransactionArgs{},
+			},
+			{ // block 3: BLOCKHASH reads
+				"calls": callsBlock3,
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 3)
+
+	block3 := results[2]
+	block3Calls := block3["calls"].([]interface{})
+	suite.Require().Len(block3Calls, 3, "three BLOCKHASH calls in block 3")
+
+	// Call 0 asks for BLOCKHASH(base.Number) — newSimGetHashFn delegates
+	// to k.GetHashFn(ctx), which covers ctx.HeaderHash AND the
+	// tendermint-header-recompute fallback. Compute the expected value
+	// with the same function so the test stays robust to how the test
+	// ctx populates its header (ctx.HeaderHash may be empty in
+	// suite-level contexts).
+	expectedBase := "0x" + common.Bytes2Hex(
+		suite.app.EvmKeeper.GetHashFn(suite.ctx)(uint64(baseHeight)).Bytes(), //nolint:gosec // baseHeight >= 0 by construction
+	)
+	suite.Require().Equal(expectedBase, block3Calls[0].(map[string]interface{})["returnData"],
+		"BLOCKHASH(base.Number) must match k.GetHashFn(ctx)(base.Number)")
+
+	// Calls 1 and 2 ask for simulated-sibling hashes (base+1, base+2).
+	// These must match the hashes reported in the block envelope.
+	expectedHash1 := results[0]["hash"].(string)
+	expectedHash2 := results[1]["hash"].(string)
+	suite.Require().Equal(expectedHash1, block3Calls[1].(map[string]interface{})["returnData"],
+		"BLOCKHASH(base+1) must match block 1's envelope hash")
+	suite.Require().Equal(expectedHash2, block3Calls[2].(map[string]interface{})["returnData"],
+		"BLOCKHASH(base+2) must match block 2's envelope hash")
+}
+
+// TestSimulateV1_MultiBlock_PrecompileStateChains is the load-bearing
+// regression for the shared-StateDB design: it exercises a *custom
+// precompile* whose Cosmos-side writes live in the StateDB's cached
+// ctx — the layer that a naive per-block StateDB would silently drop.
+// Block 1 calls btctoken.transfer (routes through bankKeeper, mutates
+// s.cachedCtx); block 2 calls btctoken.balanceOf and must observe the
+// transferred amount. If s.cachedCtx were dropped between blocks,
+// balanceOf would return zero and the test would fail loud.
+//
+// This complements the pure-EVM TestSimulateV1_MultiBlock_StateChains
+// which only covers the EVM journal half of the shared StateDB. Both
+// halves must survive the block boundary for the design to hold.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiBlock_PrecompileStateChains() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000077")
+	btcToken := common.HexToAddress(types.BTCTokenPrecompileAddress)
+
+	// Fund sender via bank directly — StateDB balance overrides only
+	// touch the EVM state object and do not propagate to bankKeeper,
+	// which is what btctoken.transfer actually reads.
+	initialBalance := sdkmath.NewInt(1_000_000_000_000_000_000)
+	transferAmount := big.NewInt(777_000_000_000_000_000)
+	coin := sdk.NewCoin(types.DefaultEVMDenom, initialBalance)
+	suite.Require().NoError(suite.app.BankKeeper.MintCoins(
+		suite.ctx, types.ModuleName, sdk.NewCoins(coin)))
+	suite.Require().NoError(suite.app.BankKeeper.SendCoinsFromModuleToAccount(
+		suite.ctx, types.ModuleName, sender.Bytes(), sdk.NewCoins(coin)))
+
+	// ABI: transfer(address,uint256) — selector 0xa9059cbb; balanceOf(address)
+	// — selector 0x70a08231. Encoded by hand to avoid dragging ABI binding
+	// generation into keeper tests.
+	transferSelector := []byte{0xa9, 0x05, 0x9c, 0xbb}
+	balanceOfSelector := []byte{0x70, 0xa0, 0x82, 0x31}
+
+	padAddr := func(addr common.Address) []byte {
+		buf := make([]byte, 32)
+		copy(buf[12:], addr.Bytes())
+		return buf
+	}
+	padUint := func(v *big.Int) []byte {
+		buf := make([]byte, 32)
+		v.FillBytes(buf)
+		return buf
+	}
+
+	transferData := append([]byte{}, transferSelector...)
+	transferData = append(transferData, padAddr(recipient)...)
+	transferData = append(transferData, padUint(transferAmount)...)
+
+	balanceOfData := append([]byte{}, balanceOfSelector...)
+	balanceOfData = append(balanceOfData, padAddr(recipient)...)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{
+			{
+				"calls": []types.TransactionArgs{
+					{From: &sender, To: &btcToken, Input: (*hexutil.Bytes)(&transferData)},
+				},
+			},
+			{
+				"calls": []types.TransactionArgs{
+					{From: &sender, To: &btcToken, Input: (*hexutil.Bytes)(&balanceOfData)},
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 2)
+
+	block1Calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(block1Calls, 1)
+	suite.Require().Equal("0x1", block1Calls[0].(map[string]interface{})["status"],
+		"block 1 btctoken.transfer must succeed")
+
+	block2Calls := results[1]["calls"].([]interface{})
+	suite.Require().Len(block2Calls, 1)
+	block2Call := block2Calls[0].(map[string]interface{})
+	suite.Require().Equal("0x1", block2Call["status"],
+		"block 2 btctoken.balanceOf must succeed")
+
+	// Decode the 32-byte returnData and verify it matches transferAmount.
+	// If s.cachedCtx were dropped between blocks, bankKeeper would read
+	// canonical state (pre-transfer) and return 0 here.
+	returnData := block2Call["returnData"].(string)
+	got := new(big.Int)
+	got.SetString(returnData[2:], 16)
+	suite.Require().Equal(0, got.Cmp(transferAmount),
+		"block 2 balanceOf must return transferAmount; got %s (precompile cachedCtx did not survive block boundary)", got.String())
+}
+
+// TestSimulateV1_MultiCall_ImplicitGasAfterExhaustedBudget — two calls
+// against a budget the first call fully consumes. The second call omits
+// args.Gas, so the implicit-gas resolver must surface -38015 as a
+// per-call error instead of letting applyMessageWithConfig fail the
+// request with gRPC Internal and wipe the first call's success.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_ImplicitGasAfterExhaustedBudget() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000201")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+
+	tightGasLimit := hexutil.Uint64(21_000)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"blockOverrides": map[string]interface{}{
+				"gasLimit": tightGasLimit,
+			},
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &recipient, Value: value},
+				// Omit Gas — implicit. After call 1 consumes all 21k,
+				// remaining=0; preflight must emit -38015.
+				{From: &sender, To: &recipient, Value: value},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err, "the request must NOT collapse to gRPC Internal")
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	suite.Require().Equal("0x1", calls[0].(map[string]interface{})["status"],
+		"call 1 must succeed and survive in the response envelope")
+
+	call2 := calls[1].(map[string]interface{})
+	suite.Require().NotNil(call2["error"], "call 2 must carry a per-call SimError")
+	suite.Require().EqualValues(
+		float64(types.SimErrCodeBlockGasLimitReached),
+		call2["error"].(map[string]interface{})["code"],
+	)
+}
+
+// TestSimulateV1_ExplicitGasBelowIntrinsic — a single call with explicit
+// args.Gas below the call's actual intrinsic-gas requirement. Pre-fix
+// this collapsed to gRPC Internal; the driver-loop catch on
+// core.ErrIntrinsicGas now surfaces it as a per-call -38013.
+func (suite *KeeperTestSuite) TestSimulateV1_ExplicitGasBelowIntrinsic() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000202")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+	tooLowGas := hexutil.Uint64(20_999) // intrinsic-gas baseline is 21000
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, To: &recipient, Value: value, Gas: &tooLowGas},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err, "the request must NOT collapse to gRPC Internal")
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 1)
+
+	call := calls[0].(map[string]interface{})
+	suite.Require().NotNil(call["error"], "below-intrinsic call must carry a per-call SimError")
+	suite.Require().EqualValues(
+		float64(types.SimErrCodeIntrinsicGas),
+		call["error"].(map[string]interface{})["code"],
+	)
+}
+
+// TestSimulateV1_MultiBlock_ParentHashChainCoherent — three blocks, each
+// with one successful transfer, each with a non-trivial cumulative
+// gasUsed. The response envelope's `block[i+1].parentHash` must equal
+// `block[i].hash`, and `block[0].parentHash` must equal the request's
+// BaseBlockHash.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiBlock_ParentHashChainCoherent() {
+	suite.SetupTest()
+
+	sender := suite.address
+	recipient := common.HexToAddress("0xbbbb000000000000000000000000000000000200")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	value := (*hexutil.Big)(big.NewInt(1))
+
+	transfer := types.TransactionArgs{From: &sender, To: &recipient, Value: value}
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{
+			{
+				"stateOverrides": map[common.Address]map[string]interface{}{
+					sender: {"balance": balance},
+				},
+				"calls": []types.TransactionArgs{transfer},
+			},
+			{"calls": []types.TransactionArgs{transfer}},
+			{"calls": []types.TransactionArgs{transfer}},
+		},
+	})
+	suite.Require().NoError(err)
+
+	canonical := common.HexToHash("0x65fdad50586258b80fdeec1e9d108e975d20a1a34ab3dfadd97eeedffa0727cc")
+	req := suite.simulateV1Request(optsJSON)
+	req.BaseBlockHash = canonical.Bytes()
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, req)
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 3)
+
+	suite.Require().Equal(canonical.Hex(), results[0]["parentHash"],
+		"block[0].parentHash must echo BaseBlockHash")
+
+	for i := 0; i < len(results)-1; i++ {
+		suite.Require().Equal(
+			results[i]["hash"], results[i+1]["parentHash"],
+			"block[%d].parentHash must equal block[%d].hash", i+1, i,
+		)
+	}
+}
+
+// log0Runtime is 6 bytes: PUSH1 0; PUSH1 0; LOG0; STOP. A call to a
+// contract carrying this runtime emits one empty LOG0 (zero data, zero
+// topics) whose Address is the contract address.
+const log0Runtime = "0x60006000A000"
+
+// TestSimulateV1_MultiCall_CumulativeLogIndex — two calls in one block
+// each emitting a single LOG0 must produce log indices 0 and 1
+// respectively (geth-aligned per-block monotonicity). A second block
+// with a single LOG0 call must reset the counter to 0.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_CumulativeLogIndex() {
+	suite.SetupTest()
+
+	sender := suite.address
+	emitter := common.HexToAddress("0xbbbb000000000000000000000000000000000203")
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	emit := types.TransactionArgs{From: &sender, To: &emitter}
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{
+			{
+				"stateOverrides": map[common.Address]map[string]interface{}{
+					sender:  {"balance": balance},
+					emitter: {"code": log0Runtime},
+				},
+				"calls": []types.TransactionArgs{emit, emit},
+			},
+			{"calls": []types.TransactionArgs{emit}},
+		},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 2)
+
+	block0Calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(block0Calls, 2)
+
+	logs0 := block0Calls[0].(map[string]interface{})["logs"].([]interface{})
+	suite.Require().Len(logs0, 1)
+	suite.Require().Equal("0x0", logs0[0].(map[string]interface{})["logIndex"],
+		"first call's LOG0 must land at logIndex 0")
+
+	logs1 := block0Calls[1].(map[string]interface{})["logs"].([]interface{})
+	suite.Require().Len(logs1, 1)
+	suite.Require().Equal("0x1", logs1[0].(map[string]interface{})["logIndex"],
+		"second call's LOG0 must land at logIndex 1 (cumulative within block)")
+
+	// Block 2: counter must reset.
+	block1Calls := results[1]["calls"].([]interface{})
+	suite.Require().Len(block1Calls, 1)
+	logs2 := block1Calls[0].(map[string]interface{})["logs"].([]interface{})
+	suite.Require().Len(logs2, 1)
+	suite.Require().Equal("0x0", logs2[0].(map[string]interface{})["logIndex"],
+		"block 2's first log must reset to logIndex 0")
+}

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -1958,6 +1958,61 @@ func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_BlockGasLimit() {
 	)
 }
 
+// TestSimulateV1_MultiCall_LogTxIndexMatchesBlockPosition — first call
+// is rejected pre-execution (requested gas > block gas limit, surfaces
+// -38015 without entering the EVM), second call lands and emits a log.
+// The block's transactions array therefore contains a single tx at
+// position 0; the emitted log's transactionIndex must agree (0x0), not
+// echo the loop position the rejected call occupied.
+func (suite *KeeperTestSuite) TestSimulateV1_MultiCall_LogTxIndexMatchesBlockPosition() {
+	suite.SetupTest()
+
+	sender := suite.address
+	balance := (*hexutil.Big)(big.NewInt(1_000_000_000_000_000_000))
+	blockGasLimit := hexutil.Uint64(5_000_000)
+	overBudgetGas := hexutil.Uint64(5_000_001)
+	initCode := hexutil.MustDecode(emptyLogDeployer)
+
+	optsJSON, err := json.Marshal(map[string]interface{}{
+		"blockStateCalls": []map[string]interface{}{{
+			"blockOverrides": map[string]interface{}{
+				"gasLimit": blockGasLimit,
+			},
+			"stateOverrides": map[common.Address]map[string]interface{}{
+				sender: {"balance": balance},
+			},
+			"calls": []types.TransactionArgs{
+				{From: &sender, Gas: &overBudgetGas, Input: (*hexutil.Bytes)(&initCode)},
+				{From: &sender, Input: (*hexutil.Bytes)(&initCode)},
+			},
+		}},
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.app.EvmKeeper.SimulateV1(suite.ctx, suite.simulateV1Request(optsJSON))
+	suite.Require().NoError(err)
+	suite.Require().Nil(resp.Error)
+
+	results := suite.simulateV1BlockResults(resp)
+	suite.Require().Len(results, 1)
+
+	txs := results[0]["transactions"].([]interface{})
+	suite.Require().Len(txs, 1, "rejected call must not enter the block's transactions array")
+
+	calls := results[0]["calls"].([]interface{})
+	suite.Require().Len(calls, 2)
+
+	call1 := calls[1].(map[string]interface{})
+	suite.Require().Equal("0x1", call1["status"], "second call must succeed and emit its log")
+	logs := call1["logs"].([]interface{})
+	suite.Require().Len(logs, 1)
+	suite.Require().Equal(
+		"0x0",
+		logs[0].(map[string]interface{})["transactionIndex"],
+		"log's transactionIndex must equal the call's position in the sealed block",
+	)
+}
+
 // TestSimulateV1_MultiCall_NonceAutoIncrement — two CREATE calls from
 // the same sender with no explicit nonce. Both must succeed: if the
 // nonce didn't advance between calls, the second CREATE would resolve

--- a/x/evm/keeper/setup_test.go
+++ b/x/evm/keeper/setup_test.go
@@ -182,6 +182,11 @@ func (suite *KeeperTestSuite) SetupAppWithT(checkTx bool, t require.TestingT) {
 		tmhash.Sum([]byte("app")), tmhash.Sum([]byte("validators")),
 	)
 	suite.ctx = suite.app.NewContextLegacy(checkTx, header)
+	// NewContextLegacy does not inject consensus params; baseapp
+	// normally does this inside FinalizeBlock. Populate them here so
+	// downstream readers (notably mezotypes.BlockGasLimit) see the
+	// chain's real MaxGas instead of the zero-value fallback.
+	suite.ctx = suite.ctx.WithConsensusParams(*app.DefaultConsensusParams)
 
 	queryHelper := baseapp.NewQueryServerTestHelper(suite.ctx, suite.app.InterfaceRegistry())
 	evmtypes.RegisterQueryServer(queryHelper, suite.app.EvmKeeper)

--- a/x/evm/keeper/simulate_v1.go
+++ b/x/evm/keeper/simulate_v1.go
@@ -475,9 +475,14 @@ func (k *Keeper) processSimBlock(
 		// `(*state.StateDB).SetTxContext(thash, ti)` — it only updates
 		// the StateDB's per-call TxHash / TxIndex while leaving the
 		// pre-set BlockHash and LogIndex alone.
+		//
+		// TxIndex is the call's position in the sealed block, not the
+		// loop index: pre-execution rejections above `continue` without
+		// appending to txHashes, so len(txHashes) is the index this
+		// call will land at if it succeeds.
 		callTxHash := computeSimTxHash(msg)
-		callCfg := statedb.NewTxConfig(common.Hash{}, callTxHash, uint(i), 0) //nolint:gosec
-		sdb.SetTxContext(callCfg.TxHash, int(callCfg.TxIndex))                //nolint:gosec
+		callCfg := statedb.NewTxConfig(common.Hash{}, callTxHash, uint(len(txHashes)), 0) //nolint:gosec
+		sdb.SetTxContext(callCfg.TxHash, int(callCfg.TxIndex))                            //nolint:gosec
 
 		res, _, runErr := k.applyMessageWithConfig(
 			ctx,

--- a/x/evm/keeper/simulate_v1.go
+++ b/x/evm/keeper/simulate_v1.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
+	"reflect"
 	"slices"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -251,6 +252,14 @@ func assembleSimBlock(
 // sanitizes the chain, builds preliminary headers, applies state
 // overrides, executes per-call, and assembles response envelopes.
 //
+// State-propagation invariant: ONE *statedb.StateDB is shared across
+// every call and every block in the request. Both the EVM journal and
+// mezo's StateDB-scoped cached-ctx (where custom precompile Cosmos-side
+// writes live) ride on that single StateDB, so call/block continuity
+// covers both layers uniformly. commit=false keeps the whole thing
+// ephemeral. A fresh StateDB per block would silently drop
+// custom-precompile Cosmos writes between blocks.
+//
 // Error policy: spec-coded failures (sanitize-chain violation,
 // state-override validation, per-call preflight) are returned as
 // *types.SimError through the plain error channel; callers branch with
@@ -268,138 +277,421 @@ func (k *Keeper) simulateV1(
 		return []*types.SimBlockResult{}, nil
 	}
 
-	// Current scope: single block, single call. The driver is the
-	// single source of truth for these bounds — callers hit the same
-	// error surface regardless of entry point.
-	if len(opts.BlockStateCalls) != 1 {
-		return nil, fmt.Errorf("multi-block simulate not yet implemented")
-	}
-	if len(opts.BlockStateCalls[0].Calls) > 1 {
-		return nil, fmt.Errorf("multi-call simulate not yet implemented")
-	}
-
 	sanitized, err := sanitizeSimChain(base, opts.BlockStateCalls)
 	if err != nil {
 		return nil, err
 	}
 
-	// Request-wide deadline is enforced by the gRPC backend ctx. The
-	// gas pool, block/call caps, and evm.Cancel plumbing are not wired
-	// yet — they land alongside the kill switch.
+	// One Rules value covers every simulated block, derived from ctx
+	// (i.e. base) rather than from each block's own number/time. This
+	// is deliberate: applyMessageWithConfig reads ctx.BlockHeight() /
+	// ctx.BlockTime() internally for fork-gated behavior (signer rules,
+	// access-list prep, intrinsic gas). Since those internal reads are
+	// anchored at ctx, every piece of fork-gated machinery below the
+	// driver sees
+	// the *base* ruleset regardless of which simulated block's header
+	// we hand the EVM. Using a single base-derived `rules` for header
+	// construction keeps the driver aligned with that internal truth.
+	//
+	// The sentinel enforces this anchoring: if the span's last block
+	// would cross onto a different fork than base, rules() anywhere in
+	// the simulation would disagree with applyMessageWithConfig's
+	// internal rules() — silently producing wrong-fork output. Fork
+	// activation is monotonic in (height, time), so comparing base vs.
+	// last-sim is sufficient: intermediate blocks are guaranteed to
+	// match both endpoints when the endpoints match. Conservative where
+	// it matters (a span fully inside a post-fork region whose base is
+	// pre-fork is rejected rather than silently executed with
+	// pre-fork rules from ctx).
 	rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())) //nolint:gosec
+	lastBlock := sanitized[len(sanitized)-1]
+	lastRules := cfg.Rules(
+		lastBlock.BlockOverrides.Number.ToInt().Int64(),
+		uint64(*lastBlock.BlockOverrides.Time),
+	)
+	if !sameForks(rules, lastRules) {
+		return nil, types.NewSimForkSpanUnsupported()
+	}
 
+	// ONE StateDB for the entire request — see the package comment
+	// above. Per-block StateDB would silently drop custom-precompile
+	// Cosmos writes between blocks.
+	//
+	// The initial TxConfig carries a zero BlockHash because the
+	// simulated block hash for any block is not known until that
+	// block's calls have all executed and cumulative gas is sealed
+	// into the header. processSimBlock updates per-call TxHash /
+	// TxIndex via SetTxContext (geth-aligned: BlockHash untouched)
+	// and back-stamps log.BlockHash with the simulated block hash
+	// after the block finalizes.
+	sdb := statedb.New(ctx, k, statedb.NewEmptyTxConfig(common.Hash{}))
+
+	// Build, execute, and link headers in a single pass. processSimBlock
+	// patches headers[bi].GasUsed before sealing the block hash, so by
+	// the next iteration parent.Hash() (RLP-recomputed each call, no
+	// cache) already reflects the final hash — the response envelope's
+	// parent chain is coherent by construction. newSimGetHashFn resolves
+	// prior siblings via headers[:bi] and likewise recomputes Hash() on
+	// demand, so it sees up-to-date values too.
+	headers := make([]*ethtypes.Header, len(sanitized))
 	results := make([]*types.SimBlockResult, 0, len(sanitized))
 	parent := base
-
-	for i, block := range sanitized {
-		header := makeSimHeader(parent, block.BlockOverrides, rules, cfg.ChainConfig, opts.Validation)
+	for bi, block := range sanitized {
+		headers[bi] = makeSimHeader(parent, block.BlockOverrides, rules, cfg.ChainConfig, opts.Validation)
 
 		// baseHeaderFromContext only populates the fields the driver
 		// consumes, so base.Hash() is unrelated to the canonical chain
-		// hash. When the caller supplies one, prefer it over
-		// makeSimHeader's parent.Hash() default for the first simulated
-		// block; otherwise fall back to the legacy behavior.
-		if i == 0 && baseHash != (common.Hash{}) {
-			header.ParentHash = baseHash
+		// hash; prefer the caller-supplied BaseBlockHash for block 0.
+		if bi == 0 && baseHash != (common.Hash{}) {
+			headers[bi].ParentHash = baseHash
 		}
 
-		// Per-block StateDB. Multi-call support will switch to a
-		// shared StateDB with FinaliseBetweenCalls between calls.
-		txConfig := statedb.NewEmptyTxConfig(common.BytesToHash(ctx.HeaderHash()))
-		sdb := statedb.New(ctx, k, txConfig)
-
-		var moves map[common.Address]common.Address
-		if len(block.StateOverrides) > 0 {
-			m, applyErr := applyStateOverrides(sdb, block.StateOverrides, rules)
-			if applyErr != nil {
-				return nil, applyErr
-			}
-			moves = m
+		res, blockErr := k.processSimBlock(
+			ctx, cfg, sdb, base, headers, bi, block, rules, opts, gasCap,
+		)
+		if blockErr != nil {
+			return nil, blockErr
 		}
 
-		// Gate Random on the merge fork: go-ethereum flips its rule
-		// set to Paris when BlockContext.Random != nil. Pre-merge we
-		// must leave it nil to preserve the legacy opcode set,
-		// matching the derivation used by NewEVMWithOverrides.
-		var random *common.Hash
-		if cfg.ChainConfig.MergeNetsplitBlock != nil {
-			random = &header.MixDigest
-		}
-		blockCtx := vm.BlockContext{
-			CanTransfer: core.CanTransfer,
-			Transfer:    core.Transfer,
-			GetHash:     k.GetHashFn(ctx),
-			Coinbase:    header.Coinbase,
-			GasLimit:    header.GasLimit,
-			BlockNumber: new(big.Int).Set(header.Number),
-			Time:        header.Time,
-			Difficulty:  new(big.Int).Set(header.Difficulty),
-			BaseFee:     header.BaseFee,
-			BlobBaseFee: big.NewInt(0),
-			Random:      random,
-		}
-
-		precompiles := k.precompilesWithMoves(ctx, cfg, moves)
-
-		// validation=false preserves the spec-compliant relaxation
-		// (no base-fee checks, caller may lack funds); validation=true
-		// forces the realistic path.
-		noBaseFee := !opts.Validation
-		evmOverrides := &EVMOverrides{
-			BlockContext: &blockCtx,
-			Precompiles:  precompiles,
-			NoBaseFee:    &noBaseFee,
-		}
-
-		calls := make([]types.SimCallResult, 0, len(block.Calls))
-		txHashes := make([]common.Hash, 0, len(block.Calls))
-		var cumGas uint64
-
-		for _, args := range block.Calls {
-			// Default nonce from the simulated StateDB so callers
-			// omitting `nonce` see any preceding state override (and
-			// eventually preceding calls in the same block).
-			if args.Nonce == nil {
-				h := hexutil.Uint64(sdb.GetNonce(args.GetFrom()))
-				args.Nonce = &h
-			}
-
-			msg, msgErr := args.ToMessage(gasCap, header.BaseFee)
-			if msgErr != nil {
-				calls = append(calls, types.SimCallResult{
-					Logs:  []*ethtypes.Log{},
-					Error: types.NewSimInvalidParams(msgErr.Error()),
-				})
-				continue
-			}
-
-			res, _, runErr := k.applyMessageWithConfig(
-				ctx,
-				WrapMessage(msg),
-				nil,   // tracer
-				false, // commit = false (ephemeral simulate)
-				cfg,
-				txConfig,
-				sdb,
-				evmOverrides,
-			)
-			if runErr != nil {
-				return nil, runErr
-			}
-
-			calls = append(calls, types.BuildSimCallResult(res))
-			txHashes = append(txHashes, computeSimTxHash(msg))
-			cumGas += res.GasUsed
-		}
-
-		results = append(results, &types.SimBlockResult{
-			Block: assembleSimBlock(header, txHashes, cumGas),
-			Calls: calls,
-		})
-		parent = header
+		parent = headers[bi]
+		results = append(results, res)
 	}
 
 	return results, nil
+}
+
+// processSimBlock executes one simulated block against the shared
+// StateDB. It applies the block's StateOverrides (incl.
+// MovePrecompileTo), builds the per-block BlockContext with the
+// simulate-aware GetHashFn, runs the block's calls sequentially with
+// cumulative gas accounting and per-call ephemeral resets, and
+// assembles the response envelope.
+//
+// The header at headers[bi] is mutated in place: assembleSimBlock
+// patches GasUsed before computing the block hash. Later blocks see
+// this block through headers[:laterIdx] via newSimGetHashFn.
+func (k *Keeper) processSimBlock(
+	ctx sdk.Context,
+	cfg *statedb.EVMConfig,
+	sdb *statedb.StateDB,
+	base *ethtypes.Header,
+	headers []*ethtypes.Header,
+	bi int,
+	block types.SimBlock,
+	rules params.Rules,
+	opts *types.SimOpts,
+	gasCap uint64,
+) (*types.SimBlockResult, error) {
+	header := headers[bi]
+
+	var moves map[common.Address]common.Address
+	if len(block.StateOverrides) > 0 {
+		m, applyErr := applyStateOverrides(sdb, block.StateOverrides, rules)
+		if applyErr != nil {
+			return nil, applyErr
+		}
+		moves = m
+	}
+
+	// Gate Random on the merge fork: go-ethereum flips its rule set to
+	// Paris when BlockContext.Random != nil. Pre-merge we must leave it
+	// nil to preserve the legacy opcode set, matching the derivation
+	// used by NewEVMWithOverrides.
+	var random *common.Hash
+	if cfg.ChainConfig.MergeNetsplitBlock != nil {
+		random = &header.MixDigest
+	}
+
+	blockCtx := vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		// Simulate-aware GetHashFn: canonical-range delegated to
+		// k.GetHashFn, simulated-sibling range scanned from already-
+		// finalized past siblings (headers[:bi]). Canonical-range hashes
+		// are therefore unforgeable by any BlockOverrides field.
+		GetHash:     newSimGetHashFn(k.GetHashFn(ctx), base, headers[:bi]),
+		Coinbase:    header.Coinbase,
+		GasLimit:    header.GasLimit,
+		BlockNumber: new(big.Int).Set(header.Number),
+		Time:        header.Time,
+		Difficulty:  new(big.Int).Set(header.Difficulty),
+		BaseFee:     header.BaseFee,
+		BlobBaseFee: big.NewInt(0),
+		Random:      random,
+	}
+
+	precompiles := k.precompilesWithMoves(ctx, cfg, moves)
+
+	// validation=false preserves the spec-compliant relaxation (no
+	// base-fee checks, caller may lack funds); validation=true forces
+	// the realistic path.
+	noBaseFee := !opts.Validation
+	evmOverrides := &EVMOverrides{
+		BlockContext: &blockCtx,
+		Precompiles:  precompiles,
+		NoBaseFee:    &noBaseFee,
+	}
+
+	calls := make([]types.SimCallResult, 0, len(block.Calls))
+	txHashes := make([]common.Hash, 0, len(block.Calls))
+	var cumGas uint64
+
+	for i := range block.Calls {
+		// Clear per-call ephemerals (logs, refund, transient storage,
+		// precompile call counter) while preserving account/storage
+		// mutations. Runs unconditionally at the top of every call —
+		// idempotent on a fresh StateDB, covers both call boundaries
+		// within a block and block boundaries (call 0 of block N+1).
+		sdb.FinaliseBetweenCalls()
+
+		args := block.Calls[i]
+		args.Nonce = resolveSimCallNonce(sdb, &args)
+
+		var simErr *types.SimError
+		args.Gas, simErr = resolveSimCallGas(&args, header, cumGas)
+		if simErr != nil {
+			calls = append(calls, types.SimCallResult{
+				Logs:  []*ethtypes.Log{},
+				Error: simErr,
+			})
+			continue
+		}
+
+		msg, msgErr := args.ToMessage(gasCap, header.BaseFee)
+		if msgErr != nil {
+			calls = append(calls, types.SimCallResult{
+				Logs:  []*ethtypes.Log{},
+				Error: types.NewSimInvalidParams(msgErr.Error()),
+			})
+			continue
+		}
+
+		// Per-call TxConfig so AddLog stamps distinct TxHash / TxIndex
+		// on every emitted log. BlockHash is left zero in callCfg
+		// because the block hash depends on cumulative GasUsed, which
+		// isn't known until every call in this block has executed; the
+		// post-pass below patches log.BlockHash once that hash is
+		// computed. SetTxContext mirrors geth's
+		// `(*state.StateDB).SetTxContext(thash, ti)` — it only updates
+		// the StateDB's per-call TxHash / TxIndex while leaving the
+		// pre-set BlockHash and LogIndex alone.
+		callTxHash := computeSimTxHash(msg)
+		callCfg := statedb.NewTxConfig(common.Hash{}, callTxHash, uint(i), 0) //nolint:gosec
+		sdb.SetTxContext(callCfg.TxHash, int(callCfg.TxIndex))                //nolint:gosec
+
+		res, _, runErr := k.applyMessageWithConfig(
+			ctx,
+			WrapMessage(msg),
+			nil,   // tracer
+			false, // commit = false (ephemeral simulate)
+			cfg,
+			callCfg,
+			sdb,
+			evmOverrides,
+		)
+		if runErr != nil {
+			// applyMessageWithConfig surfaces both user-recoverable
+			// errors (intrinsic gas too low for the call's actual gas
+			// requirement) and infrastructure errors via the same
+			// channel. Convert the recoverable case to a per-call
+			// SimError so prior successful calls remain in the
+			// envelope instead of being wiped by a top-level gRPC
+			// Internal. Catch is intentionally narrow — only
+			// core.ErrIntrinsicGas — so genuine internal failures
+			// still propagate.
+			if errors.Is(runErr, core.ErrIntrinsicGas) {
+				var provided uint64
+				if args.Gas != nil {
+					provided = uint64(*args.Gas)
+				}
+				calls = append(calls, types.SimCallResult{
+					Logs:  []*ethtypes.Log{},
+					Error: types.NewSimIntrinsicGas(provided, 0),
+				})
+				continue
+			}
+			return nil, runErr
+		}
+
+		// Mirror the CREATE branch's post-call SetNonce in
+		// applyMessageWithConfig (state_transition.go:580). For
+		// MsgEthereumTx, CALL nonce progression is owned by the
+		// ante handler — but eth_simulateV1 bypasses ante, so the
+		// driver has to advance the StateDB nonce here. Without
+		// this, multi-CALL chains from the same sender all read
+		// the same defaulted nonce, producing colliding synthetic
+		// tx hashes and wrong CREATE addresses for any follow-up
+		// CREATE in the same block. Anchored on msg.Nonce+1 (not
+		// GetNonce+1) so the post-state mirrors CREATE when the
+		// caller supplies an explicit args.Nonce that diverges
+		// from the StateDB value. Runs regardless of res.VmError —
+		// a reverted CALL still consumes the nonce on the real
+		// chain.
+		if msg.To != nil {
+			sdb.SetNonce(msg.From, msg.Nonce+1)
+		}
+
+		calls = append(calls, types.BuildSimCallResult(res))
+		txHashes = append(txHashes, callTxHash)
+		cumGas += res.GasUsed
+	}
+
+	// Finalize the header (GasUsed must be set before Hash()) and
+	// back-stamp every log with values that aren't knowable until the
+	// block is sealed: BlockHash (depends on cumulative GasUsed) and
+	// Index (must be per-block monotonic; AddLog stamps from
+	// txConfig.LogIndex+len(s.logs), both of which reset between calls).
+	// assembleSimBlock re-patches GasUsed idempotently below.
+	header.GasUsed = cumGas
+	finalBlockHash := header.Hash()
+	var logIdx uint
+	for i := range calls {
+		for _, log := range calls[i].Logs {
+			log.BlockHash = finalBlockHash
+			log.Index = logIdx
+			logIdx++
+		}
+	}
+
+	return &types.SimBlockResult{
+		Block: assembleSimBlock(header, txHashes, cumGas),
+		Calls: calls,
+	}, nil
+}
+
+// nonceSource narrows *statedb.StateDB down to the single method
+// resolveSimCallNonce consumes. Keeping the function signature
+// interface-typed lets helper unit tests pass a fake without
+// instantiating a full keeper.
+type nonceSource interface {
+	GetNonce(common.Address) uint64
+}
+
+// resolveSimCallNonce returns the nonce to apply to a sim call:
+// args.Nonce when explicitly set, otherwise a freshly allocated
+// pointer holding the StateDB nonce for args.From. Defaulting from the
+// shared StateDB lets multi-call chains implicitly advance for CREATE
+// callers — note that applyMessageWithConfig only bumps the StateDB
+// nonce on contract creation, so back-to-back non-CREATE calls from
+// the same sender read the same default nonce; harmless for simulate,
+// which has no uniqueness check.
+func resolveSimCallNonce(
+	sdb nonceSource,
+	args *types.TransactionArgs,
+) *hexutil.Uint64 {
+	if args.Nonce != nil {
+		return args.Nonce
+	}
+	n := hexutil.Uint64(sdb.GetNonce(args.GetFrom()))
+	return &n
+}
+
+// resolveSimCallGas returns the gas limit to apply to a sim call,
+// drawing from the per-block budget (header.GasLimit - cumGasUsed). An
+// explicit args.Gas is preserved, but a value that would push the
+// cumulative block gas past header.GasLimit is rejected with -38015 —
+// emitted as a per-call error so preceding valid calls still surface.
+// When args.Gas is nil a freshly allocated pointer holding the
+// remaining budget is returned. On error the returned pointer is nil.
+//
+// header.GasLimit is treated as authoritative: a caller who sets
+// blockOverrides.gasLimit to 0 (or otherwise produces a zero-limit
+// block) gets a block where every call either defaults to Gas=0 and
+// fails on intrinsic gas inside applyMessageWithConfig, or — if Gas is
+// explicitly >0 — trips the -38015 preflight. This matches geth's
+// behavior (empty core.GasPool) and keeps the per-block work bound
+// real even under hostile BlockOverrides.
+func resolveSimCallGas(
+	args *types.TransactionArgs,
+	header *ethtypes.Header,
+	cumGasUsed uint64,
+) (*hexutil.Uint64, *types.SimError) {
+	var remaining uint64
+	if header.GasLimit > cumGasUsed {
+		remaining = header.GasLimit - cumGasUsed
+	}
+
+	// Block budget already exhausted: any further call (default or
+	// explicit gas) would fail intrinsic-gas inside applyMessageWithConfig.
+	// Surface as a per-call -38015 so the request envelope retains
+	// preceding successful results instead of collapsing to gRPC Internal.
+	if remaining == 0 {
+		var requested uint64
+		if args.Gas != nil {
+			requested = uint64(*args.Gas)
+		}
+		return nil, types.NewSimBlockGasLimitReached(requested, 0)
+	}
+
+	if args.Gas == nil {
+		g := hexutil.Uint64(remaining)
+		return &g, nil
+	}
+
+	requested := uint64(*args.Gas)
+	if requested > remaining {
+		return nil, types.NewSimBlockGasLimitReached(requested, remaining)
+	}
+	return args.Gas, nil
+}
+
+// newSimGetHashFn builds the simulate-aware BLOCKHASH resolver. The
+// closure captures base + the already-finalized past-sibling headers
+// (headers[:bi] from the caller). Resolution order:
+//
+//   - height <= base.Number → delegate to the canonical resolver,
+//     which returns the canonical CometBFT header hash. Callers supply
+//     k.GetHashFn(ctx), whose ctx is anchored at base by the gRPC
+//     layer via rpctypes.ContextWithHeight.
+//   - height  > base.Number → look up the simulated sibling by height;
+//     return header.Hash() on hit.
+//   - not found → zero hash.
+//
+// Canonical-range hashes are thus unforgeable by any BlockOverrides
+// field: sim[] only holds simulated blocks whose Number > base.Number
+// (enforced by sanitizeSimChain). This diverges from go-ethereum's
+// simulate.go (which uses base.Hash() for the height==base case)
+// because mezod surfaces CometBFT header hashes as canonical block
+// hashes, not ethtypes.Header.Hash() values.
+//
+// The function takes a canonical vm.GetHashFunc (rather than a Keeper +
+// ctx) so unit tests can exercise every resolution path against a
+// synthetic canonical resolver without a full keeper instance.
+func newSimGetHashFn(
+	canonical vm.GetHashFunc,
+	base *ethtypes.Header,
+	sim []*ethtypes.Header,
+) vm.GetHashFunc {
+	baseN := base.Number.Uint64()
+	// Index simulated siblings by height so BLOCKHASH stays O(1) per
+	// opcode invocation (a single contract call can issue many).
+	simByHeight := make(map[uint64]*ethtypes.Header, len(sim))
+	for _, h := range sim {
+		simByHeight[h.Number.Uint64()] = h
+	}
+	return func(height uint64) common.Hash {
+		if height <= baseN {
+			return canonical(height)
+		}
+		if h, ok := simByHeight[height]; ok {
+			return h.Hash()
+		}
+		return common.Hash{}
+	}
+}
+
+// sameForks reports whether two Rules values share the same fork
+// activation bitmap. The driver's fork-boundary sentinel uses it to
+// ensure all simulated blocks fall within a single fork.
+//
+// ChainConfig.Rules allocates a fresh *big.Int ChainID on every call,
+// so direct struct equality always fails on the pointer. reflect.DeepEqual
+// dereferences the ChainID and compares every remaining field by value,
+// which keeps the "bitmap" framing correct as go-ethereum adds new rule
+// flags. Within one chain ChainID is invariant, so including it in the
+// comparison is a no-op.
+func sameForks(a, b params.Rules) bool {
+	return reflect.DeepEqual(a, b)
 }
 
 // computeSimTxHash derives a deterministic "tx hash" for a simulated

--- a/x/evm/keeper/simulate_v1_test.go
+++ b/x/evm/keeper/simulate_v1_test.go
@@ -19,8 +19,9 @@ import (
 // grpc_query_test.go against a fully-wired KeeperTestSuite app. The
 // private simulateV1 driver is not covered with dedicated tests here —
 // repeating the same scenarios against a hand-built keeper would reimplement
-// the suite setup for no additional signal. Helper coverage (sanitize +
-// make-header) lives below and runs without a keeper instance.
+// the suite setup for no additional signal. Helper coverage (sanitize-
+// chain, resolve-call, make-header) lives below and runs without a
+// keeper instance.
 func TestSimulateV1_CoveredInGrpcQueryTest(_ *testing.T) {}
 
 func hbig(n int64) *hexutil.Big { return (*hexutil.Big)(big.NewInt(n)) }
@@ -236,4 +237,224 @@ func TestMakeSimHeader_OverrideFields(t *testing.T) {
 	require.Equal(t, uint64(1_234_567), h.GasLimit)
 	require.Equal(t, feeRecipient, h.Coinbase)
 	require.Equal(t, prevRandao, h.MixDigest)
+}
+
+// --- resolveSimCallNonce / resolveSimCallGas ----------------------------
+
+// fakeNonceSource implements the nonceSource interface for
+// resolveSimCallNonce unit tests so we avoid standing up a full
+// StateDB / keeper.
+type fakeNonceSource struct{ n uint64 }
+
+func (f fakeNonceSource) GetNonce(common.Address) uint64 { return f.n }
+
+func TestResolveSimCallNonce_DefaultsFromStateDB(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	src := fakeNonceSource{n: 7}
+	args := &types.TransactionArgs{From: &from}
+
+	nonce := resolveSimCallNonce(src, args)
+	require.NotNil(t, nonce)
+	require.Equal(t, uint64(7), uint64(*nonce))
+}
+
+func TestResolveSimCallNonce_PreservesExplicit(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000002")
+	src := fakeNonceSource{n: 7}
+	explicit := hexutil.Uint64(42)
+	args := &types.TransactionArgs{From: &from, Nonce: &explicit}
+
+	nonce := resolveSimCallNonce(src, args)
+	require.Same(t, &explicit, nonce)
+	require.Equal(t, uint64(42), uint64(*nonce))
+}
+
+func TestResolveSimCallGas_DefaultsToRemaining(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000003")
+	args := &types.TransactionArgs{From: &from}
+	header := &ethtypes.Header{GasLimit: 1_000_000}
+
+	gas, simErr := resolveSimCallGas(args, header, 400_000)
+	require.Nil(t, simErr)
+	require.NotNil(t, gas)
+	require.Equal(t, uint64(600_000), uint64(*gas))
+}
+
+func TestResolveSimCallGas_BlockGasLimitReached(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000004")
+	gas := hexutil.Uint64(700_000)
+	args := &types.TransactionArgs{From: &from, Gas: &gas}
+	header := &ethtypes.Header{GasLimit: 1_000_000}
+
+	resolved, simErr := resolveSimCallGas(args, header, 400_000)
+	require.Nil(t, resolved)
+	require.NotNil(t, simErr)
+	require.Equal(t, types.SimErrCodeBlockGasLimitReached, simErr.ErrorCode())
+	require.Contains(t, simErr.Message, "700000")
+	require.Contains(t, simErr.Message, "600000")
+}
+
+// When the per-block budget is exhausted and the caller omits args.Gas,
+// the resolver emits -38015 instead of defaulting Gas=0 (which would
+// fail intrinsic-gas inside applyMessageWithConfig and bubble as gRPC
+// Internal, wiping preceding successful results).
+func TestResolveSimCallGas_ZeroRemaining_DefaultEmitsSimError(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000005")
+	args := &types.TransactionArgs{From: &from}
+	header := &ethtypes.Header{GasLimit: 0}
+
+	resolved, simErr := resolveSimCallGas(args, header, 0)
+	require.Nil(t, resolved)
+	require.NotNil(t, simErr)
+	require.Equal(t, types.SimErrCodeBlockGasLimitReached, simErr.ErrorCode())
+}
+
+// Same path with a non-zero cumGasUsed that has eaten the entire block.
+func TestResolveSimCallGas_BudgetFullyConsumed_DefaultEmitsSimError(t *testing.T) {
+	from := common.HexToAddress("0xaaaa00000000000000000000000000000000000a")
+	args := &types.TransactionArgs{From: &from}
+	header := &ethtypes.Header{GasLimit: 1_000_000}
+
+	resolved, simErr := resolveSimCallGas(args, header, 1_000_000)
+	require.Nil(t, resolved)
+	require.NotNil(t, simErr)
+	require.Equal(t, types.SimErrCodeBlockGasLimitReached, simErr.ErrorCode())
+}
+
+// TestResolveSimCallGas_ZeroGasLimit_ExplicitGasRejected pins the
+// behavior when the caller supplies an explicit args.Gas against a
+// zero-limit block: -38015 is returned from preflight, no EVM work
+// runs at all.
+func TestResolveSimCallGas_ZeroGasLimit_ExplicitGasRejected(t *testing.T) {
+	from := common.HexToAddress("0xaaaa000000000000000000000000000000000006")
+	gas := hexutil.Uint64(21_000)
+	args := &types.TransactionArgs{From: &from, Gas: &gas}
+	header := &ethtypes.Header{GasLimit: 0}
+
+	resolved, simErr := resolveSimCallGas(args, header, 0)
+	require.Nil(t, resolved)
+	require.NotNil(t, simErr)
+	require.Equal(t, types.SimErrCodeBlockGasLimitReached, simErr.ErrorCode())
+}
+
+// --- newSimGetHashFn -----------------------------------------------------
+
+// canonicalHash is a fixed magic byte pattern a synthetic canonical
+// resolver returns so tests can assert the closure delegated to it.
+func canonicalHashForHeight(h uint64) common.Hash {
+	var out common.Hash
+	out[0] = 0xCA
+	out[1] = byte(h)
+	return out
+}
+
+// fakeCanonical returns a deterministic canonicalHashForHeight value
+// for every height — an in-test stand-in for k.GetHashFn(ctx). Used
+// across the newSimGetHashFn cases so the assertions can distinguish
+// canonical hits from simulated-sibling hits and zero-hash misses.
+func fakeCanonical(h uint64) common.Hash { return canonicalHashForHeight(h) }
+
+func TestNewSimGetHashFn_HitBase(t *testing.T) {
+	base := &ethtypes.Header{Number: big.NewInt(100)}
+	fn := newSimGetHashFn(fakeCanonical, base, nil)
+	require.Equal(t, canonicalHashForHeight(100), fn(100))
+}
+
+func TestNewSimGetHashFn_BelowBase_Canonical(t *testing.T) {
+	base := &ethtypes.Header{Number: big.NewInt(100)}
+	fn := newSimGetHashFn(fakeCanonical, base, nil)
+	require.Equal(t, canonicalHashForHeight(42), fn(42))
+	require.Equal(t, canonicalHashForHeight(99), fn(99))
+}
+
+func TestNewSimGetHashFn_AboveBase_ScansSim(t *testing.T) {
+	base := &ethtypes.Header{Number: big.NewInt(100)}
+	sim := []*ethtypes.Header{
+		{Number: big.NewInt(101), Time: 10},
+		{Number: big.NewInt(102), Time: 20},
+		{Number: big.NewInt(103), Time: 30},
+	}
+	fn := newSimGetHashFn(fakeCanonical, base, sim)
+
+	require.Equal(t, sim[0].Hash(), fn(101))
+	require.Equal(t, sim[1].Hash(), fn(102))
+	require.Equal(t, sim[2].Hash(), fn(103))
+}
+
+func TestNewSimGetHashFn_NotFound_Zero(t *testing.T) {
+	base := &ethtypes.Header{Number: big.NewInt(100)}
+	sim := []*ethtypes.Header{
+		{Number: big.NewInt(101), Time: 10},
+	}
+	fn := newSimGetHashFn(fakeCanonical, base, sim)
+	require.Equal(t, common.Hash{}, fn(102)) // beyond sim[] but future
+	require.Equal(t, common.Hash{}, fn(200)) // far future
+}
+
+// TestNewSimGetHashFn_CanonicalUnforgeable verifies that the closure
+// never serves an attacker-controlled hash for a canonical-range height
+// even if, hypothetically, a sim[] slot carries a Number <= base.Number
+// (bypassing sanitizeSimChain's monotonic check). Guards against future
+// refactors breaking the invariant the multi-block security argument
+// rests on.
+func TestNewSimGetHashFn_CanonicalUnforgeable(t *testing.T) {
+	base := &ethtypes.Header{Number: big.NewInt(100)}
+	// Craft a sim[] header with Number == base.Number - 1 that sanitize
+	// would never produce.
+	evil := &ethtypes.Header{
+		Number:     big.NewInt(99),
+		Time:       1,
+		Difficulty: big.NewInt(7),
+		Extra:      []byte("malicious"),
+	}
+	fn := newSimGetHashFn(fakeCanonical, base, []*ethtypes.Header{evil})
+
+	// Canonical range: must come from the canonical source, NOT from evil.
+	got := fn(99)
+	require.Equal(t, canonicalHashForHeight(99), got)
+	require.NotEqual(t, evil.Hash(), got, "attacker-controlled sim[] header must not surface as canonical hash")
+}
+
+// Two cfg.Rules invocations at the same (height, time) must compare equal,
+// even though ChainConfig.Rules allocates a fresh *big.Int ChainID on every
+// call — the whole point of the helper is to look past that pointer.
+func TestSameForks_DistinctChainIDPointers(t *testing.T) {
+	cfg := postMergeConfig()
+	a := cfg.Rules(big.NewInt(100), true, 1000)
+	b := cfg.Rules(big.NewInt(100), true, 1000)
+	require.NotSame(t, a.ChainID, b.ChainID, "fixture relies on Rules() returning fresh ChainID pointers")
+	require.True(t, sameForks(a, b))
+}
+
+func TestSameForks_SameForkDifferentHeights(t *testing.T) {
+	cfg := postMergeConfig()
+	require.True(t, sameForks(
+		cfg.Rules(big.NewInt(100), true, 1000),
+		cfg.Rules(big.NewInt(999_999), true, 9_999_999),
+	))
+}
+
+// The fork-span rejection emits a *SimError on the spec-reserved
+// -38026 (ClientLimitExceeded) channel. Pins the wire shape so a future
+// refactor doesn't accidentally regress to a bare fmt.Errorf and route
+// to gRPC Internal.
+func TestNewSimForkSpanUnsupported(t *testing.T) {
+	e := types.NewSimForkSpanUnsupported()
+	require.Equal(t, types.SimErrCodeClientLimitExceeded, e.ErrorCode())
+	require.Contains(t, e.Error(), "fork boundary")
+}
+
+// Crossing a time-gated fork must flip sameForks to false — this is the
+// boundary the simulate driver's sentinel relies on.
+func TestSameForks_AcrossForkBoundary(t *testing.T) {
+	cfg := postMergeConfig()
+	shanghai := uint64(1_000_000)
+	cancun := uint64(2_000_000)
+	cfg.ShanghaiTime = &shanghai
+	cfg.CancunTime = &cancun
+
+	pre := cfg.Rules(big.NewInt(100), true, cancun-1)
+	post := cfg.Rules(big.NewInt(100), true, cancun)
+	require.True(t, post.IsCancun && !pre.IsCancun, "fixture must straddle Cancun activation")
+	require.False(t, sameForks(pre, post))
 }

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -129,6 +129,28 @@ func (s *StateDB) Keeper() Keeper {
 	return s.keeper
 }
 
+// SetTxContext mirrors go-ethereum's `(*state.StateDB).SetTxContext` —
+// it replaces the per-tx hash and tx index used by AddLog when stamping
+// emitted logs. Reusing a single StateDB across many logical
+// "transactions" (calls) and calling SetTxContext between them lets
+// each call's logs carry distinct TxHash / TxIndex values.
+//
+// BlockHash and LogIndex on the StateDB's txConfig are intentionally
+// left untouched, matching the geth signature; per-block hash patching
+// happens separately, after each block finalizes.
+//
+// Safe to call between calls; the txConfig is read-only from AddLog's
+// perspective and never participates in the journal.
+//
+// TODO (geth-upgrade): once go-ethereum v1.16.9 lands, decide whether
+// the simulate driver should call geth's native
+// `(*state.StateDB).SetTxContext` directly — and whether this wrapper
+// can be dropped in favor of it.
+func (s *StateDB) SetTxContext(thash common.Hash, ti int) {
+	s.txConfig.TxHash = thash
+	s.txConfig.TxIndex = uint(ti) //nolint:gosec
+}
+
 // GetContext returns the transaction Context.
 func (s *StateDB) GetContext() sdk.Context {
 	return s.ctx
@@ -757,11 +779,23 @@ func (ccc *CachedCtxCheckpoint) Revert(stateDB *StateDB) {
 }
 
 // FinaliseBetweenCalls clears per-call ephemeral state (logs, refund,
-// transient storage) and resets the precompile-call counter while
-// preserving state objects, access list, and journal — so accumulated
-// cross-call account/storage mutations remain visible. Used by simulate
-// drivers running several calls against a shared StateDB without
-// committing between them.
+// transient storage, journal, and revision stack) and resets the
+// precompile-call counter while preserving state objects, access list,
+// and the live cached cosmos ctx — so accumulated cross-call
+// account/storage mutations and precompile-side writes remain visible.
+// Used by simulate drivers running several calls against a shared
+// StateDB without committing between them.
+//
+// Clearing the journal bounds memory: each custom-precompile call
+// appends a multistore Clone() to the journal, which would otherwise
+// accumulate across the whole request. It also disarms the latent
+// panic where addLogChange.Revert reads s.logs[len-1] after s.logs has
+// been niled by a prior FinaliseBetweenCalls.
+//
+// Invariant: callers must not hold a live Snapshot() across this call.
+// The revision stack is wiped, so a stale revision id will fail
+// RevertToSnapshot. The simulate driver does not snapshot at the
+// top level; future drivers must preserve that.
 //
 // TODO (geth-upgrade): v1.16.9 introduces the canonical-spelled geth
 // finaliser on the [vm.StateDB] interface; once the upgrade lands,
@@ -771,6 +805,9 @@ func (s *StateDB) FinaliseBetweenCalls() {
 	s.refund = 0
 	s.transientStorage = newTransientStorage()
 	s.ongoingPrecompilesCallsCounter = 0
+	s.journal = newJournal()
+	s.validRevisions = nil
+	s.nextRevisionID = 0
 }
 
 func (s *StateDB) CacheContext() (sdk.Context, *CachedCtxCheckpoint) {

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -788,6 +788,12 @@ func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
 		db.RegisterCachedCtxCheckpoint(address, ccp),
 	)
 
+	// Bump the revision stack so the post-finalize id reset is
+	// observable. Without these calls nextRevisionID is already 0 and
+	// the assertion below would hold tautologically.
+	suite.Require().Equal(0, db.Snapshot())
+	suite.Require().Equal(1, db.Snapshot())
+
 	suite.Require().NotEmpty(db.Logs())
 	suite.Require().Equal(uint64(42), db.GetRefund())
 	suite.Require().Equal(value1, db.GetTransientState(address, key1))
@@ -811,6 +817,12 @@ func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
 	suite.Require().NoError(
 		db.RegisterCachedCtxCheckpoint(address, ccp),
 	)
+
+	// Journal and revision stack are cleared, so the next Snapshot()
+	// restarts at id 0. This bounds memory across long simulate
+	// requests (per-precompile multistore clones don't accumulate)
+	// and disarms the latent addLogChange-revert-on-empty-slice panic.
+	suite.Require().Equal(0, db.Snapshot())
 }
 
 func CollectContractStorage(db *statedb.StateDB) statedb.Storage {

--- a/x/evm/types/simulate_v1_errors.go
+++ b/x/evm/types/simulate_v1_errors.go
@@ -105,6 +105,46 @@ func NewSimClientLimitExceeded(span *big.Int, maxSpan int64) *SimError {
 	}
 }
 
+// NewSimBlockGasLimitReached reports that a call's requested or defaulted
+// gas would push cumulative block gas past the simulated block's gas limit
+// (-38015).
+func NewSimBlockGasLimitReached(requested, remaining uint64) *SimError {
+	return &SimError{
+		Code: SimErrCodeBlockGasLimitReached,
+		Message: fmt.Sprintf(
+			"simulate: block gas limit reached: requested %d > remaining %d",
+			requested, remaining,
+		),
+	}
+}
+
+// NewSimIntrinsicGas reports a call whose explicit gas limit falls below
+// the call's intrinsic-gas requirement (-38013). `required` may be 0 when
+// the catch site does not have access to the computed intrinsic value;
+// the message stays informative as "have X, need 0".
+func NewSimIntrinsicGas(provided, required uint64) *SimError {
+	return &SimError{
+		Code: SimErrCodeIntrinsicGas,
+		Message: fmt.Sprintf(
+			"simulate: intrinsic gas too low: have %d, need %d",
+			provided, required,
+		),
+	}
+}
+
+// NewSimForkSpanUnsupported reports a simulated chain span that crosses a
+// fork activation boundary, which mezod does not yet support. Reuses
+// SimErrCodeClientLimitExceeded (-38026) — the spec does not reserve a
+// fork-boundary code, and "client-imposed limit on fork-uniformity" is a
+// defensible fit. Distinguishable from NewSimClientLimitExceeded by
+// message text.
+func NewSimForkSpanUnsupported() *SimError {
+	return &SimError{
+		Code:    SimErrCodeClientLimitExceeded,
+		Message: "simulate: span crosses a fork boundary; not yet supported",
+	}
+}
+
 // NewSimMovePrecompileSelfRef reports a MovePrecompileTo override whose
 // destination is the source address (-38022).
 func NewSimMovePrecompileSelfRef(addr common.Address) *SimError {


### PR DESCRIPTION
References: [MEZO-4227](https://linear.app/thesis-co/issue/MEZO-4227)

### Introduction

Extends `eth_simulateV1` from the single-call / single-block slice on `main` to arbitrarily many blocks each carrying arbitrarily many calls. State mutations propagate across both call and block boundaries through one shared `*statedb.StateDB` allocated for the whole request — covering the EVM journal and mezo's StateDB-scoped cached cosmos ctx (where custom-precompile writes live) uniformly. `traceTransfers`, `validation=true`, `returnFullTransactions`, the request-wide DoS kill switch, and full spec conformance remain follow-up work.

### Changes

- **Multi-call / multi-block driver** (`x/evm/keeper/simulate_v1.go`). One shared StateDB threads through every call of every block. `FinaliseBetweenCalls` clears per-call ephemerals (logs, refund, transient storage, journal, revisions, precompile counter) at the top of every call. `SetTxContext` swaps per-call `TxHash` / `TxIndex` so each call's logs carry distinct values. Cumulative log indices and `BlockHash` are back-stamped after the block hash seals. Headers are built lazily inside the per-block loop and `GasUsed`-patched before the next iteration reads `parent.Hash()`, so the response envelope's parent chain is coherent by construction.
- **Per-call resolvers**. `resolveSimCallNonce` defaults from the shared StateDB so preceding state overrides and CREATE-induced bumps propagate. `resolveSimCallGas` defaults to the per-block remaining budget (`header.GasLimit - cumGasUsed`); explicit-over-budget and zero-remaining paths emit `-38015` as a per-call `SimError` so prior successes survive in the envelope.
- **`BLOCKHASH` resolver**. `newSimGetHashFn` returns canonical hashes for `height <= base.Number` (delegated to `k.GetHashFn(ctx)`, anchored at base by the rpc/backend layer), simulated-sibling hashes for `height > base.Number` via an O(1) height-indexed map of already-finalized siblings, and zero otherwise. Canonical-range hashes are unforgeable by any `BlockOverrides` because `sanitizeSimChain` rejects `sim[]` entries with `Number <= base.Number`.
- **Fork-boundary sentinel**. A single base-derived `params.Rules` drives header construction for every simulated block (matching what `applyMessageWithConfig` reads from ctx internally). `sameForks` compares base vs. last-sim Rules; spans crossing a fork are rejected via `NewSimForkSpanUnsupported` (`-38026`).
- **Intrinsic-gas surfacing**. The driver narrows on `core.ErrIntrinsicGas` from `applyMessageWithConfig` and routes it to a per-call `-38013` (`NewSimIntrinsicGas`) instead of collapsing the request to gRPC Internal.
- **Anchor handshake** (`rpc/backend/simulate_v1.go` + `x/evm/keeper/grpc_query.go`). The backend resolves `BlockNumberOrHash` to a concrete height before marshaling so the keeper anchor validator compares the same numeric value that `ContextWithHeight` anchors ctx at — `BlockNumber`'s JSON round-trip does not preserve sentinels. `validateSimulateV1Anchor` is defense-in-depth for direct-gRPC callers: a numeric mismatch is rejected with `-32602` instead of silently simulating against the wrong base.
- **StateDB additions** (`x/evm/statedb/statedb.go`). `SetTxContext` mirrors go-ethereum's `(*state.StateDB).SetTxContext`. `FinaliseBetweenCalls` now also clears the journal and revision stack — bounds memory across long requests (per-precompile multistore clones don't accumulate) and disarms a latent panic where `addLogChange.Revert` would slice an already-niled `s.logs`.
- **Spec-coded errors** (`x/evm/types/simulate_v1_errors.go`). New constructors: `NewSimBlockGasLimitReached` (`-38015`), `NewSimIntrinsicGas` (`-38013`), `NewSimForkSpanUnsupported` (`-38026`).
- **Test setup fix** (`x/evm/keeper/setup_test.go`). `SetupAppWithT` now populates `ConsensusParams` on the suite ctx; `NewContextLegacy` does not, and `mezotypes.BlockGasLimit` otherwise reads the zero-value fallback.

Feature remains query-side only: no proto changes to `service Msg`, no genesis or stored-state mutations, no ante handler edits, no `ApplyTransaction` edits.

### Testing

- `make test-unit` — passes. New Go coverage in `x/evm/keeper/simulate_v1_test.go` (`TestResolveSimCallNonce_*`, `TestResolveSimCallGas_*`, `TestNewSimGetHashFn_*`, `TestSameForks_*`, `TestNewSimForkSpanUnsupported`) and in `x/evm/keeper/grpc_query_test.go` (`TestSimulateV1_MultiCall_*`, `TestSimulateV1_MultiBlock_*`, `TestSimulateV1_ExplicitGasBelowIntrinsic`).
- `make proto-all` — clean.
- `make lint` — clean on the changed files.
- Hardhat system tests — `./tests/system/system-tests.sh SimulateV1_MultiCall SimulateV1_MultiBlock` runs green against a fresh `make localnode-bin-start`, including the new custom-precompile cases.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) — docs update for the method and divergences lands with spec conformance.
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
