### PR TITLE
Enforce BTC supply invariant on EVM tx commit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -419,6 +419,11 @@ func NewMezo(
 		app.BlockedAddrs(),
 	)
 
+	// Inject the bridge BTC supply invariant check into the EVM keeper.
+	// Wired here (after both keepers exist) to keep x/evm free of any
+	// x/bridge import.
+	app.EvmKeeper.SetVerifyBTCSupply(app.BridgeKeeper.VerifyBTCSupply)
+
 	precompiles, err := customEvmPrecompiles(
 		logger,
 		app.BankKeeper,

--- a/x/bridge/keeper/abci.go
+++ b/x/bridge/keeper/abci.go
@@ -19,7 +19,9 @@ func (k *Keeper) EndBlock(ctx context.Context) error {
 	var asserts []func(context.Context) error
 
 	if params.BtcSupplyAssertionEnabled {
-		asserts = append(asserts, k.verifyBTCSupply)
+		asserts = append(asserts, func(innerCtx context.Context) error {
+			return k.verifyBTCSupply(innerCtx, true)
+		})
 	}
 
 	for _, f := range asserts {
@@ -34,12 +36,22 @@ func (k *Keeper) EndBlock(ctx context.Context) error {
 	return nil
 }
 
+// VerifyBTCSupply is a silent wrapper over verifyBTCSupply, exported
+// for callers that want to enforce the same invariant outside the
+// bridge end-blocker.
+func (k *Keeper) VerifyBTCSupply(ctx context.Context) error {
+	return k.verifyBTCSupply(ctx, false)
+}
+
 // verifyBTCSupply asserts that:
 // btc_supply = total_btc_minted - total_btc_burnt.
 // btc_supply being the total supply of BTC as tracked by x/bank
 // and total_btc_{minted/burnt} being value tracked when the x/bridge
 // is instructed to burn or mint BTC.
-func (k *Keeper) verifyBTCSupply(ctx context.Context) error {
+//
+// The verbose flag controls the per-block "safe BTC supply state"
+// info log so callers other than the end-blocker stay silent.
+func (k *Keeper) verifyBTCSupply(ctx context.Context, verbose bool) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	var (
@@ -55,11 +67,13 @@ func (k *Keeper) verifyBTCSupply(ctx context.Context) error {
 		)
 	}
 
-	k.Logger(sdkCtx).Info("safe BTC supply state",
-		"totalSupply", totalSupply.String(),
-		"totalMinted", totalMinted.String(),
-		"totalBurnt", totalBurnt.String(),
-	)
+	if verbose {
+		k.Logger(sdkCtx).Info("safe BTC supply state",
+			"totalSupply", totalSupply.String(),
+			"totalMinted", totalMinted.String(),
+			"totalBurnt", totalBurnt.String(),
+		)
+	}
 
 	return nil
 }

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -16,6 +16,7 @@
 package keeper
 
 import (
+	"context"
 	"math/big"
 	"slices"
 	"strings"
@@ -70,6 +71,8 @@ type Keeper struct {
 	feeMarketKeeper types.FeeMarketKeeper
 	// access to consensus params
 	consensusKeeper types.ConsensusKeeper
+	// post-commit invariant check; wired in via SetVerifyBTCSupply.
+	verifyBTCSupply func(ctx context.Context) error
 
 	// chain ID number obtained from the context's chain id
 	eip155ChainID *big.Int
@@ -124,6 +127,13 @@ func NewKeeper(
 		ss:                ss,
 		customPrecompiles: make(map[common.Address]*precompile.VersionMap),
 	}
+}
+
+// SetVerifyBTCSupply registers the post-commit invariant check. Wired
+// in app.go after both keepers exist; using a function field keeps the
+// EVM keeper free of a direct x/bridge dependency.
+func (k *Keeper) SetVerifyBTCSupply(fn func(ctx context.Context) error) {
+	k.verifyBTCSupply = fn
 }
 
 // Logger returns a module-specific logger.

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -617,6 +617,15 @@ func (k *Keeper) applyMessageWithConfig(
 		if err := stateDB.Commit(); err != nil {
 			return nil, nil, errorsmod.Wrap(err, "failed to commit stateDB")
 		}
+
+		// Fail fast on txs whose post-commit state would break the
+		// bridge BTC supply invariant; rejecting here turns it into a
+		// regular tx-level failure instead of a downstream cosmos-level
+		// failure.
+		if err := k.verifyBTCSupply(ctx); err != nil {
+			return nil, nil, errorsmod.Wrap(types.ErrInvalidSupply, err.Error())
+		}
+
 		committedChanges = stateDB.CommittedStateChanges()
 		if len(committedChanges) > 0 {
 			ctx.Logger().Debug(

--- a/x/evm/types/errors.go
+++ b/x/evm/types/errors.go
@@ -44,6 +44,7 @@ const (
 	codeErrInvalidGasLimit
 	codeErrInvalidSigner
 	codeErrTxTypeNotSupported
+	codeErrInvalidSupply
 )
 
 var ErrPostTxProcessing = errors.New("failed to execute post processing")
@@ -95,6 +96,11 @@ var (
 	ErrInvalidGasLimit    = errorsmod.Register(ModuleName, codeErrInvalidGasLimit, "invalid gas limit")
 	ErrInvalidSigner      = errorsmod.Register(ModuleName, codeErrInvalidSigner, "invalid signer")
 	ErrTxTypeNotSupported = errorsmod.Register(ModuleName, codeErrTxTypeNotSupported, "transaction type not supported")
+
+	// ErrInvalidSupply is returned when a post-commit invariant check
+	// rejects an EVM transaction.
+	ErrInvalidSupply = errorsmod.Register(ModuleName, codeErrInvalidSupply,
+		"EVM transaction failed post-commit invariant check")
 )
 
 // NewExecErrorWithReason unpacks the revert return bytes and returns a wrapped error


### PR DESCRIPTION
### Introduction

The bridge module asserts the BTC supply invariant `bankSupply == minted - burnt` once per block in its end-blocker. With this change the same invariant is also enforced after every EVM transaction commit, so a transaction whose post-commit state would violate it fails at the EVM level instead of as a downstream cosmos-level failure.

### Changes

#### `x/bridge/keeper`

`verifyBTCSupply` takes a `verbose` flag that gates the per-block `safe BTC supply state` info log. The end-blocker calls it with `verbose=true`. A public `VerifyBTCSupply` wrapper calls it with `verbose=false` for callers outside the bridge module that want to enforce the same invariant silently.

#### `x/evm/keeper`

The EVM keeper carries a `verifyBTCSupply func(ctx context.Context) error` field, populated via `SetVerifyBTCSupply`. `applyMessageWithConfig` invokes the function immediately after `stateDB.Commit()`; a non-nil result is wrapped as `types.ErrInvalidSupply` and returned to the message handler, which causes the SDK to discard the msg-level cache and revert the bank state mutations from the failed commit.

#### `x/evm/types`

`ErrInvalidSupply` is registered.

#### `app`

`app.EvmKeeper.SetVerifyBTCSupply(app.BridgeKeeper.VerifyBTCSupply)` is called immediately after both keepers are constructed. Function-field injection keeps `x/evm` free of any direct `x/bridge` import.

### Testing

Verified end-to-end on a single-node localnet. The bridge end-blocker `safe BTC supply state` info log still fires once per block. A BTC withdrawal through the `assetsbridge` precompile (`approve` + `bridgeOut`) succeeds end-to-end and updates `BTCBurnt` and `bankSupply` together. A crafted transaction whose post-commit state would break the invariant is rejected at the EVM level with `ErrInvalidSupply`, the bank state mutations are discarded by the SDK msg-cache, and the chain keeps producing blocks. The full system test suite was also run against the patched node.

---

### Author's checklist

- [ ] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
