### PR TITLE
Make eth_simulateV1 system test suites portable across live chains

### DIFF
--- a/tests/system/test/SimulateV1_MezoDivergence.test.ts
+++ b/tests/system/test/SimulateV1_MezoDivergence.test.ts
@@ -33,8 +33,8 @@ import btcabi from "../../../precompile/btctoken/abi.json"
  *
  * | Scenario                            | Given                                | When                                              | Then                                                                    |
  * |-------------------------------------|--------------------------------------|---------------------------------------------------|-------------------------------------------------------------------------|
- * | btctoken state chains across calls  | dev0 pre-funded with native BTC      | btctoken.transfer + .balanceOf in one block       | both succeed; balanceOf returns the transferred amount                  |
- * | btctoken state chains across blocks | dev0 pre-funded with native BTC      | btctoken.transfer in block 1; .balanceOf in 2     | block 2 reads block 1's amount via the cached Cosmos context            |
+ * | btctoken state chains across calls  | signer holds any non-zero native BTC | btctoken.transfer + .balanceOf in one block       | both succeed; balanceOf returns the transferred amount                  |
+ * | btctoken state chains across blocks | signer holds any non-zero native BTC | btctoken.transfer in block 1; .balanceOf in 2     | block 2 reads block 1's amount via the cached Cosmos context            |
  * | BTC custom precompile move rejected | btctoken precompile (immovable)      | eth_call with movePrecompileToAddress             | request rejected; message contains "cannot move mezo custom precompile" |
  * | BlockOverrides.beaconRoot rejected  | post-Cancun field unsupported        | eth_simulateV1 with blockOverrides.beaconRoot     | -32602 with a BeaconRoot-specific message                               |
  * | BlockOverrides.withdrawals rejected | post-Cancun field unsupported        | eth_simulateV1 with blockOverrides.withdrawals    | -32602 with a Withdrawals-specific message                              |
