### PR TITLE
StateDB interface compliance

### DIFF
--- a/x/evm/keeper/simulate_v1.go
+++ b/x/evm/keeper/simulate_v1.go
@@ -513,7 +513,8 @@ func (k *Keeper) processSimBlock(
 		// mutations. Runs unconditionally at the top of every call —
 		// idempotent on a fresh StateDB, covers both call boundaries
 		// within a block and block boundaries (call 0 of block N+1).
-		sdb.FinaliseBetweenCalls()
+		//nolint:misspell
+		sdb.Finalise(false)
 
 		args := block.Calls[i]
 		args.Nonce = resolveSimCallNonce(sdb, &args)

--- a/x/evm/keeper/simulate_v1.go
+++ b/x/evm/keeper/simulate_v1.go
@@ -508,13 +508,12 @@ func (k *Keeper) processSimBlock(
 			return nil, nil, types.NewSimTimeout(timeout)
 		}
 
-		// Clear per-call ephemerals (logs, refund, transient storage,
-		// precompile call counter) while preserving account/storage
-		// mutations. Runs unconditionally at the top of every call —
-		// idempotent on a fresh StateDB, covers both call boundaries
-		// within a block and block boundaries (call 0 of block N+1).
-		//nolint:misspell
-		sdb.Finalise(false)
+		// Clear per-call ephemeral bookkeeping while preserving
+		// account/storage mutations. Runs unconditionally at the top
+		// of every call — idempotent on a fresh StateDB, covers both
+		// call boundaries within a block and block boundaries
+		// (call 0 of block N+1).
+		sdb.ResetTxEphemerals()
 
 		args := block.Calls[i]
 		args.Nonce = resolveSimCallNonce(sdb, &args)

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -546,6 +546,8 @@ func (suite *KeeperTestSuite) TestEVMConfig() {
 	suite.Require().Equal(big.NewInt(0), cfg.BaseFee)
 	suite.Require().Equal(suite.address, cfg.CoinBase)
 	suite.Require().Equal(types.DefaultParams().ChainConfig.EthereumConfig(big.NewInt(31611)), cfg.ChainConfig)
+	suite.Require().Nil(cfg.ChainConfig.VerkleTime)
+	suite.Require().False(cfg.ChainConfig.IsEIP4762(big.NewInt(suite.ctx.BlockHeight()), uint64(suite.ctx.BlockTime().Unix())))
 }
 
 func (suite *KeeperTestSuite) TestNewEVM_BlobBaseFee() {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -547,7 +547,7 @@ func (suite *KeeperTestSuite) TestEVMConfig() {
 	suite.Require().Equal(suite.address, cfg.CoinBase)
 	suite.Require().Equal(types.DefaultParams().ChainConfig.EthereumConfig(big.NewInt(31611)), cfg.ChainConfig)
 	suite.Require().Nil(cfg.ChainConfig.VerkleTime)
-	suite.Require().False(cfg.ChainConfig.IsEIP4762(big.NewInt(suite.ctx.BlockHeight()), uint64(suite.ctx.BlockTime().Unix())))
+	suite.Require().False(cfg.ChainConfig.IsEIP4762(big.NewInt(suite.ctx.BlockHeight()), big.NewInt(suite.ctx.BlockTime().Unix()).Uint64()))
 }
 
 func (suite *KeeperTestSuite) TestNewEVM_BlobBaseFee() {

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -434,9 +434,33 @@ func (s *StateDB) AccessEvents() *gethstate.AccessEvents {
 	return nil
 }
 
+// Finalise clears per-call state for flows that reuse one StateDB without
+// committing between calls, such as simulations. Normal transaction execution
+// does not call it because Mezod creates and discards a StateDB per transaction.
+//
+// State objects, access list, and the live cached Cosmos context are preserved,
+// so accumulated cross-call account/storage mutations and precompile-side writes
+// remain visible. The journal and revision stack are cleared to bound memory and
+// to prevent reverting across call boundaries. Callers must not hold a live
+// Snapshot() across this call.
+//
 //nolint:misspell
-func (s *StateDB) Finalise(bool) {
-	// TODO (geth-upgrade): implement when adding support for the new state finalization flow in 1.16.9.
+func (s *StateDB) Finalise(deleteEmptyObjects bool) {
+	// Required by geth's StateDB interface. Mezod does not use Finalise for
+	// canonical empty-account deletion.
+	_ = deleteEmptyObjects
+
+	s.logs = nil
+	s.refund = 0
+	s.transientStorage = newTransientStorage()
+	s.ongoingPrecompilesCallsCounter = 0
+	s.journal = newJournal()
+	s.validRevisions = nil
+	s.nextRevisionID = 0
+
+	for _, obj := range s.stateObjects {
+		obj.newContract = false
+	}
 }
 
 // GetCode returns the code of account, nil if not exists.
@@ -821,38 +845,6 @@ func (ccc *CachedCtxCheckpoint) Revert(stateDB *StateDB) {
 		// at time of creation
 		ccc.ms.Write()
 	}
-}
-
-// FinaliseBetweenCalls clears per-call ephemeral state (logs, refund,
-// transient storage, journal, and revision stack) and resets the
-// precompile-call counter while preserving state objects, access list,
-// and the live cached cosmos ctx — so accumulated cross-call
-// account/storage mutations and precompile-side writes remain visible.
-// Used by simulate drivers running several calls against a shared
-// StateDB without committing between them.
-//
-// Clearing the journal bounds memory: each custom-precompile call
-// appends a multistore Clone() to the journal, which would otherwise
-// accumulate across the whole request. It also disarms the latent
-// panic where addLogChange.Revert reads s.logs[len-1] after s.logs has
-// been niled by a prior FinaliseBetweenCalls.
-//
-// Invariant: callers must not hold a live Snapshot() across this call.
-// The revision stack is wiped, so a stale revision id will fail
-// RevertToSnapshot. The simulate driver does not snapshot at the
-// top level; future drivers must preserve that.
-//
-// TODO (geth-upgrade): v1.16.9 introduces the canonical-spelled geth
-// finaliser on the [vm.StateDB] interface; once the upgrade lands,
-// this helper collapses into that call plus the counter reset.
-func (s *StateDB) FinaliseBetweenCalls() {
-	s.logs = nil
-	s.refund = 0
-	s.transientStorage = newTransientStorage()
-	s.ongoingPrecompilesCallsCounter = 0
-	s.journal = newJournal()
-	s.validRevisions = nil
-	s.nextRevisionID = 0
 }
 
 func (s *StateDB) CacheContext() (sdk.Context, *CachedCtxCheckpoint) {

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -510,7 +510,6 @@ func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) commo
 
 // GetStateAndCommittedState returns the current value and the committed value.
 func (s *StateDB) GetStateAndCommittedState(addr common.Address, hash common.Hash) (common.Hash, common.Hash) {
-	// TODO (geth-upgrade): check when reviewing state access changes in 1.16.9.
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.GetState(hash), stateObject.GetCommittedState(hash)

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -450,7 +450,6 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 		panic("unsupported on Mezo: empty-account deletion during Finalise")
 	}
 
-	s.logs = nil
 	s.refund = 0
 	s.transientStorage = newTransientStorage()
 	s.ongoingPrecompilesCallsCounter = 0
@@ -461,6 +460,9 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 	for _, obj := range s.stateObjects {
 		obj.newContract = false
 	}
+
+	// Since we are using Finalise() for simulations, we also clear the logs.
+	s.logs = nil
 }
 
 // GetCode returns the code of account, nil if not exists.

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -464,6 +464,11 @@ func (s *StateDB) Finalise(_ bool) {}
 // The revision stack is wiped, so a stale revision id will fail
 // RevertToSnapshot. The simulate driver does not snapshot at the top
 // level; future drivers must preserve that.
+//
+// Divergence from geth: self-destructed objects stay live in
+// s.stateObjects until Commit. In a simulated call sequence, call N+1
+// can therefore still observe Exist(addr)==true for an account
+// self-destructed in call N.
 func (s *StateDB) ResetTxEphemerals() {
 	s.logs = nil
 	s.refund = 0

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -434,22 +434,38 @@ func (s *StateDB) AccessEvents() *gethstate.AccessEvents {
 	return nil
 }
 
-// Finalise clears per-call state for flows that reuse one StateDB without
-// committing between calls, such as simulations. Normal transaction execution
-// does not call it because Mezod creates and discards a StateDB per transaction.
+// Finalise satisfies vm.StateDB on go-ethereum v1.16.9. It's a no-op
+// stub kept solely for interface compliance.
 //
-// State objects, access list, and the live cached Cosmos context are preserved,
-// so accumulated cross-call account/storage mutations and precompile-side writes
-// remain visible. The journal and revision stack are cleared to bound memory and
-// to prevent reverting across call boundaries. Callers must not hold a live
-// Snapshot() across this call.
+// Geth's Finalise flushes dirty objects toward a trie root and may
+// delete EIP-158-empty accounts. Mezo does neither, because it uses
+// a fresh StateDB per tx and account-level deletion lives at the
+// keeper layer.
 //
 //nolint:misspell
-func (s *StateDB) Finalise(deleteEmptyObjects bool) {
-	if deleteEmptyObjects {
-		panic("unsupported on Mezo: empty-account deletion during Finalise")
-	}
+func (s *StateDB) Finalise(_ bool) {}
 
+// ResetTxEphemerals clears per-call ephemeral state (logs, refund,
+// transient storage, journal, revision stack, and the EIP-6780
+// newContract flag) and resets the precompile-call counter while
+// preserving state objects, access list, and the live cached cosmos
+// ctx — so accumulated cross-call account/storage mutations and
+// precompile-side writes remain visible. Used by simulate drivers
+// running several calls against a shared StateDB without committing
+// between them.
+//
+// Clearing the journal bounds memory: each custom-precompile call
+// appends a multistore Clone() to the journal, which would otherwise
+// accumulate across the whole request. It also disarms the latent
+// panic where addLogChange.Revert reads s.logs[len-1] after s.logs
+// has been cleared by a prior ResetTxEphemerals call.
+//
+// Invariant: callers must not hold a live Snapshot() across this call.
+// The revision stack is wiped, so a stale revision id will fail
+// RevertToSnapshot. The simulate driver does not snapshot at the top
+// level; future drivers must preserve that.
+func (s *StateDB) ResetTxEphemerals() {
+	s.logs = nil
 	s.refund = 0
 	s.transientStorage = newTransientStorage()
 	s.ongoingPrecompilesCallsCounter = 0
@@ -457,12 +473,17 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 	s.validRevisions = nil
 	s.nextRevisionID = 0
 
+	// EIP-6780: each simulated call is a separate transaction, so
+	// newContract has to be cleared between calls — otherwise a
+	// contract created in call N could be 6780-destroyed in call N+1.
+	// Geth handles this at end-of-tx by iterating journal.dirties;
+	// we just reset the journal above, so dirties is empty by the
+	// time this loop runs. Iterating live state objects sidesteps
+	// that ordering dependency, and the assignment is a no-op for
+	// anything that never had the flag.
 	for _, obj := range s.stateObjects {
 		obj.newContract = false
 	}
-
-	// Since we are using Finalise() for simulations, we also clear the logs.
-	s.logs = nil
 }
 
 // GetCode returns the code of account, nil if not exists.

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -430,7 +430,7 @@ func (s *StateDB) Witness() *stateless.Witness {
 }
 
 func (s *StateDB) AccessEvents() *gethstate.AccessEvents {
-	// TODO (geth-upgrade): implement when adding support for the new access-event flow in 1.16.9.
+	// Mezo does not activate Verkle/EIP-4762 and does not rely on Verkle trees.
 	return nil
 }
 

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -446,9 +446,9 @@ func (s *StateDB) AccessEvents() *gethstate.AccessEvents {
 //
 //nolint:misspell
 func (s *StateDB) Finalise(deleteEmptyObjects bool) {
-	// Required by geth's StateDB interface. Mezod does not use Finalise for
-	// canonical empty-account deletion.
-	_ = deleteEmptyObjects
+	if deleteEmptyObjects {
+		panic("unsupported on Mezo: empty-account deletion during Finalise")
+	}
 
 	s.logs = nil
 	s.refund = 0

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -456,6 +456,11 @@ func (suite *StateDBTestSuite) TestGetStateAndCommittedState() {
 	suite.Require().Equal(common.Hash{}, committed)
 }
 
+func (suite *StateDBTestSuite) TestAccessEvents() {
+	db := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
+	suite.Require().Nil(db.AccessEvents())
+}
+
 func (suite *StateDBTestSuite) TestMutationReturnValues() {
 	key := common.BigToHash(big.NewInt(1))
 	value1 := common.BigToHash(big.NewInt(2))
@@ -891,6 +896,7 @@ func (suite *StateDBTestSuite) TestCommittedStateChanges() {
 func (suite *StateDBTestSuite) TestResetTxEphemeralsReusableStateDB() {
 	key1 := common.BigToHash(big.NewInt(1))
 	value1 := common.BigToHash(big.NewInt(2))
+	addr2 := common.BigToAddress(big.NewInt(202))
 
 	// The suite's ctx carries a real MultiStore, required for
 	// CacheContext() when we exercise the precompile-call counter.
@@ -905,14 +911,23 @@ func (suite *StateDBTestSuite) TestResetTxEphemeralsReusableStateDB() {
 	// must survive the reset.
 	db.AddBalance(address, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
 	db.CreateContract(address)
+	db.AddBalance(addr2, uint256.NewInt(50), tracing.BalanceChangeUnspecified)
+	db.CreateContract(addr2)
 	db.AddLog(&ethtypes.Log{Address: address})
 	db.AddRefund(42)
 	db.SetTransientState(address, key1, value1)
 
 	// Trigger the precompile-call counter via a registered cache-ctx
-	// checkpoint so we can observe it resetting.
+	// checkpoint so we can observe it hitting the cap and then resetting.
 	_, ccp := db.CacheContext()
-	suite.Require().NoError(
+	maxCalls := suite.app.EvmKeeper.GetMaxPrecompilesCallsPerExecution(suite.ctx)
+	suite.Require().NotZero(maxCalls)
+	for i := uint(0); i < maxCalls; i++ {
+		suite.Require().NoError(
+			db.RegisterCachedCtxCheckpoint(address, ccp),
+		)
+	}
+	suite.Require().Error(
 		db.RegisterCachedCtxCheckpoint(address, ccp),
 	)
 
@@ -935,17 +950,23 @@ func (suite *StateDBTestSuite) TestResetTxEphemeralsReusableStateDB() {
 	// Account mutation is preserved: state objects are not dropped.
 	suite.Require().True(db.Exist(address))
 	suite.Require().Equal(uint256.NewInt(100), db.GetBalance(address))
+	suite.Require().True(db.Exist(addr2))
+	suite.Require().Equal(uint256.NewInt(50), db.GetBalance(addr2))
 	balance, destroyed := db.SelfDestruct6780(address)
 	suite.Require().False(destroyed)
 	suite.Require().Equal(*uint256.NewInt(100), balance)
+	balance, destroyed = db.SelfDestruct6780(addr2)
+	suite.Require().False(destroyed)
+	suite.Require().Equal(*uint256.NewInt(50), balance)
 
-	// The counter is reset: after the reset we can register
-	// checkpoints up to the EvmKeeper's cap anew. The cap is not
-	// exposed from the test package, so we exercise the "fresh start"
-	// guarantee by confirming at least one additional registration
-	// succeeds post-reset even though the counter was already
-	// incremented before.
-	suite.Require().NoError(
+	// The counter is reset: after the reset we can register up to the
+	// cap anew, and the next registration fails again.
+	for i := uint(0); i < maxCalls; i++ {
+		suite.Require().NoError(
+			db.RegisterCachedCtxCheckpoint(address, ccp),
+		)
+	}
+	suite.Require().Error(
 		db.RegisterCachedCtxCheckpoint(address, ccp),
 	)
 

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -456,6 +456,57 @@ func (suite *StateDBTestSuite) TestGetStateAndCommittedState() {
 	suite.Require().Equal(common.Hash{}, committed)
 }
 
+func (suite *StateDBTestSuite) TestMutationReturnValues() {
+	key := common.BigToHash(big.NewInt(1))
+	value1 := common.BigToHash(big.NewInt(2))
+	value2 := common.BigToHash(big.NewInt(3))
+	code1 := []byte("hello world")
+	code2 := []byte("goodbye world")
+
+	db := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
+
+	prevBalance := db.AddBalance(address, uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	suite.Require().Equal(*uint256.NewInt(0), prevBalance)
+
+	prevBalance = db.AddBalance(address, uint256.NewInt(5), tracing.BalanceChangeUnspecified)
+	suite.Require().Equal(*uint256.NewInt(10), prevBalance)
+
+	prevBalance = db.SubBalance(address, uint256.NewInt(3), tracing.BalanceChangeUnspecified)
+	suite.Require().Equal(*uint256.NewInt(15), prevBalance)
+
+	prevCode := db.SetCode(address, code1, tracing.CodeChangeUnspecified)
+	suite.Require().Nil(prevCode)
+
+	prevCode = db.SetCode(address, code2, tracing.CodeChangeUnspecified)
+	suite.Require().Equal(code1, prevCode)
+
+	prevState := db.SetState(address, key, value1)
+	suite.Require().Equal(common.Hash{}, prevState)
+
+	prevState = db.SetState(address, key, value2)
+	suite.Require().Equal(value1, prevState)
+
+	prevBalance = db.SelfDestruct(address)
+	suite.Require().Equal(*uint256.NewInt(12), prevBalance)
+}
+
+func (suite *StateDBTestSuite) TestSelfDestruct6780ReturnValues() {
+	existingDB := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
+	existingDB.AddBalance(address, uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+
+	prevBalance, destroyed := existingDB.SelfDestruct6780(address)
+	suite.Require().Equal(*uint256.NewInt(10), prevBalance)
+	suite.Require().False(destroyed)
+
+	createdDB := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
+	createdDB.AddBalance(address, uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	createdDB.CreateContract(address)
+
+	prevBalance, destroyed = createdDB.SelfDestruct6780(address)
+	suite.Require().Equal(*uint256.NewInt(10), prevBalance)
+	suite.Require().True(destroyed)
+}
+
 func (suite *StateDBTestSuite) TestFinalise() {
 	key := common.BigToHash(big.NewInt(1))
 	value := common.BigToHash(big.NewInt(2))

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -540,6 +540,18 @@ func (suite *StateDBTestSuite) TestFinalise() {
 	suite.Require().NoError(db.Commit())
 }
 
+func (suite *StateDBTestSuite) TestFinaliseDeleteEmptyObjectsUnsupported() {
+	db := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
+
+	suite.Require().PanicsWithValue(
+		"unsupported on Mezo: empty-account deletion during Finalise",
+		func() {
+			//nolint:misspell
+			db.Finalise(true)
+		},
+	)
+}
+
 func (suite *StateDBTestSuite) TestAccessList() {
 	value1 := common.BigToHash(big.NewInt(1))
 	value2 := common.BigToHash(big.NewInt(2))

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -524,7 +524,9 @@ func (suite *StateDBTestSuite) TestFinaliseNoOp() {
 	db.SetState(address, key, value)
 	db.Snapshot()
 
+	//nolint:misspell
 	db.Finalise(false)
+	//nolint:misspell
 	db.Finalise(true)
 
 	suite.Require().Equal(uint64(42), db.GetRefund())

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -415,6 +415,47 @@ func (suite *StateDBTestSuite) TestInvalidSnapshotId() {
 	})
 }
 
+func (suite *StateDBTestSuite) TestGetStateAndCommittedState() {
+	key1 := common.BigToHash(big.NewInt(1))
+	value1 := common.BigToHash(big.NewInt(2))
+	value2 := common.BigToHash(big.NewInt(3))
+	key2 := common.BigToHash(big.NewInt(4))
+	value3 := common.BigToHash(big.NewInt(5))
+
+	keeper := statedb.NewMockKeeper()
+	db := statedb.New(sdk.Context{}, keeper, emptyTxConfig)
+
+	current, committed := db.GetStateAndCommittedState(address, key1)
+	suite.Require().Equal(common.Hash{}, current)
+	suite.Require().Equal(common.Hash{}, committed)
+
+	db.SetState(address, key1, value1)
+	suite.Require().NoError(db.Commit())
+
+	db = statedb.New(sdk.Context{}, keeper, emptyTxConfig)
+	current, committed = db.GetStateAndCommittedState(address, key1)
+	suite.Require().Equal(value1, current)
+	suite.Require().Equal(value1, committed)
+
+	db.SetState(address, key1, value2)
+	current, committed = db.GetStateAndCommittedState(address, key1)
+	suite.Require().Equal(value2, current)
+	suite.Require().Equal(value1, committed)
+
+	db = statedb.New(sdk.Context{}, keeper, emptyTxConfig)
+	db.OverrideStorage(address, map[common.Hash]common.Hash{
+		key2: value3,
+	})
+
+	current, committed = db.GetStateAndCommittedState(address, key1)
+	suite.Require().Equal(common.Hash{}, current)
+	suite.Require().Equal(common.Hash{}, committed)
+
+	current, committed = db.GetStateAndCommittedState(address, key2)
+	suite.Require().Equal(value3, current)
+	suite.Require().Equal(common.Hash{}, committed)
+}
+
 func (suite *StateDBTestSuite) TestFinalise() {
 	key := common.BigToHash(big.NewInt(1))
 	value := common.BigToHash(big.NewInt(2))

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -415,6 +415,39 @@ func (suite *StateDBTestSuite) TestInvalidSnapshotId() {
 	})
 }
 
+func (suite *StateDBTestSuite) TestFinalise() {
+	key := common.BigToHash(big.NewInt(1))
+	value := common.BigToHash(big.NewInt(2))
+
+	db := statedb.New(suite.ctx, suite.app.EvmKeeper, emptyTxConfig)
+	rules := params.Rules{IsBerlin: true}
+	db.Prepare(rules, address, address, nil, nil, nil)
+
+	db.CreateAccount(address)
+	db.CreateContract(address)
+	db.AddRefund(42)
+	db.SetTransientState(address, key, value)
+	db.AddLog(&ethtypes.Log{Address: address})
+	db.AddBalance(address, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	db.SetState(address, key, value)
+	db.Snapshot()
+
+	//nolint:misspell
+	db.Finalise(false)
+
+	suite.Require().Equal(uint64(0), db.GetRefund())
+	suite.Require().Equal(common.Hash{}, db.GetTransientState(address, key))
+	suite.Require().Empty(db.Logs())
+	suite.Require().Panics(func() {
+		db.RevertToSnapshot(0)
+	})
+	balance, destroyed := db.SelfDestruct6780(address)
+	suite.Require().False(destroyed)
+	suite.Require().Equal(*uint256.NewInt(100), balance)
+
+	suite.Require().NoError(db.Commit())
+}
+
 func (suite *StateDBTestSuite) TestAccessList() {
 	value1 := common.BigToHash(big.NewInt(1))
 	value2 := common.BigToHash(big.NewInt(2))
@@ -761,7 +794,7 @@ func (suite *StateDBTestSuite) TestCommittedStateChanges() {
 	suite.Require().Equal(value2, changeMap[key2].Value)
 }
 
-func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
+func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
 	key1 := common.BigToHash(big.NewInt(1))
 	value1 := common.BigToHash(big.NewInt(2))
 
@@ -777,6 +810,7 @@ func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
 	// Prime per-call ephemeral state alongside an account mutation that
 	// must survive the finalize.
 	db.AddBalance(address, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	db.CreateContract(address)
 	db.AddLog(&ethtypes.Log{Address: address})
 	db.AddRefund(42)
 	db.SetTransientState(address, key1, value1)
@@ -798,7 +832,8 @@ func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
 	suite.Require().Equal(uint64(42), db.GetRefund())
 	suite.Require().Equal(value1, db.GetTransientState(address, key1))
 
-	db.FinaliseBetweenCalls()
+	//nolint:misspell
+	db.Finalise(false)
 
 	suite.Require().Empty(db.Logs())
 	suite.Require().Equal(uint64(0), db.GetRefund())
@@ -807,6 +842,9 @@ func (suite *StateDBTestSuite) TestFinaliseBetweenCalls() {
 	// Account mutation is preserved: state objects are not dropped.
 	suite.Require().True(db.Exist(address))
 	suite.Require().Equal(uint256.NewInt(100), db.GetBalance(address))
+	balance, destroyed := db.SelfDestruct6780(address)
+	suite.Require().False(destroyed)
+	suite.Require().Equal(*uint256.NewInt(100), balance)
 
 	// The counter is reset: after the finalize we can register
 	// checkpoints up to the EvmKeeper's cap anew. The cap is not

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -507,7 +507,7 @@ func (suite *StateDBTestSuite) TestSelfDestruct6780ReturnValues() {
 	suite.Require().True(destroyed)
 }
 
-func (suite *StateDBTestSuite) TestFinalise() {
+func (suite *StateDBTestSuite) TestFinaliseNoOp() {
 	key := common.BigToHash(big.NewInt(1))
 	value := common.BigToHash(big.NewInt(2))
 
@@ -524,32 +524,20 @@ func (suite *StateDBTestSuite) TestFinalise() {
 	db.SetState(address, key, value)
 	db.Snapshot()
 
-	//nolint:misspell
 	db.Finalise(false)
+	db.Finalise(true)
 
-	suite.Require().Equal(uint64(0), db.GetRefund())
-	suite.Require().Equal(common.Hash{}, db.GetTransientState(address, key))
-	suite.Require().Empty(db.Logs())
-	suite.Require().Panics(func() {
+	suite.Require().Equal(uint64(42), db.GetRefund())
+	suite.Require().Equal(value, db.GetTransientState(address, key))
+	suite.Require().Len(db.Logs(), 1)
+	suite.Require().NotPanics(func() {
 		db.RevertToSnapshot(0)
 	})
 	balance, destroyed := db.SelfDestruct6780(address)
-	suite.Require().False(destroyed)
+	suite.Require().True(destroyed)
 	suite.Require().Equal(*uint256.NewInt(100), balance)
 
 	suite.Require().NoError(db.Commit())
-}
-
-func (suite *StateDBTestSuite) TestFinaliseDeleteEmptyObjectsUnsupported() {
-	db := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
-
-	suite.Require().PanicsWithValue(
-		"unsupported on Mezo: empty-account deletion during Finalise", //nolint:misspell
-		func() {
-			//nolint:misspell
-			db.Finalise(true)
-		},
-	)
 }
 
 func (suite *StateDBTestSuite) TestAccessList() {
@@ -898,7 +886,7 @@ func (suite *StateDBTestSuite) TestCommittedStateChanges() {
 	suite.Require().Equal(value2, changeMap[key2].Value)
 }
 
-func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
+func (suite *StateDBTestSuite) TestResetTxEphemeralsReusableStateDB() {
 	key1 := common.BigToHash(big.NewInt(1))
 	value1 := common.BigToHash(big.NewInt(2))
 
@@ -912,7 +900,7 @@ func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
 	db.Prepare(rules, address, address, nil, nil, nil)
 
 	// Prime per-call ephemeral state alongside an account mutation that
-	// must survive the finalize.
+	// must survive the reset.
 	db.AddBalance(address, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
 	db.CreateContract(address)
 	db.AddLog(&ethtypes.Log{Address: address})
@@ -926,7 +914,7 @@ func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
 		db.RegisterCachedCtxCheckpoint(address, ccp),
 	)
 
-	// Bump the revision stack so the post-finalize id reset is
+	// Bump the revision stack so the post-reset id reset is
 	// observable. Without these calls nextRevisionID is already 0 and
 	// the assertion below would hold tautologically.
 	suite.Require().Equal(0, db.Snapshot())
@@ -936,8 +924,7 @@ func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
 	suite.Require().Equal(uint64(42), db.GetRefund())
 	suite.Require().Equal(value1, db.GetTransientState(address, key1))
 
-	//nolint:misspell
-	db.Finalise(false)
+	db.ResetTxEphemerals()
 
 	suite.Require().Empty(db.Logs())
 	suite.Require().Equal(uint64(0), db.GetRefund())
@@ -950,11 +937,11 @@ func (suite *StateDBTestSuite) TestFinaliseReusableStateDB() {
 	suite.Require().False(destroyed)
 	suite.Require().Equal(*uint256.NewInt(100), balance)
 
-	// The counter is reset: after the finalize we can register
+	// The counter is reset: after the reset we can register
 	// checkpoints up to the EvmKeeper's cap anew. The cap is not
 	// exposed from the test package, so we exercise the "fresh start"
 	// guarantee by confirming at least one additional registration
-	// succeeds post-finalize even though the counter was already
+	// succeeds post-reset even though the counter was already
 	// incremented before.
 	suite.Require().NoError(
 		db.RegisterCachedCtxCheckpoint(address, ccp),

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -544,7 +544,7 @@ func (suite *StateDBTestSuite) TestFinaliseDeleteEmptyObjectsUnsupported() {
 	db := statedb.New(sdk.Context{}, statedb.NewMockKeeper(), emptyTxConfig)
 
 	suite.Require().PanicsWithValue(
-		"unsupported on Mezo: empty-account deletion during Finalise",
+		"unsupported on Mezo: empty-account deletion during Finalise", //nolint:misspell
 		func() {
 			//nolint:misspell
 			db.Finalise(true)


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/MEZO-4005/statedb-interface-compliance

### Introduction

This PR brings Mezod’s custom `StateDB` in line with the `go-ethereum v1.16.9` interface.

The main change is adding the new `Finalise()` method for interface compliance and introducing `ResetTxEphemerals()` for flows that reuse a `StateDB` between simulated calls, such as `eth_simulateV1`. Normal on-chain transaction execution is unchanged: Mezod still creates and discards a `StateDB` per transaction.

The PR also implements `AccessEvents()` and finishes `GetStateAndCommittedState()`. Mezod does not support Verkle / EIP-4762 today, so `AccessEvents()` returns `nil`.

### Changes

- Implemented `Finalise()` as a no-op interface-compliance stub.
- Added `ResetTxEphemerals()` for simulation call boundaries.
- Implemented `AccessEvents()`.
- Finished `GetStateAndCommittedState()`.
- Added coverage for new `StateDB` return values and reset behavior.

### Testing

- `go test ./x/evm/statedb`


---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [X] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
