### PR TITLE
Add proto messages for SetCode transactions

### DIFF
--- a/.claude/MEZO-4013-eip7702-set-code/roadmap.md
+++ b/.claude/MEZO-4013-eip7702-set-code/roadmap.md
@@ -8,9 +8,13 @@
 
 ## Current progress
 
-- **Phase 1 — done.** `prague_time` plumbed through `ChainConfig`, plus
-  the eight additional fork-time placeholders bundled in via MEZO-4007.
+- **Phase 1.** `prague_time` plumbed through `ChainConfig`, plus the
+  eight additional fork-time placeholders bundled in via MEZO-4007.
   PR: [#673](https://github.com/mezo-org/mezod/pull/673).
+- **Phase 2.** `SetCodeTx` and `SetCodeAuthorization` proto messages
+  plus the Cosmos `TxData` implementation, with stateless validation
+  and a pre-Prague ante gate.
+  PR: [#674](https://github.com/mezo-org/mezod/pull/674).
 
 ## Status of prerequisites
 

--- a/.claude/MEZO-4013-eip7702-set-code/roadmap.md
+++ b/.claude/MEZO-4013-eip7702-set-code/roadmap.md
@@ -251,11 +251,12 @@ and ensure regressions are visible.
   designator.
 - New suite `tests/system/test/Eip7702MezoDivergence.test.ts`:
   pin every spec divergence (no mempool authority reservation;
-  storage retained on delegation clear; reimplemented
-  validate/apply path in keeper; no Mezo-specific signer adapter).
+  reimplemented validate/apply path in keeper; no Mezo-specific
+  signer adapter).
 - Keeper-level fuzz target on the `SetCodeTx` proto unmarshaler.
-- Update `docs/evm-compatibility.md` to flip EIP-7702 from "out of
-  scope" / "deferred" to "supported", with a back-link to the spec.
+- Add a Prague section to `docs/evm-compatibility.md` following the
+  Cancun template, listing EIP-7702 as supported with a back-link to
+  `spec.md`.
 
 **Out of scope.** Production activation and any change to live chain
 config.
@@ -340,7 +341,9 @@ on cadence and gate the live-chain switch on its own review.
   §"Key decisions" (reimplement, don't refactor).
 - New per-node configuration for EIP-7702 enable/disable. Per spec
   §"Configuration".
-- Storage-clearing extensions when a delegation is cleared. Per spec
-  divergence #3.
+- Storage-clearing extensions when a delegation is cleared. Slots
+  written by a prior delegate persist after the delegation is cleared
+  and remain readable by a subsequent re-delegation of the same
+  authority.
 - `eth_simulateV1` validation-mode handling for auth lists. Tracked in
   `MEZO-4336` Phase 15.

--- a/app/ante/evm/ante_test.go
+++ b/app/ante/evm/ante_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	ethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 	utiltx "github.com/mezo-org/mezod/testutil/tx"
 	evmtypes "github.com/mezo-org/mezod/x/evm/types"
 )
@@ -1090,4 +1092,60 @@ func (suite *AnteTestSuite) TestAnteWithMulitpleSdkMsgs() {
 	if suite.Error(err, "expected error") {
 		suite.EqualError(err, "cannot submit more than one transaction at a time: feature not supported")
 	}
+}
+
+func (suite *AnteTestSuite) TestAnteHandlerSetCodeTxRequiresPrague() {
+	addr, privKey := utiltx.NewAddrKey()
+	to := utiltx.GenerateAddress()
+
+	buildTx := func() sdk.Tx {
+		chainID := suite.app.EvmKeeper.ChainID()
+
+		authPriv, err := ethcrypto.GenerateKey()
+		suite.Require().NoError(err)
+		signedAuth, err := types.SignSetCode(authPriv, types.SetCodeAuthorization{
+			ChainID: *uint256.MustFromBig(chainID),
+			Address: utiltx.GenerateAddress(),
+			Nonce:   1,
+		})
+		suite.Require().NoError(err)
+
+		setCodeTx := &types.SetCodeTx{
+			ChainID:   uint256.MustFromBig(chainID),
+			Nonce:     1,
+			GasTipCap: uint256.NewInt(1),
+			GasFeeCap: uint256.MustFromBig(big.NewInt(ethparams.InitialBaseFee + 1)),
+			Gas:       100000,
+			To:        to,
+			Value:     uint256.NewInt(10),
+			AuthList:  []types.SetCodeAuthorization{signedAuth},
+		}
+
+		msg := &evmtypes.MsgEthereumTx{}
+		suite.Require().NoError(msg.FromEthereumTx(types.NewTx(setCodeTx)))
+		msg.From = addr.Hex()
+
+		return suite.CreateTestTx(msg, privKey, 1, false)
+	}
+
+	suite.enableFeemarket = true
+	suite.enableLondonHF = false
+	suite.SetupTest()
+
+	acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr.Bytes())
+	suite.Require().NoError(acc.SetSequence(1))
+	suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+
+	suite.Require().NoError(
+		suite.app.EvmKeeper.SetBalance(
+			suite.ctx, addr, big.NewInt((ethparams.InitialBaseFee+10)*100000),
+		),
+	)
+
+	_, err := suite.anteHandler(suite.ctx, buildTx(), false)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "set code tx not supported")
+
+	suite.enableFeemarket = false
+	suite.enableLondonHF = true
 }

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -17,6 +17,7 @@ package evm
 
 import (
 	"errors"
+	"math/big"
 	"strconv"
 
 	errorsmod "cosmossdk.io/errors"
@@ -191,6 +192,11 @@ func (vbd EthValidateBasicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 
 		if baseFee == nil && txData.TxType() == ethtypes.DynamicFeeTxType {
 			return ctx, errorsmod.Wrap(ethtypes.ErrTxTypeNotSupported, "dynamic fee tx not supported")
+		}
+
+		if txData.TxType() == ethtypes.SetCodeTxType &&
+			!ethCfg.IsPrague(big.NewInt(ctx.BlockHeight()), uint64(ctx.BlockTime().Unix())) { //nolint:gosec
+			return ctx, errorsmod.Wrap(ethtypes.ErrTxTypeNotSupported, "set code tx not supported")
 		}
 
 		txFee = txFee.Add(sdk.Coin{Denom: evmDenom, Amount: sdkmath.NewIntFromBigInt(txData.Fee())})

--- a/proto/ethermint/evm/v1/tx.proto
+++ b/proto/ethermint/evm/v1/tx.proto
@@ -150,6 +150,83 @@ message DynamicFeeTx {
   bytes s = 12;
 }
 
+// SetCodeTx is the data of EIP-7702 set-code transactions (type 0x04).
+// `to` must be set (no contract creation) and `auth_list` must be non-empty;
+// proto3 has no field-level required semantics, so these invariants are
+// enforced by Validate() — not by the wire format.
+message SetCodeTx {
+  option (gogoproto.goproto_getters) = false;
+  option (cosmos_proto.implements_interface) = "TxData";
+
+  // chain_id of the destination EVM chain
+  string chain_id = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.customname) = "ChainID",
+    (gogoproto.jsontag) = "chainID"
+  ];
+  // nonce corresponds to the account nonce (transaction sequence).
+  uint64 nonce = 2;
+  // gas_tip_cap defines the max value for the gas tip
+  string gas_tip_cap = 3 [ (gogoproto.customtype) = "cosmossdk.io/math.Int" ];
+  // gas_fee_cap defines the max value for the gas fee
+  string gas_fee_cap = 4 [ (gogoproto.customtype) = "cosmossdk.io/math.Int" ];
+  // gas defines the gas limit defined for the transaction.
+  uint64 gas = 5 [ (gogoproto.customname) = "GasLimit" ];
+  // to is the hex formatted address of the recipient
+  string to = 6;
+  // value defines the the transaction amount.
+  string value = 7 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.customname) = "Amount"
+  ];
+  // data is the data payload bytes of the transaction.
+  bytes data = 8;
+  // accesses is an array of access tuples
+  repeated AccessTuple accesses = 9 [
+    (gogoproto.castrepeated) = "AccessList",
+    (gogoproto.jsontag) = "accessList",
+    (gogoproto.nullable) = false
+  ];
+  // auth_list carries the EIP-7702 authorization tuples.
+  repeated SetCodeAuthorization auth_list = 10 [
+    (gogoproto.castrepeated) = "AuthorizationList",
+    (gogoproto.jsontag) = "authorizationList",
+    (gogoproto.nullable) = false
+  ];
+  // v defines the signature value
+  bytes v = 11;
+  // r defines the signature value
+  bytes r = 12;
+  // s define the signature value
+  bytes s = 13;
+}
+
+// SetCodeAuthorization is a single EIP-7702 authorization tuple.
+message SetCodeAuthorization {
+  option (gogoproto.goproto_getters) = false;
+
+  // chain_id is the chain on which the authorization is valid. A nil/missing
+  // value is rejected by Validate; the zero value is the EIP-7702 "any chain"
+  // sentinel and is accepted.
+  string chain_id = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.customname) = "ChainID",
+    (gogoproto.jsontag) = "chainID"
+  ];
+  // address is the hex formatted address whose code the signer authorizes.
+  string address = 2;
+  // nonce of the authorizing account at the time the authorization is signed.
+  uint64 nonce = 3;
+  // v is the per-tuple signature yParity (0 or 1). Encoded as bytes for
+  // consistency with all other tx-level signature fields in this proto;
+  // empty bytes round-trip to zero.
+  bytes v = 4;
+  // r defines the signature value
+  bytes r = 5;
+  // s defines the signature value
+  bytes s = 6;
+}
+
 // ExtensionOptionsEthereumTx is an extension option for ethereum transactions
 message ExtensionOptionsEthereumTx {
   option (gogoproto.goproto_getters) = false;

--- a/x/evm/types/chain_config_test.go
+++ b/x/evm/types/chain_config_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math/big"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
@@ -16,617 +17,198 @@ func newIntPtr(i int64) *sdkmath.Int {
 	return &v
 }
 
+// validBaselineConfig returns a ChainConfig that passes Validate(). Time
+// forks past Osaka are left nil because params.DefaultBlobSchedule has no
+// entries for them yet and CheckConfigForkOrder rejects configs that
+// activate a time fork without a matching blob schedule entry.
+func validBaselineConfig() ChainConfig {
+	return ChainConfig{
+		HomesteadBlock:      newIntPtr(0),
+		DAOForkBlock:        newIntPtr(0),
+		EIP150Block:         newIntPtr(0),
+		EIP150Hash:          defaultEIP150Hash,
+		EIP155Block:         newIntPtr(0),
+		EIP158Block:         newIntPtr(0),
+		ByzantiumBlock:      newIntPtr(0),
+		ConstantinopleBlock: newIntPtr(0),
+		PetersburgBlock:     newIntPtr(0),
+		IstanbulBlock:       newIntPtr(0),
+		MuirGlacierBlock:    newIntPtr(0),
+		BerlinBlock:         newIntPtr(0),
+		LondonBlock:         newIntPtr(0),
+		ArrowGlacierBlock:   newIntPtr(0),
+		GrayGlacierBlock:    newIntPtr(0),
+		MergeNetsplitBlock:  newIntPtr(0),
+		ShanghaiTime:        newIntPtr(0),
+		CancunTime:          newIntPtr(0),
+		PragueTime:          newIntPtr(0),
+		OsakaTime:           newIntPtr(0),
+	}
+}
+
+// mutate returns a copy of base with mutator applied.
+func mutate(base ChainConfig, mutator func(*ChainConfig)) ChainConfig {
+	cfg := base
+	mutator(&cfg)
+	return cfg
+}
+
 func TestChainConfigValidate(t *testing.T) {
+	baseline := validBaselineConfig()
+
 	testCases := []struct {
 		name     string
 		config   ChainConfig
 		expError bool
 	}{
 		{"default", DefaultChainConfig(), false},
-		{
-			"valid",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-			},
-			false,
-		},
+		{"valid baseline", baseline, false},
 		{
 			"valid with nil values",
 			ChainConfig{
-				HomesteadBlock:      nil,
-				DAOForkBlock:        nil,
-				EIP150Block:         nil,
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         nil,
-				EIP158Block:         nil,
-				ByzantiumBlock:      nil,
-				ConstantinopleBlock: nil,
-				PetersburgBlock:     nil,
-				IstanbulBlock:       nil,
-				MuirGlacierBlock:    nil,
-				BerlinBlock:         nil,
-				LondonBlock:         nil,
-				CancunTime:          nil,
-				ShanghaiTime:        nil,
+				EIP150Hash: defaultEIP150Hash,
 			},
 			false,
 		},
-		{
-			"empty",
-			ChainConfig{},
-			false,
-		},
+		{"empty", ChainConfig{}, false},
 		{
 			"invalid HomesteadBlock",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.HomesteadBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid DAOForkBlock",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.DAOForkBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid EIP150Block",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(0),
-				EIP150Block:    newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.EIP150Block = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid EIP150Hash",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(0),
-				EIP150Block:    newIntPtr(0),
-				EIP150Hash:     "  ",
-			},
+			mutate(baseline, func(c *ChainConfig) { c.EIP150Hash = "  " }),
 			true,
 		},
 		{
 			"invalid EIP155Block",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(0),
-				EIP150Block:    newIntPtr(0),
-				EIP150Hash:     defaultEIP150Hash,
-				EIP155Block:    newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.EIP155Block = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid EIP158Block",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(0),
-				EIP150Block:    newIntPtr(0),
-				EIP150Hash:     defaultEIP150Hash,
-				EIP155Block:    newIntPtr(0),
-				EIP158Block:    newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.EIP158Block = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid ByzantiumBlock",
-			ChainConfig{
-				HomesteadBlock: newIntPtr(0),
-				DAOForkBlock:   newIntPtr(0),
-				EIP150Block:    newIntPtr(0),
-				EIP150Hash:     defaultEIP150Hash,
-				EIP155Block:    newIntPtr(0),
-				EIP158Block:    newIntPtr(0),
-				ByzantiumBlock: newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.ByzantiumBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid ConstantinopleBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.ConstantinopleBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid PetersburgBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.PetersburgBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid IstanbulBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.IstanbulBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid MuirGlacierBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.MuirGlacierBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BerlinBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BerlinBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid LondonBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.LondonBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid ArrowGlacierBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.ArrowGlacierBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid GrayGlacierBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.GrayGlacierBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid MergeNetsplitBlock",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.MergeNetsplitBlock = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid fork order - skip HomesteadBlock",
-			ChainConfig{
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.HomesteadBlock = nil }),
 			true,
 		},
 		{
 			"invalid ShanghaiTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.ShanghaiTime = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid CancunTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.CancunTime = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid PragueTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.PragueTime = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid OsakaTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.OsakaTime = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BPO1Time",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BPO1Time = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BPO2Time",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BPO2Time = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BPO3Time",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(0),
-				BPO3Time:            newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BPO3Time = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BPO4Time",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(0),
-				BPO3Time:            newIntPtr(0),
-				BPO4Time:            newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BPO4Time = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid BPO5Time",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(0),
-				BPO3Time:            newIntPtr(0),
-				BPO4Time:            newIntPtr(0),
-				BPO5Time:            newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.BPO5Time = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid AmsterdamTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(0),
-				BPO3Time:            newIntPtr(0),
-				BPO4Time:            newIntPtr(0),
-				BPO5Time:            newIntPtr(0),
-				AmsterdamTime:       newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.AmsterdamTime = newIntPtr(-1) }),
 			true,
 		},
 		{
 			"invalid VerkleTime",
-			ChainConfig{
-				HomesteadBlock:      newIntPtr(0),
-				DAOForkBlock:        newIntPtr(0),
-				EIP150Block:         newIntPtr(0),
-				EIP150Hash:          defaultEIP150Hash,
-				EIP155Block:         newIntPtr(0),
-				EIP158Block:         newIntPtr(0),
-				ByzantiumBlock:      newIntPtr(0),
-				ConstantinopleBlock: newIntPtr(0),
-				PetersburgBlock:     newIntPtr(0),
-				IstanbulBlock:       newIntPtr(0),
-				MuirGlacierBlock:    newIntPtr(0),
-				BerlinBlock:         newIntPtr(0),
-				LondonBlock:         newIntPtr(0),
-				ArrowGlacierBlock:   newIntPtr(0),
-				GrayGlacierBlock:    newIntPtr(0),
-				MergeNetsplitBlock:  newIntPtr(0),
-				ShanghaiTime:        newIntPtr(0),
-				CancunTime:          newIntPtr(0),
-				PragueTime:          newIntPtr(0),
-				OsakaTime:           newIntPtr(0),
-				BPO1Time:            newIntPtr(0),
-				BPO2Time:            newIntPtr(0),
-				BPO3Time:            newIntPtr(0),
-				BPO4Time:            newIntPtr(0),
-				BPO5Time:            newIntPtr(0),
-				AmsterdamTime:       newIntPtr(0),
-				VerkleTime:          newIntPtr(-1),
-			},
+			mutate(baseline, func(c *ChainConfig) { c.VerkleTime = newIntPtr(-1) }),
 			true,
 		},
 	}
