### PR TITLE
Bump testnet nodes to v10.0.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v10.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v10.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v10.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v10.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v10.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1


### PR DESCRIPTION
Closes: MEZO-4355

### Introduction

Here we bump our testnet nodes to v10.0.0-rc0.

Keeping as a draft until v10.0.0-rc0 is published.

### Testing

Apply using `helmfile apply -l type=validator --context 1 --concurrency 1` at the v10.0.0 testnet halt block.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