@@ -111,8 +111,9 @@ describe("SimulateV1_MezoDivergence", function () {
     // Cosmos bank keeper, not the EVM journal — their mutations ride in
     // the StateDB's cached Cosmos context and must survive call
     // boundaries. balance stateOverrides only touch the EVM state object
-    // and do not propagate to bankKeeper, so this case leans on the
-    // localnode dev0 signer's real pre-funded BTC balance.
+    // and do not propagate to bankKeeper, so the signer must hold real
+    // on-chain BTC of at least transferAmount. Pinned to 1000 wei to
+    // keep the case light on live chains (localnode, staging, testnet).
     let result: any[]
 
     before(async function () {
@@ -121,7 +122,7 @@ describe("SimulateV1_MezoDivergence", function () {
         btcabi,
         ethers.provider,
       )
-      const transferAmount = ethers.parseEther("0.5")
+      const transferAmount = 1000n
       const transferData = btcToken.interface.encodeFunctionData("transfer", [
         recipientAddr,
         transferAmount,
@@ -157,7 +158,7 @@ describe("SimulateV1_MezoDivergence", function () {
         ["uint256"],
         calls[1].returnData,
       )
-      expect(balance).to.equal(ethers.parseEther("0.5"))
+      expect(balance).to.equal(1000n)
     })
   })
 
@@ -173,7 +174,7 @@ describe("SimulateV1_MezoDivergence", function () {
         btcabi,
         ethers.provider,
       )
-      const transferAmount = ethers.parseEther("0.5")
+      const transferAmount = 1000n
       const transferData = btcToken.interface.encodeFunctionData("transfer", [
         recipient,
         transferAmount,
@@ -220,7 +221,7 @@ describe("SimulateV1_MezoDivergence", function () {
         block2Call.returnData,
       )
       expect(balance).to.equal(
-        ethers.parseEther("0.5"),
+        1000n,
         "block 2 must observe block 1's btctoken.transfer through the StateDB's cached Cosmos context",
       )
     })

--- a/tests/system/test/SimulateV1_SpecCompliance.test.ts
+++ b/tests/system/test/SimulateV1_SpecCompliance.test.ts
@@ -229,6 +229,20 @@ describe("SimulateV1_SpecCompliance", function () {
     }
   }
 
+  // freshAnchor fetches the chain's current latest header. Contexts
+  // that derive override values from `latest.{timestamp,number}` MUST
+  // call this inside their own before(): on a live chain the head
+  // advances during the suite (50+ s wall-clock), so a one-shot
+  // file-level capture goes stale and `latestTime + N` falls below
+  // the simulate's parent.timestamp, tripping a spurious -38021. The
+  // per-context refresh keeps the override window valid regardless of
+  // when the context runs.
+  async function freshAnchor(): Promise<{ time: bigint; num: bigint }> {
+    const latest = await ethers.provider.getBlock("latest")
+    if (!latest) throw new Error("no latest block")
+    return { time: BigInt(latest.timestamp), num: BigInt(latest.number) }
+  }
+
   // -----------------------------------------------------------------
   // Shared resources captured once, used by many contexts. Each
   // context's own setup goes in its local before() below.
@@ -237,11 +251,6 @@ describe("SimulateV1_SpecCompliance", function () {
   let tokenAddr: string
   let senderAddr: string
   let recipientAddr: string
-  // Captured at file-level so override values that anchor on
-  // latestTime/latestBlockNum stay valid even if the live localnode
-  // head advances during the suite.
-  let latestTime: bigint
-  let latestBlockNum: bigint
   let baseStateOverrides: Record<string, { balance: string }>
 
   const AMOUNT = ethers.parseUnits("1", 18)
@@ -254,11 +263,6 @@ describe("SimulateV1_SpecCompliance", function () {
     const [deployer] = await ethers.getSigners()
     senderAddr = deployer.address
     recipientAddr = ethers.Wallet.createRandom().address
-
-    const latest = await ethers.provider.getBlock("latest")
-    if (!latest) throw new Error("no latest block")
-    latestTime = BigInt(latest.timestamp)
-    latestBlockNum = BigInt(latest.number)
 
     baseStateOverrides = {
       [senderAddr]: { balance: ethers.toQuantity(ethers.parseEther("100")) },
@@ -541,6 +545,7 @@ describe("SimulateV1_SpecCompliance", function () {
       // BLOCKHASH(genesis_height) can return zero on some EVM rules,
       // so the previous block is the safer probe.
       const reader = ethers.getAddress("0x" + "babe".repeat(10))
+      const { num: latestBlockNum } = await freshAnchor()
       const probedHeight = latestBlockNum - 1n
       const r = await simulate({
         blockStateCalls: [
@@ -1353,6 +1358,8 @@ describe("SimulateV1_SpecCompliance", function () {
     }
 
     before(async function () {
+      const { time: latestTime, num: latestBlockNum } = await freshAnchor()
+
       // -38020: numbers must be strictly increasing. Both overrides
       // must sit above latestBlockNum so the first block clears the
       // base-anchored span check; -38020 then fires on the second
@@ -1405,6 +1412,8 @@ describe("SimulateV1_SpecCompliance", function () {
     let blocknumberIncrementBlocks: any[]
 
     before(async function () {
+      const { time: latestTime, num: latestBlockNum } = await freshAnchor()
+
       // Auto-increment: only first `time` set; second block must end
       // up with timestamp > first. Anchor the explicit timestamp above
       // latestTime so the first block does not trip -38021 against base.
@@ -1491,6 +1500,7 @@ describe("SimulateV1_SpecCompliance", function () {
     let r: { error: CapturedError; result: any[] | undefined }
 
     before(async function () {
+      const { num: latestBlockNum } = await freshAnchor()
       const future = latestBlockNum + 1_000_000n
       r = await simulateAt(
         {
@@ -1521,6 +1531,7 @@ describe("SimulateV1_SpecCompliance", function () {
       // monotonicity path. Pin the anchor to latestBlockNum so the
       // override stays valid even if the live localnode head advances
       // during the suite.
+      const { num: latestBlockNum } = await freshAnchor()
       const a = latestBlockNum + 1n
       const b = a + 1n
       const r = await simulateAt(
@@ -1758,6 +1769,7 @@ describe("SimulateV1_SpecCompliance", function () {
       // the live localnode head advances during the suite. base+1 keeps
       // the simulator from gap-filling empty headers.
       const target = "0xc100000000000000000000000000000000000000"
+      const { num: latestBlockNum } = await freshAnchor()
       const probeNumber = latestBlockNum + 1n
       const r = await simulateAt(
         {
@@ -2336,14 +2348,20 @@ describe("SimulateV1_SpecCompliance", function () {
           { calls: [{ from: senderAddr, to: tokenAddr, data: transferData }] },
         ],
       }
+      // Both runs MUST anchor at the same explicit block number, not
+      // "latest" — on a live chain a new canonical block can land
+      // between the two calls, swapping the parent and changing the
+      // simulated block hash. Capturing the anchor once here keeps the
+      // determinism invariant the test pins.
+      const anchor = ethers.toQuantity((await freshAnchor()).num)
       const blocks: any[] = await ethers.provider.send("eth_simulateV1", [
         opts,
-        "latest",
+        anchor,
       ])
       block = blocks[0]
       const blocksRerun: any[] = await ethers.provider.send(
         "eth_simulateV1",
-        [opts, "latest"],
+        [opts, anchor],
       )
       blockRerun = blocksRerun[0]
     })


### PR DESCRIPTION
### Introduction

The two `eth_simulateV1` system test suites (`SimulateV1_SpecCompliance` and `SimulateV1_MezoDivergence`) now run unmodified against any live mezod node — localnode, staging, or testnet — without environment-specific tuning. Prior to this change the suites assumed two localnode-only invariants: an unfunded but always-pre-loaded dev0 signer, and a chain whose head does not advance during the ~50 s wall-clock of a full suite run. Both assumptions break on staging and testnet, where the suites would either fail outright (insufficient funds for a hardcoded 0.5 BTC transfer) or report flaky failures depending on block timing (stale anchors, racing parents).

### Changes

#### `SimulateV1_MezoDivergence.test.ts` — btctoken state-chain transfer is light enough for any signer

The two btctoken state-chain cases (`custom Mezo precompile state chains across calls` and `... across blocks`) now transfer `1000n` wei (≈ 1e-15 BTC) instead of `parseEther("0.5")`. The invariant they pin — that custom-precompile state writes propagate across calls and across blocks via the shared `*statedb.StateDB` cached Cosmos context — does not depend on the magnitude of the transfer; any non-zero amount exercises the same `bankKeeper` write path. Lowering the value lets a test signer with any non-zero native BTC balance (plus gas headroom) run the suite, instead of needing ≥ 0.5 BTC of real funds on the target chain before each run. The case-level inline comment and the file-header scenario table were updated to reflect the relaxed prerequisite.

#### `SimulateV1_SpecCompliance.test.ts` — per-test anchor refresh; deterministic hash-stability anchor

Six contexts (`BLOCKHASH below base falls through to canonical chain`, `block ordering errors`, `block timestamp / number auto-increment`, `future block anchor`, `override block num`, `block-override reflected in contract`) derive override values from `latest.{timestamp,number}` of the canonical chain. Those values were previously captured once in the file-level `before()` and reused across the entire suite. On a chain that produces blocks during the suite, `latestTime + 10` lands below the simulator's parent timestamp by the time a dependent context executes, tripping a spurious top-level `-38021`. The file-level captures are removed; a new `freshAnchor()` helper reads the canonical head on demand, and each affected `before()` calls it at its own start so override windows stay valid wherever the context runs in the suite ordering.

The hash-stability assertion `Block envelope: non-empty block / hash is stable across identical re-runs` previously issued two `eth_simulateV1` calls anchored at `"latest"`. A canonical block landing between those two calls swapped the parent and changed the simulated block hash, producing a flaky mismatch. Both calls now anchor at the same explicit block number captured up-front via `freshAnchor()`, so the determinism invariant holds regardless of canonical-chain timing.

### Testing

`tests/system/test/SimulateV1_SpecCompliance.test.ts` and `tests/system/test/SimulateV1_MezoDivergence.test.ts` executed end-to-end against both target environments. **82/82 passing on each.**

| Environment | Endpoint | Signer | Result | Wall time |
|---|---|---|---|---|
| localnode (fresh genesis) | `http://127.0.0.1:8545` | dev0 (pre-funded) | 82/82 ✅ | 20 s |
| mezo-staging `mezo-node-4` | `http://mezo-node-4.test.mezo.org:8545` | funded with ~0.6 BTC | 82/82 ✅ | 50 s |

Reproducer commands:

```
# Localnode
make localnode-bin-start
cd tests/system && npx hardhat test ./test/SimulateV1_SpecCompliance.test.ts ./test/SimulateV1_MezoDivergence.test.ts --network localhost

# mezo-staging
cd tests/system && NETWORK=testnet RPC_URL=http://mezo-node-4.test.mezo.org:8545 PRIVATE_KEYS=0x<funded-key> \
  npx hardhat test ./test/SimulateV1_SpecCompliance.test.ts ./test/SimulateV1_MezoDivergence.test.ts --network testnet
```

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