@@ -640,4 +222,85 @@ func TestChainConfigValidate(t *testing.T) {
 			require.NoError(t, err, tc.name)
 		}
 	}
+}
+
+// TestChainConfigEthereumConfig asserts that ChainConfig.EthereumConfig
+// maps each fork-time field to the corresponding field on the returned
+// *params.ChainConfig. A cross-wired assignment (e.g. OsakaTime going
+// to params.PragueTime) would silently activate the wrong fork on
+// every fresh genesis; populating each field with a distinct sentinel
+// makes any swap immediately visible.
+func TestChainConfigEthereumConfig(t *testing.T) {
+	// Each fork time gets a distinct sentinel so a cross-wire
+	// (e.g. assigning OsakaTime to params.PragueTime) is detectable.
+	const (
+		shanghaiSentinel  uint64 = 1001
+		cancunSentinel    uint64 = 1002
+		pragueSentinel    uint64 = 1003
+		osakaSentinel     uint64 = 1004
+		bpo1Sentinel      uint64 = 1005
+		bpo2Sentinel      uint64 = 1006
+		bpo3Sentinel      uint64 = 1007
+		bpo4Sentinel      uint64 = 1008
+		bpo5Sentinel      uint64 = 1009
+		amsterdamSentinel uint64 = 1010
+		verkleSentinel    uint64 = 1011
+	)
+
+	cfg := ChainConfig{
+		ShanghaiTime:  newIntPtr(int64(shanghaiSentinel)),
+		CancunTime:    newIntPtr(int64(cancunSentinel)),
+		PragueTime:    newIntPtr(int64(pragueSentinel)),
+		OsakaTime:     newIntPtr(int64(osakaSentinel)),
+		BPO1Time:      newIntPtr(int64(bpo1Sentinel)),
+		BPO2Time:      newIntPtr(int64(bpo2Sentinel)),
+		BPO3Time:      newIntPtr(int64(bpo3Sentinel)),
+		BPO4Time:      newIntPtr(int64(bpo4Sentinel)),
+		BPO5Time:      newIntPtr(int64(bpo5Sentinel)),
+		AmsterdamTime: newIntPtr(int64(amsterdamSentinel)),
+		VerkleTime:    newIntPtr(int64(verkleSentinel)),
+	}
+
+	chainID := big.NewInt(31611)
+	out := cfg.EthereumConfig(chainID)
+
+	require.NotNil(t, out)
+	require.Equal(t, chainID, out.ChainID, "ChainID")
+
+	// Each fork-time field must point to its dedicated sentinel; any
+	// swap between two fields would surface as a mismatch here.
+	assertTime := func(t *testing.T, name string, got *uint64, want uint64) {
+		t.Helper()
+		require.NotNil(t, got, "%s: expected non-nil pointer", name)
+		require.Equal(t, want, *got, "%s mismatch (cross-wired field?)", name)
+	}
+
+	assertTime(t, "ShanghaiTime", out.ShanghaiTime, shanghaiSentinel)
+	assertTime(t, "CancunTime", out.CancunTime, cancunSentinel)
+	assertTime(t, "PragueTime", out.PragueTime, pragueSentinel)
+	assertTime(t, "OsakaTime", out.OsakaTime, osakaSentinel)
+	assertTime(t, "BPO1Time", out.BPO1Time, bpo1Sentinel)
+	assertTime(t, "BPO2Time", out.BPO2Time, bpo2Sentinel)
+	assertTime(t, "BPO3Time", out.BPO3Time, bpo3Sentinel)
+	assertTime(t, "BPO4Time", out.BPO4Time, bpo4Sentinel)
+	assertTime(t, "BPO5Time", out.BPO5Time, bpo5Sentinel)
+	assertTime(t, "AmsterdamTime", out.AmsterdamTime, amsterdamSentinel)
+	assertTime(t, "VerkleTime", out.VerkleTime, verkleSentinel)
+
+	// nil time fields must remain nil on the returned config; a
+	// regression that defaulted unset times to zero would silently
+	// activate every fork at genesis.
+	nilCfg := ChainConfig{}
+	nilOut := nilCfg.EthereumConfig(chainID)
+	require.Nil(t, nilOut.ShanghaiTime)
+	require.Nil(t, nilOut.CancunTime)
+	require.Nil(t, nilOut.PragueTime)
+	require.Nil(t, nilOut.OsakaTime)
+	require.Nil(t, nilOut.BPO1Time)
+	require.Nil(t, nilOut.BPO2Time)
+	require.Nil(t, nilOut.BPO3Time)
+	require.Nil(t, nilOut.BPO4Time)
+	require.Nil(t, nilOut.BPO5Time)
+	require.Nil(t, nilOut.AmsterdamTime)
+	require.Nil(t, nilOut.VerkleTime)
 }

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -42,6 +42,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&DynamicFeeTx{},
 		&AccessListTx{},
 		&LegacyTx{},
