### PR TITLE
v10.0.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_5"
 	"github.com/mezo-org/mezod/app/upgrades/v0_6"
 	"github.com/mezo-org/mezod/app/upgrades/v0_7"
+	"github.com/mezo-org/mezod/app/upgrades/v10_0"
 	"github.com/mezo-org/mezod/app/upgrades/v1_0"
 	"github.com/mezo-org/mezod/app/upgrades/v2_0"
 	"github.com/mezo-org/mezod/app/upgrades/v3_0"
@@ -36,6 +37,7 @@ var (
 		v7_0.Upgrade,
 		v8_0.Upgrade,
 		v9_0.Upgrade,
+		v10_0.Upgrade,
 	}
 	Forks = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )

--- a/app/upgrades/v10_0/constants.go
+++ b/app/upgrades/v10_0/constants.go
@@ -1,0 +1,16 @@
+//nolint:revive,stylecheck
+package v10_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+// UpgradeName defines the name of the upgrade.
+const UpgradeName = "v10.0.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v10_0/upgrades.go
+++ b/app/upgrades/v10_0/upgrades.go
@@ -1,0 +1,29 @@
+//nolint:revive,stylecheck
+package v10_0
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		sdkCtx.Logger().Info("running v10.0.0 upgrade handler")
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -190,6 +190,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v7.0.0`       | 11688500  | Planned upgrade with chain halt      | [v7.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v7.0.0)                                                                                                           |
 | `v8.0.0`       | 11854127  | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0)                                                                                                           |
 | `v9.0.0`       | 12193600  | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0)                                                                                                           |
+| `v10.0.0`      | 12872000  | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0)                                                                                                         |
 
 ### Mainnet
 
@@ -204,3 +205,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v7.0.0` | 7691500 | Planned upgrade with chain halt      | [v7.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v7.0.0) |
 | `v8.0.0` | 7739500 | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0) |
 | `v9.0.0` | 8194500 | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0) |
+| `v10.0.0` | 8773000 | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0) |


### PR DESCRIPTION
References: MEZO-4355

### Introduction

This adds the v10.0.0 upgrade handler that will be executed on testnet and mainnet. The handler performs no state migration, as it is not necessary for the v10.0.0 upgrade. The goal of the handler is to ensure the chain stops and upgrades consensus rules at the same time to eliminate the risk of divergent state.

### Changes

A new `app/upgrades/v10_0` package is added containing `constants.go` (upgrade name and metadata) and `upgrades.go` (the handler itself). The handler logs `running v10.0.0 upgrade handler` and runs module migrations. The upgrade is registered in `app/upgrades.go` alongside the existing v0.3 through v9.0 upgrades. No store upgrades are required.

### Testing

1. Checkout the v9.0.0 tag currently used on testnet and mainnet.
2. Spin up a fresh localnet using `make localnet-bin-clean && make localnet-bin-init`.
3. Start at least three nodes using `make localnet-bin-start`.
4. Get PoA owner address using `npx hardhat validatorPool:owner` from `precompile/hardhat`.
5. Schedule an upgrade using `npx hardhat upgrade:submitPlan --signer <poa-owner> --name v10.0.0 --height <H+20> --info ''` where `H` is the current block of your localnet.
6. Wait until the upgrade block. Nodes should stop consensus and ask for an upgrade.
7. Switch to this PR's branch (`v10-handler`) and stop all your nodes.
8. Run `make build`.
9. Restart your nodes.
10. They should print `running v10.0.0 upgrade handler` and start producing blocks after a short while.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