+		&SetCodeTx{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/evm/types/codec_test.go
+++ b/x/evm/types/codec_test.go
@@ -30,6 +30,11 @@ func TestPackTxData(t *testing.T) {
 			true,
 		},
 		{
+			"set code tx",
+			&SetCodeTx{},
+			true,
+		},
+		{
 			"nil",
 			nil,
 			false,

--- a/x/evm/types/errors.go
+++ b/x/evm/types/errors.go
@@ -44,6 +44,8 @@ const (
 	codeErrInvalidGasLimit
 	codeErrInvalidSigner
 	codeErrTxTypeNotSupported
+	codeErrSetCodeMissingTo
+	codeErrSetCodeEmptyAuthList
 )
 
 var ErrPostTxProcessing = errors.New("failed to execute post processing")
@@ -95,6 +97,17 @@ var (
 	ErrInvalidGasLimit    = errorsmod.Register(ModuleName, codeErrInvalidGasLimit, "invalid gas limit")
 	ErrInvalidSigner      = errorsmod.Register(ModuleName, codeErrInvalidSigner, "invalid signer")
 	ErrTxTypeNotSupported = errorsmod.Register(ModuleName, codeErrTxTypeNotSupported, "transaction type not supported")
+
+	// ErrSetCodeMissingTo is returned when an EIP-7702 set-code transaction
+	// omits the recipient address. EIP-7702 forbids contract creation, which
+	// the RLP wire format encodes as an absent `to` field.
+	ErrSetCodeMissingTo = errorsmod.Register(ModuleName, codeErrSetCodeMissingTo,
+		"set-code transaction must specify a recipient")
+
+	// ErrSetCodeEmptyAuthList is returned when an EIP-7702 set-code
+	// transaction carries an empty authorization list.
+	ErrSetCodeEmptyAuthList = errorsmod.Register(ModuleName, codeErrSetCodeEmptyAuthList,
+		"set-code transaction must contain at least one authorization")
 )
 
 // NewExecErrorWithReason unpacks the revert return bytes and returns a wrapped error

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -248,6 +248,8 @@ func MsgEthereumTxGetSigners(msgV2 protov2.Message) ([][]byte, error) {
 		txData = new(DynamicFeeTx)
 	case "/ethermint.evm.v1.LegacyTx":
 		txData = new(LegacyTx)
+	case "/ethermint.evm.v1.SetCodeTx":
+		txData = new(SetCodeTx)
 	default:
 		return nil, fmt.Errorf("unrecognized TxData type: %s", msgEthTx.Data.TypeUrl)
 	}

--- a/x/evm/types/set_code_authorization.go
+++ b/x/evm/types/set_code_authorization.go
@@ -1,0 +1,112 @@
+// Copyright 2022 Evmos Foundation
+// This file is part of the Evmos Network packages.
+//
+// Evmos is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Evmos packages are distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
+package types
+
+import (
+	"math/big"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+// AuthorizationList is the EIP-7702 authorization list represented as a slice
+// of the protobuf SetCodeAuthorization tuples.
+type AuthorizationList []SetCodeAuthorization
+
+// NewAuthorizationList creates a protobuf-compatible AuthorizationList from
+// an ethereum-side []SetCodeAuthorization slice.
+func NewAuthorizationList(auths []ethtypes.SetCodeAuthorization) AuthorizationList {
+	if auths == nil {
+		return nil
+	}
+
+	al := make(AuthorizationList, 0, len(auths))
+	for _, a := range auths {
+		al = append(al, NewSetCodeAuthorization(a))
+	}
+	return al
+}
+
+// ToEthAuthorizationList converts the protobuf AuthorizationList back into
+// the geth-side []SetCodeAuthorization slice.
+func (al AuthorizationList) ToEthAuthorizationList() []ethtypes.SetCodeAuthorization {
+	if al == nil {
+		return nil
+	}
+
+	out := make([]ethtypes.SetCodeAuthorization, len(al))
+	for i, a := range al {
+		out[i] = a.ToEthAuthorization()
+	}
+	return out
+}
+
+// NewSetCodeAuthorization converts a single ethereum-side authorization
+// tuple into its protobuf form.
+func NewSetCodeAuthorization(auth ethtypes.SetCodeAuthorization) SetCodeAuthorization {
+	chainID := sdkmath.NewIntFromBigInt(auth.ChainID.ToBig())
+	return SetCodeAuthorization{
+		ChainID: &chainID,
+		Address: auth.Address.Hex(),
+		Nonce:   auth.Nonce,
+		V:       []byte{auth.V},
+		R:       auth.R.Bytes(),
+		S:       auth.S.Bytes(),
+	}
+}
+
+// ToEthAuthorization converts the protobuf authorization tuple back into the
+// geth-side SetCodeAuthorization.
+func (a SetCodeAuthorization) ToEthAuthorization() ethtypes.SetCodeAuthorization {
+	var chainID uint256.Int
+	if cid := a.GetChainID(); cid != nil {
+		chainID = *uint256.MustFromBig(cid)
+	}
+
+	var v uint8
+	if len(a.V) > 0 {
+		v = a.V[0]
+	}
+
+	r := new(uint256.Int)
+	if len(a.R) > 0 {
+		r.SetBytes(a.R)
+	}
+
+	s := new(uint256.Int)
+	if len(a.S) > 0 {
+		s.SetBytes(a.S)
+	}
+
+	return ethtypes.SetCodeAuthorization{
+		ChainID: chainID,
+		Address: common.HexToAddress(a.Address),
+		Nonce:   a.Nonce,
+		V:       v,
+		R:       *r,
+		S:       *s,
+	}
+}
+
+// GetChainID returns the authorization tuple chain id (nil-safe).
+func (a SetCodeAuthorization) GetChainID() *big.Int {
+	if a.ChainID == nil {
+		return nil
+	}
+	return a.ChainID.BigInt()
+}

--- a/x/evm/types/set_code_authorization_test.go
+++ b/x/evm/types/set_code_authorization_test.go
@@ -1,0 +1,155 @@
+package types_test
+
+import (
+	"math/big"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mezo-org/mezod/x/evm/types"
+)
+
+func TestNewAuthorizationList_NilAndEmpty(t *testing.T) {
+	require.Nil(t, types.NewAuthorizationList(nil))
+
+	empty := types.NewAuthorizationList([]ethtypes.SetCodeAuthorization{})
+	require.NotNil(t, empty)
+	require.Len(t, empty, 0)
+}
+
+func TestAuthorizationList_ToEthAuthorizationList_Nil(t *testing.T) {
+	var al types.AuthorizationList
+	require.Nil(t, al.ToEthAuthorizationList())
+}
+
+func TestSetCodeAuthorization_RoundTrip(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	// Pick a value near the high end of uint256 (well above int256 bounds, but
+	// the round-trip path itself does no bounds checking — that is Validate's
+	// job).
+	largeR := uint256.MustFromHex(
+		"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+	)
+
+	tests := []struct {
+		name string
+		auth ethtypes.SetCodeAuthorization
+	}{
+		{
+			"zero values",
+			ethtypes.SetCodeAuthorization{
+				ChainID: uint256.Int{},
+				Address: common.Address{},
+				Nonce:   0,
+				V:       0,
+				R:       uint256.Int{},
+				S:       uint256.Int{},
+			},
+		},
+		{
+			"v=0 with non-zero values",
+			ethtypes.SetCodeAuthorization{
+				ChainID: *uint256.NewInt(31611),
+				Address: addr,
+				Nonce:   42,
+				V:       0,
+				R:       *uint256.NewInt(7),
+				S:       *uint256.NewInt(11),
+			},
+		},
+		{
+			"v=1 with large R",
+			ethtypes.SetCodeAuthorization{
+				ChainID: *uint256.NewInt(31612),
+				Address: addr,
+				Nonce:   1<<63 - 1,
+				V:       1,
+				R:       *largeR,
+				S:       *uint256.NewInt(1),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			proto := types.NewSetCodeAuthorization(tc.auth)
+			back := proto.ToEthAuthorization()
+
+			require.Equal(t, tc.auth.ChainID, back.ChainID)
+			require.Equal(t, tc.auth.Address, back.Address)
+			require.Equal(t, tc.auth.Nonce, back.Nonce)
+			require.Equal(t, tc.auth.V, back.V)
+			require.Equal(t, tc.auth.R, back.R)
+			require.Equal(t, tc.auth.S, back.S)
+		})
+	}
+}
+
+func TestAuthorizationList_RoundTrip(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	in := []ethtypes.SetCodeAuthorization{
+		{
+			ChainID: *uint256.NewInt(31611),
+			Address: addr,
+			Nonce:   1,
+			V:       0,
+			R:       *uint256.NewInt(2),
+			S:       *uint256.NewInt(3),
+		},
+		{
+			ChainID: uint256.Int{},
+			Address: common.Address{},
+			Nonce:   0,
+			V:       1,
+			R:       uint256.Int{},
+			S:       uint256.Int{},
+		},
+		{
+			ChainID: *uint256.NewInt(31612),
+			Address: addr,
+			Nonce:   99,
+			V:       1,
+			R:       *uint256.NewInt(0xff),
+			S:       *uint256.NewInt(0xee),
+		},
+	}
+
+	proto := types.NewAuthorizationList(in)
+	require.Len(t, proto, len(in))
+
+	back := proto.ToEthAuthorizationList()
+	require.Equal(t, in, back)
+}
+
+func TestSetCodeAuthorization_GetChainID(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		a := types.SetCodeAuthorization{}
+		require.Nil(t, a.GetChainID())
+	})
+
+	t.Run("non-nil", func(t *testing.T) {
+		ci := sdkmath.NewInt(31611)
+		a := types.SetCodeAuthorization{ChainID: &ci}
+		require.Equal(t, big.NewInt(31611), a.GetChainID())
+	})
+}
+
+func TestSetCodeAuthorization_EmptyByteFieldsRoundTripToZero(t *testing.T) {
+	// A proto-decoded authorization can land with nil V/R/S byte slices (an
+	// uninitialized SetCodeAuthorization) — converting to eth and back must
+	// not panic and must yield zeros.
+	proto := types.SetCodeAuthorization{
+		Address: common.Address{}.Hex(),
+	}
+	eth := proto.ToEthAuthorization()
+	require.Equal(t, uint8(0), eth.V)
+	require.Equal(t, uint256.Int{}, eth.R)
+	require.Equal(t, uint256.Int{}, eth.S)
+	require.Equal(t, uint256.Int{}, eth.ChainID)
+}

--- a/x/evm/types/set_code_tx.go
+++ b/x/evm/types/set_code_tx.go
@@ -193,9 +193,11 @@ func (tx *SetCodeTx) GetTo() *common.Address {
 }
 
 // AsEthereumData returns a geth-side SetCodeTx built from this proto-formatted
-// TxData. Validate() must have run first: it guarantees ChainID, gas caps,
-// V/R/S, and To are all within bounds for uint256.MustFromBig. A nil Amount
-// is treated as zero, mirroring DynamicFeeTx semantics.
+// TxData. Validate() must have run first: it guarantees ChainID and gas caps
+// are non-nil and within int256 bounds, making uint256.MustFromBig safe on
+// them. Amount and V/R/S are bounds-checked but Validate permits them to be
+// nil — Amount for txs that transfer no value, V/R/S for unsigned txs — so
+// this method defaults them to a non-nil zero *uint256.Int.
 func (tx *SetCodeTx) AsEthereumData() ethtypes.TxData {
 	v, r, s := tx.GetRawSignatureValues()
 
@@ -207,6 +209,7 @@ func (tx *SetCodeTx) AsEthereumData() ethtypes.TxData {
 	chainID := uint256.MustFromBig(tx.GetChainID())
 	gasTipCap := uint256.MustFromBig(tx.GetGasTipCap())
 	gasFeeCap := uint256.MustFromBig(tx.GetGasFeeCap())
+
 	value := new(uint256.Int)
 	if amount := tx.GetValue(); amount != nil {
 		value = uint256.MustFromBig(amount)

--- a/x/evm/types/set_code_tx.go
+++ b/x/evm/types/set_code_tx.go
@@ -194,7 +194,8 @@ func (tx *SetCodeTx) GetTo() *common.Address {
 
 // AsEthereumData returns a geth-side SetCodeTx built from this proto-formatted
 // TxData. Validate() must have run first: it guarantees ChainID, gas caps,
-// value, V/R/S, and To are all within bounds for uint256.MustFromBig.
+// V/R/S, and To are all within bounds for uint256.MustFromBig. A nil Amount
+// is treated as zero, mirroring DynamicFeeTx semantics.
 func (tx *SetCodeTx) AsEthereumData() ethtypes.TxData {
 	v, r, s := tx.GetRawSignatureValues()
 
@@ -206,7 +207,10 @@ func (tx *SetCodeTx) AsEthereumData() ethtypes.TxData {
 	chainID := uint256.MustFromBig(tx.GetChainID())
 	gasTipCap := uint256.MustFromBig(tx.GetGasTipCap())
 	gasFeeCap := uint256.MustFromBig(tx.GetGasFeeCap())
-	value := uint256.MustFromBig(tx.GetValue())
+	value := new(uint256.Int)
+	if amount := tx.GetValue(); amount != nil {
+		value = uint256.MustFromBig(amount)
+	}
 
 	vU := new(uint256.Int)
 	if v != nil {
@@ -299,10 +303,8 @@ func (tx SetCodeTx) Validate() error {
 	}
 
 	amount := tx.GetValue()
-	if amount == nil {
-		return errorsmod.Wrap(ErrInvalidAmount, "amount cannot be nil")
-	}
-	if amount.Sign() == -1 {
+	// Amount can be nil (treated as zero) or zero, mirroring DynamicFeeTx.
+	if amount != nil && amount.Sign() == -1 {
 		return errorsmod.Wrapf(ErrInvalidAmount, "amount cannot be negative %s", amount)
 	}
 	if !types.IsValidInt256(amount) {
@@ -345,8 +347,14 @@ func (tx SetCodeTx) Validate() error {
 		return errorsmod.Wrap(ErrSetCodeEmptyAuthList, "auth list must be non-empty")
 	}
 
-	var rTmp, sTmp big.Int
+	var vTmp, rTmp, sTmp big.Int
 	for i, auth := range tx.AuthList {
+		// The tx-level chain ID above is bound to a specific Mezo network.
+		// Per-authorization chain IDs are intentionally only nil-and-bounds
+		// checked here: EIP-7702 allows auth.ChainID to be 0 (cross-chain) or
+		// the current chain id, with any other value making that single tuple
+		// invalid. Per EIP-7702 invalid tuples are silently skipped at apply
+		// time, not tx-fatal, so the 0-or-current check belongs in the keeper.
 		if auth.ChainID == nil {
 			return errorsmod.Wrapf(
 				errortypes.ErrInvalidChainID,
@@ -362,25 +370,21 @@ func (tx SetCodeTx) Validate() error {
 		if err := types.ValidateAddress(auth.Address); err != nil {
 			return errorsmod.Wrapf(err, "authorization[%d] invalid address", i)
 		}
-		if len(auth.V) > 1 {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] V length out of bound", i)
-		}
-		if len(auth.V) == 1 && auth.V[0] > 1 {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] V must be 0 or 1", i)
-		}
-		if len(auth.R) > 32 || len(auth.S) > 32 {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R or S length out of bound", i)
-		}
+		// Auth V/R/S shape is checked only for int256 bounds, mirroring
+		// tx-level signature validation. Canonical-form checks (V in {0,1},
+		// R/S non-zero, low-S, length <= 32) are deferred to the keeper's
+		// authorization recovery, where failures result in silent per-tuple
+		// skips per EIP-7702.
+		vTmp.SetBytes(auth.V)
 		rTmp.SetBytes(auth.R)
 		sTmp.SetBytes(auth.S)
-		if rTmp.Sign() == 0 || sTmp.Sign() == 0 {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R and S must be non-zero", i)
-		}
-		if !types.IsValidInt256(&rTmp) {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R out of bound", i)
-		}
-		if !types.IsValidInt256(&sTmp) {
-			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] S out of bound", i)
+		if !types.IsValidInt256(&vTmp) ||
+			!types.IsValidInt256(&rTmp) ||
+			!types.IsValidInt256(&sTmp) {
+			return errorsmod.Wrapf(
+				ErrInvalidSigner,
+				"authorization[%d] V, R or S out of bound", i,
+			)
 		}
 	}
 

--- a/x/evm/types/set_code_tx.go
+++ b/x/evm/types/set_code_tx.go
@@ -1,0 +1,413 @@
+// Copyright 2022 Evmos Foundation
+// This file is part of the Evmos Network packages.
+//
+// Evmos is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Evmos packages are distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Evmos packages. If not, see https://github.com/evmos/evmos/blob/main/LICENSE
+package types
+
+import (
+	"math/big"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+
+	"github.com/mezo-org/mezod/types"
+)
+
+// NewSetCodeTx constructs a SetCodeTx from a geth ethtypes.Transaction of
+// type SetCodeTxType. It mirrors NewDynamicFeeTx but additionally carries
+// the EIP-7702 authorization list.
+func NewSetCodeTx(tx *ethtypes.Transaction) (*SetCodeTx, error) {
+	txData := &SetCodeTx{
+		Nonce:    tx.Nonce(),
+		Data:     tx.Data(),
+		GasLimit: tx.Gas(),
+	}
+
+	v, r, s := tx.RawSignatureValues()
+	if to := tx.To(); to != nil {
+		txData.To = to.Hex()
+	}
+
+	if tx.Value() != nil {
+		amountInt, err := types.SafeNewIntFromBigInt(tx.Value())
+		if err != nil {
+			return nil, err
+		}
+		txData.Amount = &amountInt
+	}
+
+	if tx.GasFeeCap() != nil {
+		gasFeeCapInt, err := types.SafeNewIntFromBigInt(tx.GasFeeCap())
+		if err != nil {
+			return nil, err
+		}
+		txData.GasFeeCap = &gasFeeCapInt
+	}
+
+	if tx.GasTipCap() != nil {
+		gasTipCapInt, err := types.SafeNewIntFromBigInt(tx.GasTipCap())
+		if err != nil {
+			return nil, err
+		}
+		txData.GasTipCap = &gasTipCapInt
+	}
+
+	if tx.AccessList() != nil {
+		al := tx.AccessList()
+		txData.Accesses = NewAccessList(&al)
+	}
+
+	txData.AuthList = NewAuthorizationList(tx.SetCodeAuthorizations())
+
+	txData.SetSignatureValues(tx.ChainId(), v, r, s)
+	return txData, nil
+}
+
+// TxType returns the tx type
+func (tx *SetCodeTx) TxType() uint8 {
+	return ethtypes.SetCodeTxType
+}
+
+// Copy returns an instance with the same field values.
+func (tx *SetCodeTx) Copy() TxData {
+	var authList AuthorizationList
+	if tx.AuthList != nil {
+		authList = make(AuthorizationList, len(tx.AuthList))
+		for i, a := range tx.AuthList {
+			authList[i] = SetCodeAuthorization{
+				ChainID: a.ChainID,
+				Address: a.Address,
+				Nonce:   a.Nonce,
+				V:       common.CopyBytes(a.V),
+				R:       common.CopyBytes(a.R),
+				S:       common.CopyBytes(a.S),
+			}
+		}
+	}
+
+	return &SetCodeTx{
+		ChainID:   tx.ChainID,
+		Nonce:     tx.Nonce,
+		GasTipCap: tx.GasTipCap,
+		GasFeeCap: tx.GasFeeCap,
+		GasLimit:  tx.GasLimit,
+		To:        tx.To,
+		Amount:    tx.Amount,
+		Data:      common.CopyBytes(tx.Data),
+		Accesses:  tx.Accesses,
+		AuthList:  authList,
+		V:         common.CopyBytes(tx.V),
+		R:         common.CopyBytes(tx.R),
+		S:         common.CopyBytes(tx.S),
+	}
+}
+
+// GetChainID returns the chain id field from the SetCodeTx
+func (tx *SetCodeTx) GetChainID() *big.Int {
+	if tx.ChainID == nil {
+		return nil
+	}
+
+	return tx.ChainID.BigInt()
+}
+
+// GetAccessList returns the AccessList field.
+func (tx *SetCodeTx) GetAccessList() ethtypes.AccessList {
+	if tx.Accesses == nil {
+		return nil
+	}
+	return *tx.Accesses.ToEthAccessList()
+}
+
+// GetAuthorizationList returns the EIP-7702 authorization list.
+func (tx *SetCodeTx) GetAuthorizationList() []ethtypes.SetCodeAuthorization {
+	return tx.AuthList.ToEthAuthorizationList()
+}
+
+// GetData returns a copy of the input data bytes.
+func (tx *SetCodeTx) GetData() []byte {
+	return common.CopyBytes(tx.Data)
+}
+
+// GetGas returns the gas limit.
+func (tx *SetCodeTx) GetGas() uint64 {
+	return tx.GasLimit
+}
+
+// GetGasPrice returns the gas fee cap field.
+func (tx *SetCodeTx) GetGasPrice() *big.Int {
+	return tx.GetGasFeeCap()
+}
+
+// GetGasTipCap returns the gas tip cap field.
+func (tx *SetCodeTx) GetGasTipCap() *big.Int {
+	if tx.GasTipCap == nil {
+		return nil
+	}
+	return tx.GasTipCap.BigInt()
+}
+
+// GetGasFeeCap returns the gas fee cap field.
+func (tx *SetCodeTx) GetGasFeeCap() *big.Int {
+	if tx.GasFeeCap == nil {
+		return nil
+	}
+	return tx.GasFeeCap.BigInt()
+}
+
+// GetValue returns the tx amount.
+func (tx *SetCodeTx) GetValue() *big.Int {
+	if tx.Amount == nil {
+		return nil
+	}
+
+	return tx.Amount.BigInt()
+}
+
+// GetNonce returns the account sequence for the transaction.
+func (tx *SetCodeTx) GetNonce() uint64 { return tx.Nonce }
+
+// GetTo returns the pointer to the recipient address.
+func (tx *SetCodeTx) GetTo() *common.Address {
+	if tx.To == "" {
+		return nil
+	}
+	to := common.HexToAddress(tx.To)
+	return &to
+}
+
+// AsEthereumData returns a geth-side SetCodeTx built from this proto-formatted
+// TxData. Validate() must have run first: it guarantees ChainID, gas caps,
+// value, V/R/S, and To are all within bounds for uint256.MustFromBig.
+func (tx *SetCodeTx) AsEthereumData() ethtypes.TxData {
+	v, r, s := tx.GetRawSignatureValues()
+
+	var to common.Address
+	if t := tx.GetTo(); t != nil {
+		to = *t
+	}
+
+	chainID := uint256.MustFromBig(tx.GetChainID())
+	gasTipCap := uint256.MustFromBig(tx.GetGasTipCap())
+	gasFeeCap := uint256.MustFromBig(tx.GetGasFeeCap())
+	value := uint256.MustFromBig(tx.GetValue())
+
+	vU := new(uint256.Int)
+	if v != nil {
+		vU = uint256.MustFromBig(v)
+	}
+	rU := new(uint256.Int)
+	if r != nil {
+		rU = uint256.MustFromBig(r)
+	}
+	sU := new(uint256.Int)
+	if s != nil {
+		sU = uint256.MustFromBig(s)
+	}
+
+	return &ethtypes.SetCodeTx{
+		ChainID:    chainID,
+		Nonce:      tx.GetNonce(),
+		GasTipCap:  gasTipCap,
+		GasFeeCap:  gasFeeCap,
+		Gas:        tx.GetGas(),
+		To:         to,
+		Value:      value,
+		Data:       tx.GetData(),
+		AccessList: tx.GetAccessList(),
+		AuthList:   tx.GetAuthorizationList(),
+		V:          vU,
+		R:          rU,
+		S:          sU,
+	}
+}
+
+// GetRawSignatureValues returns the V, R, S signature values of the transaction.
+// The return values should not be modified by the caller.
+func (tx *SetCodeTx) GetRawSignatureValues() (v, r, s *big.Int) {
+	return rawSignatureValues(tx.V, tx.R, tx.S)
+}
+
+// SetSignatureValues sets the signature values to the transaction.
+func (tx *SetCodeTx) SetSignatureValues(chainID, v, r, s *big.Int) {
+	if v != nil {
+		tx.V = v.Bytes()
+	}
+	if r != nil {
+		tx.R = r.Bytes()
+	}
+	if s != nil {
+		tx.S = s.Bytes()
+	}
+	if chainID != nil {
+		chainIDInt := sdkmath.NewIntFromBigInt(chainID)
+		tx.ChainID = &chainIDInt
+	}
+}
+
+// Validate performs a stateless validation of the tx fields.
+func (tx SetCodeTx) Validate() error {
+	if tx.GasTipCap == nil {
+		return errorsmod.Wrap(ErrInvalidGasCap, "gas tip cap cannot nil")
+	}
+
+	if tx.GasFeeCap == nil {
+		return errorsmod.Wrap(ErrInvalidGasCap, "gas fee cap cannot nil")
+	}
+
+	if tx.GasTipCap.IsNegative() {
+		return errorsmod.Wrapf(ErrInvalidGasCap, "gas tip cap cannot be negative %s", tx.GasTipCap)
+	}
+
+	if tx.GasFeeCap.IsNegative() {
+		return errorsmod.Wrapf(ErrInvalidGasCap, "gas fee cap cannot be negative %s", tx.GasFeeCap)
+	}
+
+	if !types.IsValidInt256(tx.GetGasTipCap()) {
+		return errorsmod.Wrap(ErrInvalidGasCap, "out of bound")
+	}
+
+	if !types.IsValidInt256(tx.GetGasFeeCap()) {
+		return errorsmod.Wrap(ErrInvalidGasCap, "out of bound")
+	}
+
+	if tx.GasFeeCap.LT(*tx.GasTipCap) {
+		return errorsmod.Wrapf(
+			ErrInvalidGasCap, "max priority fee per gas higher than max fee per gas (%s > %s)",
+			tx.GasTipCap, tx.GasFeeCap,
+		)
+	}
+
+	if !types.IsValidInt256(tx.Fee()) {
+		return errorsmod.Wrap(ErrInvalidGasFee, "out of bound")
+	}
+
+	amount := tx.GetValue()
+	if amount == nil {
+		return errorsmod.Wrap(ErrInvalidAmount, "amount cannot be nil")
+	}
+	if amount.Sign() == -1 {
+		return errorsmod.Wrapf(ErrInvalidAmount, "amount cannot be negative %s", amount)
+	}
+	if !types.IsValidInt256(amount) {
+		return errorsmod.Wrap(ErrInvalidAmount, "out of bound")
+	}
+
+	if tx.To == "" {
+		return errorsmod.Wrap(ErrSetCodeMissingTo, "to address required")
+	}
+	if err := types.ValidateAddress(tx.To); err != nil {
+		return errorsmod.Wrap(err, "invalid to address")
+	}
+
+	chainID := tx.GetChainID()
+
+	if chainID == nil {
+		return errorsmod.Wrap(
+			errortypes.ErrInvalidChainID,
+			"chain ID must be present on SetCode txs",
+		)
+	}
+
+	if !types.IsValidInt256(chainID) {
+		return errorsmod.Wrap(errortypes.ErrInvalidChainID, "out of bound")
+	}
+
+	if !(chainID.Cmp(big.NewInt(31612)) == 0 || chainID.Cmp(big.NewInt(31611)) == 0) {
+		return errorsmod.Wrapf(
+			errortypes.ErrInvalidChainID,
+			"chain ID must be 31611 or 31612 on Mezo, got %s", chainID,
+		)
+	}
+
+	if v, r, s := tx.GetRawSignatureValues(); !types.IsValidInt256(v) ||
+		!types.IsValidInt256(r) || !types.IsValidInt256(s) {
+		return errorsmod.Wrap(ErrInvalidSigner, "V, R or S out of bound")
+	}
+
+	if len(tx.AuthList) == 0 {
+		return errorsmod.Wrap(ErrSetCodeEmptyAuthList, "auth list must be non-empty")
+	}
+
+	var rTmp, sTmp big.Int
+	for i, auth := range tx.AuthList {
+		if auth.ChainID == nil {
+			return errorsmod.Wrapf(
+				errortypes.ErrInvalidChainID,
+				"authorization[%d] chain ID cannot be nil", i,
+			)
+		}
+		if !types.IsValidInt256(auth.ChainID.BigInt()) {
+			return errorsmod.Wrapf(
+				errortypes.ErrInvalidChainID,
+				"authorization[%d] chain ID out of bound", i,
+			)
+		}
+		if err := types.ValidateAddress(auth.Address); err != nil {
+			return errorsmod.Wrapf(err, "authorization[%d] invalid address", i)
+		}
+		if len(auth.V) > 1 {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] V length out of bound", i)
+		}
+		if len(auth.V) == 1 && auth.V[0] > 1 {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] V must be 0 or 1", i)
+		}
+		if len(auth.R) > 32 || len(auth.S) > 32 {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R or S length out of bound", i)
+		}
+		rTmp.SetBytes(auth.R)
+		sTmp.SetBytes(auth.S)
+		if rTmp.Sign() == 0 || sTmp.Sign() == 0 {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R and S must be non-zero", i)
+		}
+		if !types.IsValidInt256(&rTmp) {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] R out of bound", i)
+		}
+		if !types.IsValidInt256(&sTmp) {
+			return errorsmod.Wrapf(ErrInvalidSigner, "authorization[%d] S out of bound", i)
+		}
+	}
+
+	return nil
+}
+
+// Fee returns gasprice * gaslimit.
+func (tx SetCodeTx) Fee() *big.Int {
+	return fee(tx.GetGasFeeCap(), tx.GasLimit)
+}
+
+// Cost returns amount + gasprice * gaslimit.
+func (tx SetCodeTx) Cost() *big.Int {
+	return cost(tx.Fee(), tx.GetValue())
+}
+
+// EffectiveGasPrice returns the effective gas price
+func (tx *SetCodeTx) EffectiveGasPrice(baseFee *big.Int) *big.Int {
+	return EffectiveGasPrice(baseFee, tx.GasFeeCap.BigInt(), tx.GasTipCap.BigInt())
+}
+
+// EffectiveFee returns effective_gasprice * gaslimit.
+func (tx SetCodeTx) EffectiveFee(baseFee *big.Int) *big.Int {
+	return fee(tx.EffectiveGasPrice(baseFee), tx.GasLimit)
+}
+
+// EffectiveCost returns amount + effective_gasprice * gaslimit.
+func (tx SetCodeTx) EffectiveCost(baseFee *big.Int) *big.Int {
+	return cost(tx.EffectiveFee(baseFee), tx.GetValue())
+}

--- a/x/evm/types/set_code_tx_test.go
+++ b/x/evm/types/set_code_tx_test.go
@@ -255,12 +255,10 @@ func TestSetCodeTxValidate(t *testing.T) {
 			errMatch: "chain ID must be present",
 		},
 		{
-			name: "nil Amount rejected",
+			name: "nil Amount accepted (treated as zero, mirrors DynamicFeeTx)",
 			mutate: func(tx *evmtypes.SetCodeTx) {
 				tx.Amount = nil
 			},
-			wantErr:  true,
-			errMatch: "amount cannot be nil",
 		},
 		{
 			name: "outer R out of int256 bounds rejected",
@@ -368,24 +366,34 @@ func TestSetCodeTxValidate(t *testing.T) {
 			errMatch: "authorization[0]",
 		},
 		{
-			name: "auth with R longer than 32 bytes (overflow shape)",
+			name: "auth with R out of int256 bounds rejected",
 			mutate: func(tx *evmtypes.SetCodeTx) {
 				bad := validAuth()
 				bad.R = overflowBytes
 				tx.AuthList = evmtypes.AuthorizationList{bad}
 			},
 			wantErr:  true,
-			errMatch: "authorization[0] R or S length out of bound",
+			errMatch: "authorization[0] V, R or S out of bound",
 		},
 		{
-			name: "auth with S longer than 32 bytes (overflow shape)",
+			name: "auth with S out of int256 bounds rejected",
 			mutate: func(tx *evmtypes.SetCodeTx) {
 				bad := validAuth()
 				bad.S = overflowBytes
 				tx.AuthList = evmtypes.AuthorizationList{bad}
 			},
 			wantErr:  true,
-			errMatch: "authorization[0] R or S length out of bound",
+			errMatch: "authorization[0] V, R or S out of bound",
+		},
+		{
+			name: "auth with V out of int256 bounds rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.V = overflowBytes
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "authorization[0] V, R or S out of bound",
 		},
 		{
 			name: "auth with nil chain id",
@@ -407,24 +415,13 @@ func TestSetCodeTxValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "auth with len(V) > 1 rejected",
+			name: "auth with non-Mezo, non-zero chain id accepted (apply-time skip per EIP-7702)",
 			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.V = []byte{0x01, 0x00}
-				tx.AuthList = evmtypes.AuthorizationList{bad}
+				ok := validAuth()
+				cid := sdkmath.NewInt(99999)
+				ok.ChainID = &cid
+				tx.AuthList = evmtypes.AuthorizationList{ok}
 			},
-			wantErr:  true,
-			errMatch: "V length out of bound",
-		},
-		{
-			name: "auth with V[0] == 2 rejected",
-			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.V = []byte{0x02}
-				tx.AuthList = evmtypes.AuthorizationList{bad}
-			},
-			wantErr:  true,
-			errMatch: "V must be 0 or 1",
 		},
 		{
 			name: "auth with V[0] == 0 accepted",
@@ -435,44 +432,28 @@ func TestSetCodeTxValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "auth with R == 0 rejected",
+			name: "auth with V[0] > 1 accepted (canonical check deferred to keeper)",
 			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.R = []byte{}
-				tx.AuthList = evmtypes.AuthorizationList{bad}
+				ok := validAuth()
+				ok.V = []byte{0x02}
+				tx.AuthList = evmtypes.AuthorizationList{ok}
 			},
-			wantErr:  true,
-			errMatch: "R and S must be non-zero",
 		},
 		{
-			name: "auth with S == 0 rejected",
+			name: "auth with R == 0 accepted (canonical check deferred to keeper)",
 			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.S = []byte{}
-				tx.AuthList = evmtypes.AuthorizationList{bad}
+				ok := validAuth()
+				ok.R = []byte{}
+				tx.AuthList = evmtypes.AuthorizationList{ok}
 			},
-			wantErr:  true,
-			errMatch: "R and S must be non-zero",
 		},
 		{
-			name: "auth with len(R) > 32 rejected",
+			name: "auth with S == 0 accepted (canonical check deferred to keeper)",
 			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.R = append([]byte{0x00}, big.NewInt(7).FillBytes(make([]byte, 32))...)
-				tx.AuthList = evmtypes.AuthorizationList{bad}
+				ok := validAuth()
+				ok.S = []byte{}
+				tx.AuthList = evmtypes.AuthorizationList{ok}
 			},
-			wantErr:  true,
-			errMatch: "R or S length out of bound",
-		},
-		{
-			name: "auth with len(S) > 32 rejected",
-			mutate: func(tx *evmtypes.SetCodeTx) {
-				bad := validAuth()
-				bad.S = append([]byte{0x00}, big.NewInt(11).FillBytes(make([]byte, 32))...)
-				tx.AuthList = evmtypes.AuthorizationList{bad}
-			},
-			wantErr:  true,
-			errMatch: "R or S length out of bound",
 		},
 	}
 

--- a/x/evm/types/set_code_tx_test.go
+++ b/x/evm/types/set_code_tx_test.go
@@ -1,0 +1,658 @@
+package types_test
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	utiltx "github.com/mezo-org/mezod/testutil/tx"
+	evmtypes "github.com/mezo-org/mezod/x/evm/types"
+)
+
+var (
+	mezoChainID    = sdkmath.NewInt(31612)
+	bigMezoChainID = mezoChainID.BigInt()
+)
+
+func newTestAuth(t *testing.T, chainID *big.Int, addr common.Address, nonce uint64) ethtypes.SetCodeAuthorization {
+	t.Helper()
+	return ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: addr,
+		Nonce:   nonce,
+		V:       1,
+		R:       *uint256.NewInt(7),
+		S:       *uint256.NewInt(11),
+	}
+}
+
+func newSignedTestAuth(
+	t *testing.T,
+	chainID *big.Int,
+	addr common.Address,
+	nonce uint64,
+	priv *ecdsa.PrivateKey,
+) ethtypes.SetCodeAuthorization {
+	t.Helper()
+
+	auth := ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: addr,
+		Nonce:   nonce,
+	}
+	signed, err := ethtypes.SignSetCode(priv, auth)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestNewSetCodeTx(t *testing.T) {
+	to := utiltx.GenerateAddress()
+	auth := newTestAuth(t, big.NewInt(31611), to, 1)
+
+	tx := ethtypes.NewTx(&ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(bigMezoChainID),
+		Nonce:     1,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1),
+		Gas:       100,
+		To:        to,
+		Value:     uint256.NewInt(1),
+		Data:      []byte("data"),
+		AuthList:  []ethtypes.SetCodeAuthorization{auth},
+	})
+
+	out, err := evmtypes.NewSetCodeTx(tx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, uint8(ethtypes.SetCodeTxType), out.TxType())
+}
+
+func TestSetCodeTxAsEthereumData(t *testing.T) {
+	to := utiltx.GenerateAddress()
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	auth := newSignedTestAuth(t, big.NewInt(31611), to, 1, priv)
+
+	original := &ethtypes.SetCodeTx{
+		ChainID:    uint256.MustFromBig(bigMezoChainID),
+		Nonce:      7,
+		GasTipCap:  uint256.NewInt(2),
+		GasFeeCap:  uint256.NewInt(5),
+		Gas:        21000,
+		To:         to,
+		Value:      uint256.NewInt(123),
+		Data:       []byte("payload"),
+		AccessList: ethtypes.AccessList{{Address: to, StorageKeys: []common.Hash{{}}}},
+		AuthList:   []ethtypes.SetCodeAuthorization{auth},
+	}
+
+	tx := ethtypes.NewTx(original)
+
+	cosmosTx, err := evmtypes.NewSetCodeTx(tx)
+	require.NoError(t, err)
+
+	out := cosmosTx.AsEthereumData()
+	resTx := ethtypes.NewTx(out)
+
+	require.Equal(t, original.Nonce, resTx.Nonce())
+	require.Equal(t, original.Data, resTx.Data())
+	require.Equal(t, original.Gas, resTx.Gas())
+	require.Equal(t, original.Value.ToBig(), resTx.Value())
+	require.Equal(t, original.AccessList, resTx.AccessList())
+	require.Equal(t, &original.To, resTx.To())
+	require.Equal(t, original.AuthList, resTx.SetCodeAuthorizations())
+	require.Equal(t, bigMezoChainID, resTx.ChainId())
+}
+
+func TestSetCodeTxCopy(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		tx := &evmtypes.SetCodeTx{}
+		cp := tx.Copy().(*evmtypes.SetCodeTx)
+		require.NotSame(t, tx, cp)
+		require.Nil(t, cp.AuthList)
+	})
+
+	t.Run("empty (non-nil) AuthList preserved as empty", func(t *testing.T) {
+		tx := &evmtypes.SetCodeTx{
+			AuthList: evmtypes.AuthorizationList{},
+		}
+		cp := tx.Copy().(*evmtypes.SetCodeTx)
+		require.NotNil(t, cp.AuthList)
+		require.Len(t, cp.AuthList, 0)
+	})
+
+	t.Run("populated tx — mutating original does not affect copy", func(t *testing.T) {
+		auth := evmtypes.SetCodeAuthorization{
+			Address: common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Hex(),
+			V:       []byte{0x01},
+			R:       []byte{0x02},
+			S:       []byte{0x03},
+		}
+
+		tx := &evmtypes.SetCodeTx{
+			Data:     []byte{0xde, 0xad},
+			V:        []byte{0x10},
+			R:        []byte{0x20},
+			S:        []byte{0x30},
+			AuthList: evmtypes.AuthorizationList{auth},
+		}
+
+		cp := tx.Copy().(*evmtypes.SetCodeTx)
+
+		tx.Data[0] = 0
+		tx.V[0] = 0
+		tx.R[0] = 0
+		tx.S[0] = 0
+		tx.AuthList[0].V[0] = 0
+		tx.AuthList[0].R[0] = 0
+		tx.AuthList[0].S[0] = 0
+
+		require.Equal(t, byte(0xde), cp.Data[0])
+		require.Equal(t, byte(0x10), cp.V[0])
+		require.Equal(t, byte(0x20), cp.R[0])
+		require.Equal(t, byte(0x30), cp.S[0])
+		require.Equal(t, byte(0x01), cp.AuthList[0].V[0])
+		require.Equal(t, byte(0x02), cp.AuthList[0].R[0])
+		require.Equal(t, byte(0x03), cp.AuthList[0].S[0])
+	})
+}
+
+func TestSetCodeTxValidate(t *testing.T) {
+	hexAddr := utiltx.GenerateAddress().Hex()
+	innerChainID := sdkmath.NewInt(31611)
+
+	validAuth := func() evmtypes.SetCodeAuthorization {
+		return evmtypes.SetCodeAuthorization{
+			ChainID: &innerChainID,
+			Address: hexAddr,
+			Nonce:   1,
+			V:       []byte{1},
+			R:       big.NewInt(7).Bytes(),
+			S:       big.NewInt(11).Bytes(),
+		}
+	}
+
+	overflowBytes := new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil).Bytes()
+
+	zero := sdkmath.ZeroInt()
+	minusOne := sdkmath.NewInt(-1)
+
+	cases := []struct {
+		name     string
+		mutate   func(tx *evmtypes.SetCodeTx)
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name:     "happy path with one auth",
+			mutate:   nil,
+			wantErr:  false,
+			errMatch: "",
+		},
+		{
+			name: "happy path with five auths",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.AuthList = evmtypes.AuthorizationList{
+					validAuth(), validAuth(), validAuth(), validAuth(), validAuth(),
+				}
+			},
+		},
+		{
+			name: "to is empty rejects with ErrSetCodeMissingTo",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.To = ""
+			},
+			wantErr:  true,
+			errMatch: evmtypes.ErrSetCodeMissingTo.Error(),
+		},
+		{
+			name: "to is zero address accepted",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.To = (common.Address{}).Hex()
+			},
+		},
+		{
+			name: "to is malformed-but-non-empty rejected by ValidateAddress",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.To = "not-a-hex-address"
+			},
+			wantErr:  true,
+			errMatch: "invalid to address",
+		},
+		{
+			name: "nil GasTipCap rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.GasTipCap = nil
+			},
+			wantErr:  true,
+			errMatch: "gas tip cap cannot nil",
+		},
+		{
+			name: "nil GasFeeCap rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.GasFeeCap = nil
+			},
+			wantErr:  true,
+			errMatch: "gas fee cap cannot nil",
+		},
+		{
+			name: "nil ChainID rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.ChainID = nil
+			},
+			wantErr:  true,
+			errMatch: "chain ID must be present",
+		},
+		{
+			name: "nil Amount rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.Amount = nil
+			},
+			wantErr:  true,
+			errMatch: "amount cannot be nil",
+		},
+		{
+			name: "outer R out of int256 bounds rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.R = overflowBytes
+			},
+			wantErr:  true,
+			errMatch: "V, R or S out of bound",
+		},
+		{
+			name: "outer S out of int256 bounds rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.S = overflowBytes
+			},
+			wantErr:  true,
+			errMatch: "V, R or S out of bound",
+		},
+		{
+			name: "outer V out of int256 bounds rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.V = overflowBytes
+			},
+			wantErr:  true,
+			errMatch: "V, R or S out of bound",
+		},
+		{
+			name: "auth list empty rejects with ErrSetCodeEmptyAuthList",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.AuthList = nil
+			},
+			wantErr:  true,
+			errMatch: evmtypes.ErrSetCodeEmptyAuthList.Error(),
+		},
+		{
+			name: "negative gas tip cap",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.GasTipCap = &minusOne
+			},
+			wantErr:  true,
+			errMatch: "gas tip cap cannot be negative",
+		},
+		{
+			name: "negative gas fee cap",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.GasFeeCap = &minusOne
+				tx.GasTipCap = &zero
+			},
+			wantErr:  true,
+			errMatch: "gas fee cap cannot be negative",
+		},
+		{
+			name: "feecap < tipcap",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				high := sdkmath.NewInt(1000)
+				low := sdkmath.NewInt(1)
+				tx.GasTipCap = &high
+				tx.GasFeeCap = &low
+			},
+			wantErr:  true,
+			errMatch: "max priority fee per gas higher than max fee per gas",
+		},
+		{
+			name: "negative amount",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				tx.Amount = &minusOne
+			},
+			wantErr:  true,
+			errMatch: "amount cannot be negative",
+		},
+		{
+			name: "non-Mezo chain id (1) rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				cid := sdkmath.NewInt(1)
+				tx.ChainID = &cid
+			},
+			wantErr:  true,
+			errMatch: "chain ID must be 31611 or 31612",
+		},
+		{
+			name: "non-Mezo chain id (31610) rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				cid := sdkmath.NewInt(31610)
+				tx.ChainID = &cid
+			},
+			wantErr:  true,
+			errMatch: "chain ID must be 31611 or 31612",
+		},
+		{
+			name: "non-Mezo chain id (31613) rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				cid := sdkmath.NewInt(31613)
+				tx.ChainID = &cid
+			},
+			wantErr:  true,
+			errMatch: "chain ID must be 31611 or 31612",
+		},
+		{
+			name: "auth with malformed address",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.Address = "not-a-hex-address"
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "authorization[0]",
+		},
+		{
+			name: "auth with R longer than 32 bytes (overflow shape)",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.R = overflowBytes
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "authorization[0] R or S length out of bound",
+		},
+		{
+			name: "auth with S longer than 32 bytes (overflow shape)",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.S = overflowBytes
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "authorization[0] R or S length out of bound",
+		},
+		{
+			name: "auth with nil chain id",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.ChainID = nil
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "chain ID cannot be nil",
+		},
+		{
+			name: "auth with zero chain id accepted (any-chain sentinel)",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				zeroAuth := validAuth()
+				z := sdkmath.ZeroInt()
+				zeroAuth.ChainID = &z
+				tx.AuthList = evmtypes.AuthorizationList{zeroAuth}
+			},
+		},
+		{
+			name: "auth with len(V) > 1 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.V = []byte{0x01, 0x00}
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "V length out of bound",
+		},
+		{
+			name: "auth with V[0] == 2 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.V = []byte{0x02}
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "V must be 0 or 1",
+		},
+		{
+			name: "auth with V[0] == 0 accepted",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				ok := validAuth()
+				ok.V = []byte{0x00}
+				tx.AuthList = evmtypes.AuthorizationList{ok}
+			},
+		},
+		{
+			name: "auth with R == 0 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.R = []byte{}
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "R and S must be non-zero",
+		},
+		{
+			name: "auth with S == 0 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.S = []byte{}
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "R and S must be non-zero",
+		},
+		{
+			name: "auth with len(R) > 32 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.R = append([]byte{0x00}, big.NewInt(7).FillBytes(make([]byte, 32))...)
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "R or S length out of bound",
+		},
+		{
+			name: "auth with len(S) > 32 rejected",
+			mutate: func(tx *evmtypes.SetCodeTx) {
+				bad := validAuth()
+				bad.S = append([]byte{0x00}, big.NewInt(11).FillBytes(make([]byte, 32))...)
+				tx.AuthList = evmtypes.AuthorizationList{bad}
+			},
+			wantErr:  true,
+			errMatch: "R or S length out of bound",
+		},
+	}
+
+	build := func() evmtypes.SetCodeTx {
+		amount := sdkmath.NewInt(1)
+		return evmtypes.SetCodeTx{
+			ChainID:   &mezoChainID,
+			GasTipCap: &mezoChainID,
+			GasFeeCap: &mezoChainID,
+			Amount:    &amount,
+			To:        hexAddr,
+			AuthList:  evmtypes.AuthorizationList{validAuth()},
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := build()
+			if tc.mutate != nil {
+				tc.mutate(&tx)
+			}
+			err := tx.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errMatch != "" {
+					require.Contains(t, err.Error(), tc.errMatch)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+
+	t.Run("auth R/S overflow wraps ErrInvalidSigner", func(t *testing.T) {
+		tx := build()
+		bad := validAuth()
+		bad.R = overflowBytes
+		tx.AuthList = evmtypes.AuthorizationList{bad}
+		err := tx.Validate()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, evmtypes.ErrInvalidSigner),
+			"expected ErrInvalidSigner, got %v", err)
+		require.False(t, errors.Is(err, evmtypes.ErrInvalidAmount),
+			"R/S overflow must not surface as ErrInvalidAmount")
+	})
+
+	t.Run("outer V/R/S out-of-bound wraps ErrInvalidSigner", func(t *testing.T) {
+		tx := build()
+		tx.R = overflowBytes
+		err := tx.Validate()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, evmtypes.ErrInvalidSigner),
+			"expected ErrInvalidSigner, got %v", err)
+	})
+}
+
+func TestSetCodeTxGetAuthorizationList(t *testing.T) {
+	to := utiltx.GenerateAddress()
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	auths := []ethtypes.SetCodeAuthorization{
+		newSignedTestAuth(t, big.NewInt(31611), to, 1, priv),
+		newSignedTestAuth(t, big.NewInt(31611), to, 2, priv),
+	}
+
+	tx := ethtypes.NewTx(&ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(bigMezoChainID),
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1),
+		Gas:       100,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  auths,
+	})
+
+	cosmosTx, err := evmtypes.NewSetCodeTx(tx)
+	require.NoError(t, err)
+
+	got := cosmosTx.GetAuthorizationList()
+	require.Equal(t, auths, got)
+}
+
+func TestSetCodeTxGetters(t *testing.T) {
+	addr := utiltx.GenerateAddress()
+	hexAddr := addr.Hex()
+
+	tx := &evmtypes.SetCodeTx{
+		ChainID:   &mezoChainID,
+		GasTipCap: &mezoChainID,
+		GasFeeCap: &mezoChainID,
+		GasLimit:  21000,
+		To:        hexAddr,
+		Amount:    &mezoChainID,
+		Nonce:     7,
+		Data:      []byte("payload"),
+	}
+
+	require.Equal(t, big.NewInt(31612), tx.GetChainID())
+	require.Nil(t, tx.GetAccessList())
+	require.Equal(t, []byte("payload"), tx.GetData())
+	require.Equal(t, uint64(21000), tx.GetGas())
+	require.Equal(t, big.NewInt(31612), tx.GetGasFeeCap())
+	require.Equal(t, big.NewInt(31612), tx.GetGasTipCap())
+	require.Equal(t, big.NewInt(31612), tx.GetGasPrice())
+	require.Equal(t, big.NewInt(31612), tx.GetValue())
+	require.Equal(t, uint64(7), tx.GetNonce())
+	require.Equal(t, &addr, tx.GetTo())
+
+	// Empty To field returns nil
+	tx.To = ""
+	require.Nil(t, tx.GetTo())
+}
+
+func TestSetCodeTxFeeCost(t *testing.T) {
+	tx := &evmtypes.SetCodeTx{
+		GasFeeCap: &mezoChainID,
+		GasTipCap: &mezoChainID,
+		GasLimit:  2,
+		Amount:    &mezoChainID,
+	}
+
+	expFee := new(big.Int).Mul(big.NewInt(31612), big.NewInt(2))
+	require.Equal(t, expFee, tx.Fee())
+
+	expCost := new(big.Int).Add(expFee, big.NewInt(31612))
+	require.Equal(t, expCost, tx.Cost())
+
+	baseFee := big.NewInt(0)
+	require.Equal(t, big.NewInt(31612), tx.EffectiveGasPrice(baseFee))
+	require.Equal(t, expFee, tx.EffectiveFee(baseFee))
+	require.Equal(t, expCost, tx.EffectiveCost(baseFee))
+}
+
+// TestSetCodeTxAnyRoundTrip marshals a packed Any to bytes and unmarshals it
+// back so the round-trip exercises proto encoding of V/R/S, AuthList, and the
+// ChainID customtype, plus the codec interface registration. Without the byte
+// round-trip the cached *SetCodeTx pointer would short-circuit decoding.
+func TestSetCodeTxAnyRoundTrip(t *testing.T) {
+	registry := types.NewInterfaceRegistry()
+	evmtypes.RegisterInterfaces(registry)
+
+	innerChainID := sdkmath.NewInt(31611)
+	auth := evmtypes.SetCodeAuthorization{
+		ChainID: &innerChainID,
+		Address: utiltx.GenerateAddress().Hex(),
+		Nonce:   1,
+		V:       []byte{1},
+		R:       big.NewInt(7).Bytes(),
+		S:       big.NewInt(11).Bytes(),
+	}
+
+	original := &evmtypes.SetCodeTx{
+		ChainID:   &mezoChainID,
+		GasTipCap: &mezoChainID,
+		GasFeeCap: &mezoChainID,
+		Amount:    &mezoChainID,
+		GasLimit:  21000,
+		Nonce:     1,
+		To:        utiltx.GenerateAddress().Hex(),
+		Data:      []byte("payload"),
+		AuthList:  evmtypes.AuthorizationList{auth},
+		V:         []byte{1},
+		R:         []byte{2},
+		S:         []byte{3},
+	}
+
+	packed, err := evmtypes.PackTxData(original)
+	require.NoError(t, err)
+
+	bz, err := proto.Marshal(packed)
+	require.NoError(t, err)
+
+	var fresh types.Any
+	require.NoError(t, proto.Unmarshal(bz, &fresh))
+	require.Empty(t, fresh.GetCachedValue(),
+		"a freshly-unmarshaled Any must not carry a cached value")
+
+	var out evmtypes.TxData
+	require.NoError(t, registry.UnpackAny(&fresh, &out))
+
+	require.Equal(t, original, out)
+}

--- a/x/evm/types/simulate_v1.go
+++ b/x/evm/types/simulate_v1.go
@@ -438,6 +438,9 @@ func newRPCTransaction(
 		} else {
 			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
 		}
+	case ethtypes.SetCodeTxType:
+		// TODO (geth-upgrade): full SetCodeTx support is covered by .claude/MEZO-4336-eth-simulate-v1-geth116/plan.md
+		panic(fmt.Sprintf("newRPCTransaction: SetCodeTxType (0x%x) is not supported", ethtypes.SetCodeTxType))
 	}
 	return result
 }

--- a/x/evm/types/tx.pb.go
+++ b/x/evm/types/tx.pb.go
@@ -258,6 +258,123 @@ func (m *DynamicFeeTx) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DynamicFeeTx proto.InternalMessageInfo
 
+// SetCodeTx is the data of EIP-7702 set-code transactions (type 0x04).
+// `to` must be set (no contract creation) and `auth_list` must be non-empty;
+// proto3 has no field-level required semantics, so these invariants are
+// enforced by Validate() — not by the wire format.
+type SetCodeTx struct {
+	// chain_id of the destination EVM chain
+	ChainID *cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3,customtype=cosmossdk.io/math.Int" json:"chainID"`
+	// nonce corresponds to the account nonce (transaction sequence).
+	Nonce uint64 `protobuf:"varint,2,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// gas_tip_cap defines the max value for the gas tip
+	GasTipCap *cosmossdk_io_math.Int `protobuf:"bytes,3,opt,name=gas_tip_cap,json=gasTipCap,proto3,customtype=cosmossdk.io/math.Int" json:"gas_tip_cap,omitempty"`
+	// gas_fee_cap defines the max value for the gas fee
+	GasFeeCap *cosmossdk_io_math.Int `protobuf:"bytes,4,opt,name=gas_fee_cap,json=gasFeeCap,proto3,customtype=cosmossdk.io/math.Int" json:"gas_fee_cap,omitempty"`
+	// gas defines the gas limit defined for the transaction.
+	GasLimit uint64 `protobuf:"varint,5,opt,name=gas,proto3" json:"gas,omitempty"`
+	// to is the hex formatted address of the recipient
+	To string `protobuf:"bytes,6,opt,name=to,proto3" json:"to,omitempty"`
+	// value defines the the transaction amount.
+	Amount *cosmossdk_io_math.Int `protobuf:"bytes,7,opt,name=value,proto3,customtype=cosmossdk.io/math.Int" json:"value,omitempty"`
+	// data is the data payload bytes of the transaction.
+	Data []byte `protobuf:"bytes,8,opt,name=data,proto3" json:"data,omitempty"`
+	// accesses is an array of access tuples
+	Accesses AccessList `protobuf:"bytes,9,rep,name=accesses,proto3,castrepeated=AccessList" json:"accessList"`
+	// auth_list carries the EIP-7702 authorization tuples.
+	AuthList AuthorizationList `protobuf:"bytes,10,rep,name=auth_list,json=authList,proto3,castrepeated=AuthorizationList" json:"authorizationList"`
+	// v defines the signature value
+	V []byte `protobuf:"bytes,11,opt,name=v,proto3" json:"v,omitempty"`
+	// r defines the signature value
+	R []byte `protobuf:"bytes,12,opt,name=r,proto3" json:"r,omitempty"`
+	// s define the signature value
+	S []byte `protobuf:"bytes,13,opt,name=s,proto3" json:"s,omitempty"`
+}
+
+func (m *SetCodeTx) Reset()         { *m = SetCodeTx{} }
+func (m *SetCodeTx) String() string { return proto.CompactTextString(m) }
+func (*SetCodeTx) ProtoMessage()    {}
+func (*SetCodeTx) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f75ac0a12d075f21, []int{4}
+}
+func (m *SetCodeTx) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SetCodeTx) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SetCodeTx.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SetCodeTx) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetCodeTx.Merge(m, src)
+}
+func (m *SetCodeTx) XXX_Size() int {
+	return m.Size()
+}
+func (m *SetCodeTx) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetCodeTx.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetCodeTx proto.InternalMessageInfo
+
+// SetCodeAuthorization is a single EIP-7702 authorization tuple.
+type SetCodeAuthorization struct {
+	// chain_id is the chain on which the authorization is valid; 0 means any.
+	ChainID *cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3,customtype=cosmossdk.io/math.Int" json:"chainID"`
+	// address is the hex formatted address whose code the signer authorizes.
+	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	// nonce of the authorizing account at the time the authorization is signed.
+	Nonce uint64 `protobuf:"varint,3,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// v is the per-tuple signature yParity (0 or 1). Encoded as bytes for
+	// consistency with all other tx-level signature fields in this proto;
+	// empty bytes round-trip to zero.
+	V []byte `protobuf:"bytes,4,opt,name=v,proto3" json:"v,omitempty"`
+	// r defines the signature value
+	R []byte `protobuf:"bytes,5,opt,name=r,proto3" json:"r,omitempty"`
+	// s defines the signature value
+	S []byte `protobuf:"bytes,6,opt,name=s,proto3" json:"s,omitempty"`
+}
+
+func (m *SetCodeAuthorization) Reset()         { *m = SetCodeAuthorization{} }
+func (m *SetCodeAuthorization) String() string { return proto.CompactTextString(m) }
+func (*SetCodeAuthorization) ProtoMessage()    {}
+func (*SetCodeAuthorization) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f75ac0a12d075f21, []int{5}
+}
+func (m *SetCodeAuthorization) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SetCodeAuthorization) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SetCodeAuthorization.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SetCodeAuthorization) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetCodeAuthorization.Merge(m, src)
+}
+func (m *SetCodeAuthorization) XXX_Size() int {
+	return m.Size()
+}
+func (m *SetCodeAuthorization) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetCodeAuthorization.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetCodeAuthorization proto.InternalMessageInfo
+
 // ExtensionOptionsEthereumTx is an extension option for ethereum transactions
 type ExtensionOptionsEthereumTx struct {
 }
@@ -266,7 +383,7 @@ func (m *ExtensionOptionsEthereumTx) Reset()         { *m = ExtensionOptionsEthe
 func (m *ExtensionOptionsEthereumTx) String() string { return proto.CompactTextString(m) }
 func (*ExtensionOptionsEthereumTx) ProtoMessage()    {}
 func (*ExtensionOptionsEthereumTx) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f75ac0a12d075f21, []int{4}
+	return fileDescriptor_f75ac0a12d075f21, []int{6}
 }
 func (m *ExtensionOptionsEthereumTx) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -317,7 +434,7 @@ func (m *MsgEthereumTxResponse) Reset()         { *m = MsgEthereumTxResponse{} }
 func (m *MsgEthereumTxResponse) String() string { return proto.CompactTextString(m) }
 func (*MsgEthereumTxResponse) ProtoMessage()    {}
 func (*MsgEthereumTxResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f75ac0a12d075f21, []int{5}
+	return fileDescriptor_f75ac0a12d075f21, []int{7}
 }
 func (m *MsgEthereumTxResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -359,7 +476,7 @@ func (m *MsgUpdateParams) Reset()         { *m = MsgUpdateParams{} }
 func (m *MsgUpdateParams) String() string { return proto.CompactTextString(m) }
 func (*MsgUpdateParams) ProtoMessage()    {}
 func (*MsgUpdateParams) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f75ac0a12d075f21, []int{6}
+	return fileDescriptor_f75ac0a12d075f21, []int{8}
 }
 func (m *MsgUpdateParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -411,7 +528,7 @@ func (m *MsgUpdateParamsResponse) Reset()         { *m = MsgUpdateParamsResponse
 func (m *MsgUpdateParamsResponse) String() string { return proto.CompactTextString(m) }
 func (*MsgUpdateParamsResponse) ProtoMessage()    {}
 func (*MsgUpdateParamsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f75ac0a12d075f21, []int{7}
+	return fileDescriptor_f75ac0a12d075f21, []int{9}
 }
 func (m *MsgUpdateParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -445,6 +562,8 @@ func init() {
 	proto.RegisterType((*LegacyTx)(nil), "ethermint.evm.v1.LegacyTx")
 	proto.RegisterType((*AccessListTx)(nil), "ethermint.evm.v1.AccessListTx")
 	proto.RegisterType((*DynamicFeeTx)(nil), "ethermint.evm.v1.DynamicFeeTx")
+	proto.RegisterType((*SetCodeTx)(nil), "ethermint.evm.v1.SetCodeTx")
+	proto.RegisterType((*SetCodeAuthorization)(nil), "ethermint.evm.v1.SetCodeAuthorization")
 	proto.RegisterType((*ExtensionOptionsEthereumTx)(nil), "ethermint.evm.v1.ExtensionOptionsEthereumTx")
 	proto.RegisterType((*MsgEthereumTxResponse)(nil), "ethermint.evm.v1.MsgEthereumTxResponse")
 	proto.RegisterType((*MsgUpdateParams)(nil), "ethermint.evm.v1.MsgUpdateParams")
@@ -454,68 +573,75 @@ func init() {
 func init() { proto.RegisterFile("ethermint/evm/v1/tx.proto", fileDescriptor_f75ac0a12d075f21) }
 
 var fileDescriptor_f75ac0a12d075f21 = []byte{
-	// 964 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x55, 0xcf, 0x8b, 0x23, 0x45,
-	0x14, 0x9e, 0x4e, 0x3a, 0xbf, 0x2a, 0x71, 0x5c, 0x9a, 0x19, 0xb6, 0x13, 0x34, 0x1d, 0x23, 0x62,
-	0x56, 0x48, 0x37, 0x3b, 0xc2, 0xc2, 0xce, 0x45, 0x26, 0x3b, 0xb3, 0xb2, 0x32, 0x83, 0x4b, 0x9b,
-	0xbd, 0xa8, 0x10, 0x6a, 0xba, 0x6b, 0x2a, 0x85, 0xe9, 0xae, 0xa6, 0xab, 0xd2, 0x74, 0xf6, 0xb8,
-	0x27, 0x6f, 0x2a, 0xfe, 0x03, 0x1e, 0x3c, 0x79, 0xf2, 0xb0, 0x67, 0xcf, 0x8b, 0xa7, 0x45, 0x2f,
-	0x22, 0x18, 0x25, 0x23, 0x08, 0x73, 0xf4, 0xec, 0x41, 0xaa, 0xaa, 0x33, 0x99, 0x6c, 0xcc, 0x8c,
-	0x2e, 0xb8, 0xb7, 0xf7, 0xfa, 0x7d, 0xef, 0x47, 0x7d, 0x5f, 0xf5, 0x2b, 0x50, 0x47, 0x7c, 0x88,
-	0xe2, 0x80, 0x84, 0xdc, 0x41, 0x49, 0xe0, 0x24, 0x37, 0x1d, 0x9e, 0xda, 0x51, 0x4c, 0x39, 0x35,
-	0xae, 0x9d, 0x87, 0x6c, 0x94, 0x04, 0x76, 0x72, 0xb3, 0x71, 0xdd, 0xa3, 0x2c, 0xa0, 0xcc, 0x09,
-	0x18, 0x16, 0xc8, 0x80, 0x61, 0x05, 0x6d, 0xd4, 0x55, 0x60, 0x20, 0x3d, 0x47, 0x39, 0x59, 0xa8,
-	0xb1, 0xd2, 0x40, 0x14, 0x53, 0xb1, 0x2d, 0x4c, 0x31, 0x55, 0x39, 0xc2, 0xca, 0xbe, 0xbe, 0x82,
-	0x29, 0xc5, 0x23, 0xe4, 0xc0, 0x88, 0x38, 0x30, 0x0c, 0x29, 0x87, 0x9c, 0xd0, 0x70, 0x5e, 0xaf,
-	0x9e, 0x45, 0xa5, 0x77, 0x3c, 0x3e, 0x71, 0x60, 0x38, 0x51, 0xa1, 0xf6, 0x67, 0x1a, 0x78, 0xe9,
-	0x88, 0xe1, 0x03, 0xd1, 0x10, 0x8d, 0x83, 0x7e, 0x6a, 0x74, 0x80, 0xee, 0x43, 0x0e, 0x4d, 0xad,
-	0xa5, 0x75, 0xaa, 0x3b, 0x5b, 0xb6, 0xca, 0xb5, 0xe7, 0xb9, 0xf6, 0x5e, 0x38, 0x71, 0x25, 0xc2,
-	0xa8, 0x03, 0x9d, 0x91, 0x87, 0xc8, 0xcc, 0xb5, 0xb4, 0x8e, 0xd6, 0x2b, 0x9c, 0x4d, 0x2d, 0xad,
-	0xeb, 0xca, 0x4f, 0x86, 0x05, 0xf4, 0x21, 0x64, 0x43, 0x33, 0xdf, 0xd2, 0x3a, 0x95, 0x5e, 0xf5,
-	0xcf, 0xa9, 0x55, 0x8a, 0x47, 0xd1, 0x6e, 0xbb, 0xdb, 0x76, 0x65, 0xc0, 0x30, 0x80, 0x7e, 0x12,
-	0xd3, 0xc0, 0xd4, 0x05, 0xc0, 0x95, 0xf6, 0xae, 0xfe, 0xe9, 0x57, 0xd6, 0x46, 0xfb, 0x8b, 0x1c,
-	0x28, 0x1f, 0x22, 0x0c, 0xbd, 0x49, 0x3f, 0x35, 0xb6, 0x40, 0x21, 0xa4, 0xa1, 0x87, 0xe4, 0x34,
-	0xba, 0xab, 0x1c, 0xe3, 0x16, 0xa8, 0x60, 0x28, 0x98, 0x23, 0x9e, 0xea, 0x5e, 0xe9, 0xd5, 0x7f,
-	0x9e, 0x5a, 0xdb, 0x8a, 0x44, 0xe6, 0x7f, 0x62, 0x13, 0xea, 0x04, 0x90, 0x0f, 0xed, 0x7b, 0x21,
-	0x77, 0xcb, 0x18, 0xb2, 0xfb, 0x02, 0x6a, 0x34, 0x41, 0x1e, 0x43, 0x26, 0x87, 0xd2, 0x7b, 0xb5,
-	0xd9, 0xd4, 0x2a, 0xbf, 0x0b, 0xd9, 0x21, 0x09, 0x08, 0x77, 0x45, 0xc0, 0xd8, 0x04, 0x39, 0x4e,
-	0xb3, 0x91, 0x72, 0x9c, 0x1a, 0xb7, 0x41, 0x21, 0x81, 0xa3, 0x31, 0x32, 0x0b, 0xb2, 0xc7, 0xeb,
-	0x6b, 0x7b, 0xcc, 0xa6, 0x56, 0x71, 0x2f, 0xa0, 0xe3, 0x90, 0xbb, 0x2a, 0x43, 0x9c, 0x4f, 0xb2,
-	0x58, 0x6c, 0x69, 0x9d, 0x5a, 0xc6, 0x57, 0x0d, 0x68, 0x89, 0x59, 0x92, 0x1f, 0xb4, 0x44, 0x78,
-	0xb1, 0x59, 0x56, 0x5e, 0x2c, 0x3c, 0x66, 0x56, 0x94, 0xc7, 0x76, 0x37, 0x05, 0x13, 0xdf, 0x3f,
-	0xee, 0x16, 0xfb, 0xe9, 0x3e, 0xe4, 0xb0, 0xfd, 0x5d, 0x1e, 0xd4, 0xf6, 0x3c, 0x0f, 0x31, 0x76,
-	0x48, 0x18, 0xef, 0xa7, 0xc6, 0x7b, 0xa0, 0xec, 0x0d, 0x21, 0x09, 0x07, 0xc4, 0x97, 0xd4, 0x54,
-	0x7a, 0xce, 0x65, 0xc3, 0x95, 0xee, 0x08, 0xf0, 0xbd, 0xfd, 0xb3, 0xa9, 0x55, 0xf2, 0x94, 0xe9,
-	0x66, 0x86, 0xbf, 0xe0, 0x38, 0xb7, 0x96, 0xe3, 0xfc, 0x7f, 0xe6, 0x58, 0xbf, 0x9c, 0xe3, 0xc2,
-	0x2a, 0xc7, 0xc5, 0xe7, 0xe6, 0xb8, 0x74, 0x81, 0xe3, 0x8f, 0x40, 0x19, 0x4a, 0xa2, 0x10, 0x33,
-	0xcb, 0xad, 0x7c, 0xa7, 0xba, 0xf3, 0xaa, 0xfd, 0xec, 0x3f, 0x69, 0x2b, 0x2a, 0xfb, 0xe3, 0x68,
-	0x84, 0x7a, 0xad, 0x27, 0x53, 0x6b, 0xe3, 0x6c, 0x6a, 0x01, 0x78, 0xce, 0xef, 0x37, 0xbf, 0x5a,
-	0x60, 0xc1, 0xb6, 0x7b, 0x5e, 0x50, 0x09, 0x58, 0x59, 0x12, 0x10, 0x2c, 0x09, 0x58, 0x5d, 0x27,
-	0xe0, 0x5f, 0x79, 0x50, 0xdb, 0x9f, 0x84, 0x30, 0x20, 0xde, 0x5d, 0x84, 0x5e, 0x88, 0x80, 0xb7,
-	0x41, 0x55, 0x08, 0xc8, 0x49, 0x34, 0xf0, 0x60, 0x74, 0xb5, 0x84, 0x42, 0xee, 0x3e, 0x89, 0xee,
-	0xc0, 0x68, 0x9e, 0x7a, 0x82, 0x90, 0x4c, 0xd5, 0xff, 0x4d, 0xea, 0x5d, 0x84, 0x44, 0x6a, 0x26,
-	0x7f, 0xe1, 0x72, 0xf9, 0x8b, 0xab, 0xf2, 0x97, 0x9e, 0x5b, 0xfe, 0xf2, 0x1a, 0xf9, 0x2b, 0xff,
-	0x8b, 0xfc, 0x60, 0x49, 0xfe, 0xea, 0x92, 0xfc, 0xb5, 0x75, 0xf2, 0xb7, 0x41, 0xe3, 0x20, 0xe5,
-	0x28, 0x64, 0x84, 0x86, 0xef, 0x47, 0x72, 0x35, 0x2f, 0x36, 0x6e, 0xb6, 0xf7, 0xbe, 0xd6, 0xc0,
-	0xf6, 0xd2, 0x26, 0x76, 0x11, 0x8b, 0x68, 0xc8, 0xe4, 0x41, 0xe5, 0x32, 0xd5, 0xd4, 0xae, 0x94,
-	0xfb, 0xf3, 0x06, 0xd0, 0x47, 0x14, 0x33, 0x33, 0x27, 0x0f, 0xb9, 0xbd, 0x7a, 0xc8, 0x43, 0x8a,
-	0x5d, 0x09, 0x31, 0xae, 0x81, 0x7c, 0x8c, 0xb8, 0xbc, 0x00, 0x35, 0x57, 0x98, 0x46, 0x1d, 0x94,
-	0x93, 0x60, 0x80, 0xe2, 0x98, 0xc6, 0xd9, 0xb6, 0x2b, 0x25, 0xc1, 0x81, 0x70, 0x45, 0x48, 0x48,
-	0x3f, 0x66, 0xc8, 0x57, 0x22, 0xba, 0x25, 0x0c, 0xd9, 0x03, 0x86, 0xfc, 0xf9, 0x7a, 0xd6, 0xc0,
-	0xcb, 0x47, 0x0c, 0x3f, 0x88, 0x7c, 0xc8, 0xd1, 0x7d, 0x18, 0xc3, 0x80, 0x89, 0x5d, 0x01, 0xc7,
-	0x7c, 0x48, 0x63, 0xc2, 0x27, 0xd9, 0x6d, 0x36, 0x7f, 0x78, 0xdc, 0xdd, 0xca, 0x1e, 0xb5, 0x3d,
-	0xdf, 0x8f, 0x11, 0x63, 0x1f, 0xf0, 0x98, 0x84, 0xd8, 0x5d, 0x40, 0x8d, 0x5b, 0xa0, 0x18, 0xc9,
-	0x0a, 0xf2, 0xe6, 0x56, 0x77, 0xcc, 0xd5, 0x63, 0xa8, 0x0e, 0x3d, 0x5d, 0xc8, 0xe4, 0x66, 0xe8,
-	0xdd, 0xcd, 0x47, 0x7f, 0x7c, 0xfb, 0xd6, 0xa2, 0x4e, 0xbb, 0x0e, 0xae, 0x3f, 0x33, 0xd2, 0x9c,
-	0xbb, 0x9d, 0x5f, 0x34, 0x90, 0x3f, 0x62, 0xd8, 0x48, 0x01, 0xb8, 0xf0, 0xc6, 0x59, 0xab, 0x8d,
-	0x96, 0xa8, 0x6f, 0xbc, 0x79, 0x05, 0x60, 0x5e, 0xbf, 0xdd, 0x7a, 0xf4, 0xe3, 0xef, 0x5f, 0xe6,
-	0x1a, 0x6d, 0xd3, 0x09, 0xd0, 0x43, 0x7a, 0xfe, 0x5c, 0x67, 0xc0, 0x01, 0x4f, 0x8d, 0x8f, 0x41,
-	0x6d, 0x89, 0xac, 0xd7, 0xfe, 0xb1, 0xf4, 0x45, 0x48, 0xe3, 0xc6, 0x95, 0x90, 0x79, 0xff, 0xde,
-	0x3b, 0x4f, 0x66, 0x4d, 0xed, 0xe9, 0xac, 0xa9, 0xfd, 0x36, 0x6b, 0x6a, 0x9f, 0x9f, 0x36, 0x37,
-	0x9e, 0x9e, 0x36, 0x37, 0x7e, 0x3a, 0x6d, 0x6e, 0x7c, 0xf8, 0x06, 0x26, 0x7c, 0x38, 0x3e, 0xb6,
-	0x3d, 0x1a, 0xc8, 0xd9, 0xba, 0x34, 0xc6, 0xd2, 0xf0, 0x9d, 0x54, 0xce, 0xc9, 0x27, 0x11, 0x62,
-	0xc7, 0x45, 0xf9, 0xb0, 0xbf, 0xfd, 0x77, 0x00, 0x00, 0x00, 0xff, 0xff, 0x34, 0xf5, 0xb6, 0x0a,
-	0xd5, 0x08, 0x00, 0x00,
+	// 1076 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x56, 0xcf, 0x8b, 0x23, 0x45,
+	0x14, 0x4e, 0x27, 0x9d, 0xa4, 0x53, 0xc9, 0x8e, 0xbb, 0x4d, 0x86, 0xed, 0x04, 0x4d, 0xc7, 0x88,
+	0x9a, 0x15, 0xd2, 0xcd, 0x8e, 0xb0, 0xb0, 0x73, 0x91, 0x64, 0x66, 0x56, 0x56, 0x66, 0x70, 0xe9,
+	0xcd, 0x5e, 0x54, 0x08, 0x35, 0xdd, 0x35, 0x9d, 0xc6, 0x74, 0x57, 0xd3, 0x55, 0x09, 0xc9, 0x1c,
+	0xf7, 0xe4, 0x4d, 0xc5, 0x7f, 0xc0, 0x83, 0x27, 0x4f, 0x1e, 0xf6, 0xec, 0xc1, 0xd3, 0xe2, 0x69,
+	0xd1, 0x8b, 0x08, 0x46, 0xc9, 0x08, 0xc2, 0x1c, 0x3c, 0x78, 0xf6, 0x20, 0x55, 0xd5, 0x99, 0xa4,
+	0x27, 0x9b, 0x19, 0x5d, 0x54, 0x10, 0xbc, 0xd5, 0xab, 0xf7, 0xbd, 0x1f, 0xf5, 0x7d, 0xaf, 0xe9,
+	0x07, 0x2a, 0x88, 0xf6, 0x51, 0xe4, 0x7b, 0x01, 0x35, 0xd1, 0xc8, 0x37, 0x47, 0x37, 0x4d, 0x3a,
+	0x36, 0xc2, 0x08, 0x53, 0xac, 0x5e, 0x3d, 0x73, 0x19, 0x68, 0xe4, 0x1b, 0xa3, 0x9b, 0xd5, 0xeb,
+	0x36, 0x26, 0x3e, 0x26, 0xa6, 0x4f, 0x5c, 0x86, 0xf4, 0x89, 0x2b, 0xa0, 0xd5, 0x8a, 0x70, 0xf4,
+	0xb8, 0x65, 0x0a, 0x23, 0x76, 0x55, 0x57, 0x0a, 0xb0, 0x64, 0xc2, 0x57, 0x76, 0xb1, 0x8b, 0x45,
+	0x0c, 0x3b, 0xc5, 0xb7, 0xcf, 0xbb, 0x18, 0xbb, 0x03, 0x64, 0xc2, 0xd0, 0x33, 0x61, 0x10, 0x60,
+	0x0a, 0xa9, 0x87, 0x83, 0x79, 0xbe, 0x4a, 0xec, 0xe5, 0xd6, 0xe1, 0xf0, 0xc8, 0x84, 0xc1, 0x44,
+	0xb8, 0x1a, 0x1f, 0x4a, 0xe0, 0xca, 0x01, 0x71, 0xf7, 0x58, 0x41, 0x34, 0xf4, 0xbb, 0x63, 0xb5,
+	0x09, 0x64, 0x07, 0x52, 0xa8, 0x49, 0x75, 0xa9, 0x59, 0xdc, 0x2a, 0x1b, 0x22, 0xd6, 0x98, 0xc7,
+	0x1a, 0xed, 0x60, 0x62, 0x71, 0x84, 0x5a, 0x01, 0x32, 0xf1, 0x8e, 0x91, 0x96, 0xae, 0x4b, 0x4d,
+	0xa9, 0x93, 0x3d, 0x9d, 0xea, 0x52, 0xcb, 0xe2, 0x57, 0xaa, 0x0e, 0xe4, 0x3e, 0x24, 0x7d, 0x2d,
+	0x53, 0x97, 0x9a, 0x85, 0x4e, 0xf1, 0xb7, 0xa9, 0x9e, 0x8f, 0x06, 0xe1, 0x76, 0xa3, 0xd5, 0xb0,
+	0xb8, 0x43, 0x55, 0x81, 0x7c, 0x14, 0x61, 0x5f, 0x93, 0x19, 0xc0, 0xe2, 0xe7, 0x6d, 0xf9, 0x83,
+	0x4f, 0xf5, 0x54, 0xe3, 0xe3, 0x34, 0x50, 0xf6, 0x91, 0x0b, 0xed, 0x49, 0x77, 0xac, 0x96, 0x41,
+	0x36, 0xc0, 0x81, 0x8d, 0x78, 0x37, 0xb2, 0x25, 0x0c, 0xf5, 0x16, 0x28, 0xb8, 0x90, 0x31, 0xe7,
+	0xd9, 0xa2, 0x7a, 0xa1, 0x53, 0xf9, 0x7e, 0xaa, 0x6f, 0x0a, 0x12, 0x89, 0xf3, 0xbe, 0xe1, 0x61,
+	0xd3, 0x87, 0xb4, 0x6f, 0xdc, 0x0d, 0xa8, 0xa5, 0xb8, 0x90, 0xdc, 0x63, 0x50, 0xb5, 0x06, 0x32,
+	0x2e, 0x24, 0xbc, 0x29, 0xb9, 0x53, 0x9a, 0x4d, 0x75, 0xe5, 0x4d, 0x48, 0xf6, 0x3d, 0xdf, 0xa3,
+	0x16, 0x73, 0xa8, 0x1b, 0x20, 0x4d, 0x71, 0xdc, 0x52, 0x9a, 0x62, 0xf5, 0x36, 0xc8, 0x8e, 0xe0,
+	0x60, 0x88, 0xb4, 0x2c, 0xaf, 0xf1, 0xd2, 0xda, 0x1a, 0xb3, 0xa9, 0x9e, 0x6b, 0xfb, 0x78, 0x18,
+	0x50, 0x4b, 0x44, 0xb0, 0xf7, 0x71, 0x16, 0x73, 0x75, 0xa9, 0x59, 0x8a, 0xf9, 0x2a, 0x01, 0x69,
+	0xa4, 0xe5, 0xf9, 0x85, 0x34, 0x62, 0x56, 0xa4, 0x29, 0xc2, 0x8a, 0x98, 0x45, 0xb4, 0x82, 0xb0,
+	0xc8, 0xf6, 0x06, 0x63, 0xe2, 0xeb, 0x47, 0xad, 0x5c, 0x77, 0xbc, 0x0b, 0x29, 0x6c, 0x7c, 0x99,
+	0x01, 0xa5, 0xb6, 0x6d, 0x23, 0x42, 0xf6, 0x3d, 0x42, 0xbb, 0x63, 0xf5, 0x2d, 0xa0, 0xd8, 0x7d,
+	0xe8, 0x05, 0x3d, 0xcf, 0xe1, 0xd4, 0x14, 0x3a, 0xe6, 0x45, 0xcd, 0xe5, 0x77, 0x18, 0xf8, 0xee,
+	0xee, 0xe9, 0x54, 0xcf, 0xdb, 0xe2, 0x68, 0xc5, 0x07, 0x67, 0xc1, 0x71, 0x7a, 0x2d, 0xc7, 0x99,
+	0xbf, 0xcc, 0xb1, 0x7c, 0x31, 0xc7, 0xd9, 0x55, 0x8e, 0x73, 0xcf, 0xcc, 0x71, 0x7e, 0x89, 0xe3,
+	0x77, 0x81, 0x02, 0x39, 0x51, 0x88, 0x68, 0x4a, 0x3d, 0xd3, 0x2c, 0x6e, 0xbd, 0x60, 0x9c, 0xff,
+	0x26, 0x0d, 0x41, 0x65, 0x77, 0x18, 0x0e, 0x50, 0xa7, 0xfe, 0x78, 0xaa, 0xa7, 0x4e, 0xa7, 0x3a,
+	0x80, 0x67, 0xfc, 0x7e, 0xfe, 0xa3, 0x0e, 0x16, 0x6c, 0x5b, 0x67, 0x09, 0x85, 0x80, 0x85, 0x84,
+	0x80, 0x20, 0x21, 0x60, 0x71, 0x9d, 0x80, 0xbf, 0x67, 0x40, 0x69, 0x77, 0x12, 0x40, 0xdf, 0xb3,
+	0xef, 0x20, 0xf4, 0xaf, 0x08, 0x78, 0x1b, 0x14, 0x99, 0x80, 0xd4, 0x0b, 0x7b, 0x36, 0x0c, 0x2f,
+	0x97, 0x90, 0xc9, 0xdd, 0xf5, 0xc2, 0x1d, 0x18, 0xce, 0x43, 0x8f, 0x10, 0xe2, 0xa1, 0xf2, 0x9f,
+	0x09, 0xbd, 0x83, 0x10, 0x0b, 0x8d, 0xe5, 0xcf, 0x5e, 0x2c, 0x7f, 0x6e, 0x55, 0xfe, 0xfc, 0x33,
+	0xcb, 0xaf, 0xac, 0x91, 0xbf, 0xf0, 0x8f, 0xc8, 0x0f, 0x12, 0xf2, 0x17, 0x13, 0xf2, 0x97, 0xd6,
+	0xc9, 0xff, 0xab, 0x0c, 0x0a, 0xf7, 0x11, 0xdd, 0xc1, 0xce, 0xff, 0xda, 0xff, 0x37, 0xb5, 0x27,
+	0xa0, 0x00, 0x87, 0xb4, 0xdf, 0x1b, 0x78, 0x84, 0x6a, 0x80, 0x67, 0x7f, 0x65, 0x35, 0x7b, 0xac,
+	0x71, 0x7b, 0x48, 0xfb, 0x38, 0xf2, 0x8e, 0xf9, 0x4f, 0xb8, 0x63, 0xc4, 0x65, 0xae, 0xc1, 0xe5,
+	0xeb, 0xb8, 0xda, 0xb5, 0xf6, 0xf9, 0x4b, 0x4b, 0x61, 0x38, 0x76, 0x12, 0x03, 0x57, 0x4c, 0x0c,
+	0x5c, 0x29, 0x31, 0x70, 0x57, 0xd6, 0x0d, 0xdc, 0x57, 0x12, 0x28, 0x3f, 0xad, 0x99, 0xbf, 0x75,
+	0xf6, 0x34, 0x90, 0x87, 0x8e, 0x13, 0x21, 0x42, 0xc4, 0x4f, 0xd8, 0x9a, 0x9b, 0x8b, 0xa9, 0xcc,
+	0x2c, 0x4f, 0x25, 0x7f, 0x8e, 0x9c, 0x78, 0x4e, 0x36, 0xf1, 0x9c, 0xdc, 0xfc, 0x39, 0x62, 0x13,
+	0x68, 0x80, 0xea, 0xde, 0x98, 0xa2, 0x80, 0x78, 0x38, 0x78, 0x3b, 0xe4, 0x0b, 0xcd, 0x62, 0x4f,
+	0x89, 0x31, 0x9f, 0x49, 0x60, 0x33, 0xb1, 0xbf, 0x58, 0x88, 0x84, 0x38, 0x20, 0x7c, 0x44, 0xf8,
+	0x0a, 0x22, 0x89, 0x0d, 0x83, 0x6f, 0x1d, 0x37, 0x80, 0x3c, 0xc0, 0x2e, 0x6b, 0x97, 0x09, 0xb8,
+	0xb9, 0x2a, 0xe0, 0x3e, 0x76, 0x2d, 0x0e, 0x51, 0xaf, 0x82, 0x4c, 0x84, 0x28, 0x7f, 0x40, 0xc9,
+	0x62, 0x47, 0xb5, 0x02, 0x94, 0x91, 0xdf, 0x43, 0x51, 0x84, 0xa3, 0x78, 0x47, 0xc8, 0x8f, 0xfc,
+	0x3d, 0x66, 0x32, 0x17, 0xfb, 0x68, 0x86, 0x04, 0x39, 0x62, 0xfc, 0xad, 0xbc, 0x0b, 0xc9, 0x03,
+	0x82, 0x9c, 0xf9, 0x52, 0x23, 0x81, 0xe7, 0x0e, 0x88, 0xfb, 0x20, 0x74, 0x20, 0x45, 0xf7, 0x60,
+	0x04, 0x7d, 0xc2, 0xfe, 0xb0, 0xf1, 0x44, 0xd0, 0x49, 0xac, 0x85, 0xf6, 0xcd, 0xa3, 0x56, 0x39,
+	0x5e, 0x05, 0xdb, 0x82, 0xcb, 0xfb, 0x34, 0xf2, 0x02, 0xd7, 0x5a, 0x40, 0xd5, 0x5b, 0x20, 0x17,
+	0xf2, 0x0c, 0x9c, 0xf5, 0xe2, 0x96, 0xb6, 0xfa, 0x0c, 0x51, 0xa1, 0x23, 0xb3, 0xc9, 0xb3, 0x62,
+	0xf4, 0xf6, 0xc6, 0xc3, 0x5f, 0xbe, 0x78, 0x6d, 0x91, 0xa7, 0x51, 0x01, 0xd7, 0xcf, 0xb5, 0x34,
+	0xe7, 0x6e, 0xeb, 0x07, 0x09, 0x64, 0x0e, 0x88, 0xab, 0x8e, 0x01, 0x58, 0xda, 0x0c, 0xf5, 0xd5,
+	0x42, 0x09, 0xea, 0xab, 0xaf, 0x5e, 0x02, 0x98, 0xe7, 0x6f, 0xd4, 0x1f, 0x7e, 0xfb, 0xf3, 0x27,
+	0xe9, 0x6a, 0x43, 0x33, 0x7d, 0x74, 0x8c, 0xcf, 0x96, 0xdc, 0x18, 0xd8, 0xa3, 0x63, 0xf5, 0x3d,
+	0x50, 0x4a, 0x90, 0xf5, 0xe2, 0x53, 0x53, 0x2f, 0x43, 0xaa, 0x37, 0x2e, 0x85, 0xcc, 0xeb, 0x77,
+	0xde, 0x78, 0x3c, 0xab, 0x49, 0x4f, 0x66, 0x35, 0xe9, 0xa7, 0x59, 0x4d, 0xfa, 0xe8, 0xa4, 0x96,
+	0x7a, 0x72, 0x52, 0x4b, 0x7d, 0x77, 0x52, 0x4b, 0xbd, 0xf3, 0xb2, 0xeb, 0xd1, 0xfe, 0xf0, 0xd0,
+	0xb0, 0xb1, 0xcf, 0x7b, 0x6b, 0xe1, 0xc8, 0xe5, 0x07, 0xc7, 0x1c, 0xf3, 0x3e, 0xe9, 0x24, 0x44,
+	0xe4, 0x30, 0xc7, 0xd7, 0xe1, 0xd7, 0xff, 0x08, 0x00, 0x00, 0xff, 0xff, 0x21, 0x0d, 0x41, 0x55,
+	0x0b, 0x0c, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1035,6 +1161,218 @@ func (m *DynamicFeeTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *SetCodeTx) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SetCodeTx) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SetCodeTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.S) > 0 {
+		i -= len(m.S)
+		copy(dAtA[i:], m.S)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.S)))
+		i--
+		dAtA[i] = 0x6a
+	}
+	if len(m.R) > 0 {
+		i -= len(m.R)
+		copy(dAtA[i:], m.R)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.R)))
+		i--
+		dAtA[i] = 0x62
+	}
+	if len(m.V) > 0 {
+		i -= len(m.V)
+		copy(dAtA[i:], m.V)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.V)))
+		i--
+		dAtA[i] = 0x5a
+	}
+	if len(m.AuthList) > 0 {
+		for iNdEx := len(m.AuthList) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.AuthList[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x52
+		}
+	}
+	if len(m.Accesses) > 0 {
+		for iNdEx := len(m.Accesses) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Accesses[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
+	if len(m.Data) > 0 {
+		i -= len(m.Data)
+		copy(dAtA[i:], m.Data)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Data)))
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.Amount != nil {
+		{
+			size := m.Amount.Size()
+			i -= size
+			if _, err := m.Amount.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+			i = encodeVarintTx(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.To) > 0 {
+		i -= len(m.To)
+		copy(dAtA[i:], m.To)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.To)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.GasLimit != 0 {
+		i = encodeVarintTx(dAtA, i, uint64(m.GasLimit))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.GasFeeCap != nil {
+		{
+			size := m.GasFeeCap.Size()
+			i -= size
+			if _, err := m.GasFeeCap.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+			i = encodeVarintTx(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.GasTipCap != nil {
+		{
+			size := m.GasTipCap.Size()
+			i -= size
+			if _, err := m.GasTipCap.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+			i = encodeVarintTx(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Nonce != 0 {
+		i = encodeVarintTx(dAtA, i, uint64(m.Nonce))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.ChainID != nil {
+		{
+			size := m.ChainID.Size()
+			i -= size
+			if _, err := m.ChainID.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+			i = encodeVarintTx(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SetCodeAuthorization) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SetCodeAuthorization) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SetCodeAuthorization) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.S) > 0 {
+		i -= len(m.S)
+		copy(dAtA[i:], m.S)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.S)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.R) > 0 {
+		i -= len(m.R)
+		copy(dAtA[i:], m.R)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.R)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.V) > 0 {
+		i -= len(m.V)
+		copy(dAtA[i:], m.V)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.V)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Nonce != 0 {
+		i = encodeVarintTx(dAtA, i, uint64(m.Nonce))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.ChainID != nil {
+		{
+			size := m.ChainID.Size()
+			i -= size
+			if _, err := m.ChainID.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+			i = encodeVarintTx(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ExtensionOptionsEthereumTx) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1356,6 +1694,101 @@ func (m *DynamicFeeTx) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovTx(uint64(l))
 		}
+	}
+	l = len(m.V)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.R)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.S)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *SetCodeTx) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ChainID != nil {
+		l = m.ChainID.Size()
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.Nonce != 0 {
+		n += 1 + sovTx(uint64(m.Nonce))
+	}
+	if m.GasTipCap != nil {
+		l = m.GasTipCap.Size()
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.GasFeeCap != nil {
+		l = m.GasFeeCap.Size()
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.GasLimit != 0 {
+		n += 1 + sovTx(uint64(m.GasLimit))
+	}
+	l = len(m.To)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.Amount != nil {
+		l = m.Amount.Size()
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Accesses) > 0 {
+		for _, e := range m.Accesses {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	if len(m.AuthList) > 0 {
+		for _, e := range m.AuthList {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	l = len(m.V)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.R)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.S)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *SetCodeAuthorization) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ChainID != nil {
+		l = m.ChainID.Size()
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.Nonce != 0 {
+		n += 1 + sovTx(uint64(m.Nonce))
 	}
 	l = len(m.V)
 	if l > 0 {
@@ -2708,6 +3141,713 @@ func (m *DynamicFeeTx) Unmarshal(dAtA []byte) error {
 			}
 			iNdEx = postIndex
 		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field S", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.S = append(m.S[:0], dAtA[iNdEx:postIndex]...)
+			if m.S == nil {
+				m.S = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SetCodeTx) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetCodeTx: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetCodeTx: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChainID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v cosmossdk_io_math.Int
+			m.ChainID = &v
+			if err := m.ChainID.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Nonce", wireType)
+			}
+			m.Nonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Nonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GasTipCap", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v cosmossdk_io_math.Int
+			m.GasTipCap = &v
+			if err := m.GasTipCap.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GasFeeCap", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v cosmossdk_io_math.Int
+			m.GasFeeCap = &v
+			if err := m.GasFeeCap.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GasLimit", wireType)
+			}
+			m.GasLimit = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.GasLimit |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field To", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.To = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v cosmossdk_io_math.Int
+			m.Amount = &v
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = append(m.Data[:0], dAtA[iNdEx:postIndex]...)
+			if m.Data == nil {
+				m.Data = []byte{}
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Accesses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Accesses = append(m.Accesses, AccessTuple{})
+			if err := m.Accesses[len(m.Accesses)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AuthList", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AuthList = append(m.AuthList, SetCodeAuthorization{})
+			if err := m.AuthList[len(m.AuthList)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field V", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.V = append(m.V[:0], dAtA[iNdEx:postIndex]...)
+			if m.V == nil {
+				m.V = []byte{}
+			}
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field R", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.R = append(m.R[:0], dAtA[iNdEx:postIndex]...)
+			if m.R == nil {
+				m.R = []byte{}
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field S", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.S = append(m.S[:0], dAtA[iNdEx:postIndex]...)
+			if m.S == nil {
+				m.S = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SetCodeAuthorization) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetCodeAuthorization: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetCodeAuthorization: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChainID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v cosmossdk_io_math.Int
+			m.ChainID = &v
+			if err := m.ChainID.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Nonce", wireType)
+			}
+			m.Nonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Nonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field V", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.V = append(m.V[:0], dAtA[iNdEx:postIndex]...)
+			if m.V == nil {
+				m.V = []byte{}
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field R", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.R = append(m.R[:0], dAtA[iNdEx:postIndex]...)
+			if m.R == nil {
+				m.R = []byte{}
+			}
+			iNdEx = postIndex
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field S", wireType)
 			}

--- a/x/evm/types/tx_data.go
+++ b/x/evm/types/tx_data.go
@@ -27,6 +27,7 @@ var (
 	_ TxData = &LegacyTx{}
 	_ TxData = &AccessListTx{}
 	_ TxData = &DynamicFeeTx{}
+	_ TxData = &SetCodeTx{}
 )
 
 // TxData implements the Ethereum transaction tx structure. It is used
@@ -75,6 +76,8 @@ func NewTxDataFromTx(tx *ethtypes.Transaction) (TxData, error) {
 		txData, err = newAccessListTx(tx)
 	case ethtypes.DynamicFeeTxType:
 		txData, err = NewDynamicFeeTx(tx)
+	case ethtypes.SetCodeTxType:
+		txData, err = NewSetCodeTx(tx)
 	default:
 		return nil, errorsmod.Wrapf(
 			ErrTxTypeNotSupported,

--- a/x/evm/types/tx_data_test.go
+++ b/x/evm/types/tx_data_test.go
@@ -135,6 +135,29 @@ func TestNewTxDataFromTx_SupportedTypes(t *testing.T) {
 				Value:     big.NewInt(0),
 			}),
 		},
+		{
+			"set code tx (type 4)",
+			ethtypes.SetCodeTxType,
+			ethtypes.NewTx(&ethtypes.SetCodeTx{
+				ChainID:   uint256.NewInt(31611),
+				Nonce:     0,
+				GasTipCap: uint256.NewInt(1),
+				GasFeeCap: uint256.NewInt(1),
+				Gas:       21000,
+				To:        to,
+				Value:     uint256.NewInt(0),
+				AuthList: []ethtypes.SetCodeAuthorization{
+					{
+						ChainID: *uint256.NewInt(31611),
+						Address: to,
+						Nonce:   1,
+						V:       1,
+						R:       *uint256.NewInt(7),
+						S:       *uint256.NewInt(11),
+					},
+				},
+			}),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
References: [MEZO-4013](https://linear.app/thesis-co/issue/MEZO-4013)

### Introduction

Adds the on-the-wire shape for EIP-7702 (Set Code Transactions) to mezod's EVM module so the rest of the stack can carry type-`0x04` transactions without translating to/from raw RLP at every layer. No type-`0x04` transaction is yet accepted by the chain — that is gated behind a Prague-active check and the keeper's authorization-processing path is not yet implemented.

### Changes

#### `SetCodeTx` and `SetCodeAuthorization` proto messages

New protobuf messages in `proto/ethermint/evm/v1/tx.proto` carry the type-`0x04` envelope and per-tuple `(chain_id, address, nonce, v, r, s)` authorization payload, mirroring the shape of `DynamicFeeTx`. Both are registered as `TxData` via `codec.go` and `tx_data.go`, and the type-URL switch in `msg.go::MsgEthereumTxGetSigners` recognizes the new message so signer resolution succeeds for type-`0x04` transactions.

#### Cosmos-side validation

`SetCodeTx.Validate()` rejects malformed type-`0x04` transactions before they reach the keeper:

- A non-empty `to` (no contract creation per EIP-7702) and a non-empty `auth_list`
- Non-nil `ChainID`, `GasTipCap`, `GasFeeCap`; `Amount` may be nil (treated as zero, matching `DynamicFeeTx` and EIP-7702 value semantics); standard gas-cap monotonicity and Mezo chain id allowlist
- Per-tuple wire shape: `auth.ChainID` non-nil and within int256 bounds, `auth.Address` parses, `auth.V`/`R`/`S` within int256 bounds. Canonical-form checks (V in {0,1}, R/S non-zero, length <= 32) and the EIP-7702 0-or-current chain-id rule are deferred to the keeper's authorization processing, where invalid tuples are silently skipped per EIP-7702 — front-loading them at stateless validate would convert per-tuple skips into tx-fatal errors
- Outer `V`/`R`/`S` within int256 bounds so `AsEthereumData`'s `uint256.MustFromBig` conversion stays panic-free on a stored tx

New error sentinels `ErrSetCodeMissingTo` and `ErrSetCodeEmptyAuthList` cover the two strict-rejection cases the EIP forbids.

#### Pre-Prague ante gate

`EthValidateBasicDecorator` rejects type-`0x04` transactions with `ErrTxTypeNotSupported` when `IsPrague` is false at the block time, mirroring the existing pre-London gate for `DynamicFeeTxType`. This holds the wire integration off until the upgrade handler activates Prague on a given network.

#### `newRPCTransaction` switch arm

`simulate_v1.go::newRPCTransaction` panics on `SetCodeTxType` with a TODO pointing at the MEZO-4336 plan; full set-code RPC support lands there.

#### `chain_config_test.go` cleanup

`TestChainConfigValidate` expresses each negative case as a one-field mutation on a shared `validBaselineConfig()` helper instead of restating every `ChainConfig` field per case (~330 lines of duplication removed). New `TestChainConfigEthereumConfig` populates each fork-time field with a distinct sentinel and asserts the corresponding field on the returned `*params.ChainConfig`, so a swapped assignment would surface immediately.

### Testing

`go test ./x/evm/types/... ./app/ante/...` — pass. Specifically:

- `TestNewSetCodeTx`, `TestSetCodeTxValidate` (table cases for every nil/out-of-bound branch including outer V/R/S and per-tuple V/R/S int256 bounds, malformed addresses, auth ChainID nil/zero/non-Mezo-non-zero/out-of-bound, and explicit acceptance cases for canonical-form variants the keeper handles — V[0] > 1, zero R, zero S, non-Mezo non-zero auth chain id), `TestSetCodeTxCopy` (nil-vs-empty AuthList preserved), `TestSetCodeTxAsEthereumData` (covers nil-amount round-trip), `TestSetCodeTxFee`, `TestSetCodeTxAnyRoundTrip` (real wire round-trip via `proto.Marshal`/`proto.Unmarshal` of the `Any` envelope, to ensure `RegisterInterfaces` resolves the type URL)
- `TestPackTxData` extended with `&SetCodeTx{}`
- `TestNewTxDataFromTx_SupportedTypes` extended with the new type
- `TestChainConfigValidate` (refactored) and `TestChainConfigEthereumConfig` (new)
- `TestAnteHandlerSetCodeTxRequiresPrague` pins the pre-Prague ante rejection end-to-end through the full ante chain

`go vet ./x/evm/types/... ./app/ante/evm/...` — clean.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
