### PR TITLE
Unit tests for BTC supply invariant check

### DIFF
--- a/x/bridge/keeper/abci_test.go
+++ b/x/bridge/keeper/abci_test.go
@@ -40,6 +40,31 @@ func TestEndBlock(t *testing.T) {
 	})
 }
 
+func TestVerifyBTCSupply(t *testing.T) {
+	ctx, k := mockContext()
+
+	require.NoError(t, k.IncreaseBTCMinted(ctx, math.NewInt(42)))
+	require.NoError(t, k.IncreaseBTCBurnt(ctx, math.NewInt(21)))
+
+	t.Run("returns nil when state is valid", func(t *testing.T) {
+		k.bankKeeper.(*mockBankKeeper).
+			On("GetSupply", ctx, evmtypes.DefaultEVMDenom).
+			Return(sdk.NewCoin(evmtypes.DefaultEVMDenom, math.NewInt(21))).
+			Times(1)
+
+		require.NoError(t, k.VerifyBTCSupply(ctx))
+	})
+
+	t.Run("returns error when state is invalid", func(t *testing.T) {
+		k.bankKeeper.(*mockBankKeeper).
+			On("GetSupply", ctx, evmtypes.DefaultEVMDenom).
+			Return(sdk.NewCoin(evmtypes.DefaultEVMDenom, math.NewInt(37))).
+			Times(1)
+
+		require.ErrorContains(t, k.VerifyBTCSupply(ctx), "invalid asset supply")
+	})
+}
+
 func TestHandleOutflowReset(t *testing.T) {
 	ctx, keeper := mockContext()
 	tokenAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -20,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	utiltx "github.com/mezo-org/mezod/testutil/tx"
+	mezotypes "github.com/mezo-org/mezod/types"
 	"github.com/mezo-org/mezod/x/evm/keeper"
 	"github.com/mezo-org/mezod/x/evm/statedb"
 	"github.com/mezo-org/mezod/x/evm/types"
@@ -890,6 +893,65 @@ func (suite *KeeperTestSuite) TestApplyMessageWithConfig() {
 			suite.Require().Equal(expectedGasUsed, res.GasUsed)
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestApplyMessageWithConfigInvalidSupply() {
+	suite.SetupTest()
+
+	amt := sdk.Coins{mezotypes.NewMezoCoinInt64(100)}
+	err := suite.app.BankKeeper.MintCoins(suite.ctx, types.ModuleName, amt)
+	suite.Require().NoError(err)
+	err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(
+		suite.ctx,
+		types.ModuleName,
+		suite.address.Bytes(),
+		amt,
+	)
+	suite.Require().NoError(err)
+
+	proposerAddress := suite.ctx.BlockHeader().ProposerAddress
+	config, err := suite.app.EvmKeeper.EVMConfig(
+		suite.ctx,
+		proposerAddress,
+		big.NewInt(31611),
+	)
+	suite.Require().NoError(err)
+
+	keeperParams := suite.app.EvmKeeper.GetParams(suite.ctx)
+	chainCfg := keeperParams.ChainConfig.EthereumConfig(
+		suite.app.EvmKeeper.ChainID(),
+	)
+	signer := ethtypes.LatestSignerForChainID(suite.app.EvmKeeper.ChainID())
+	vmdb := suite.StateDB()
+	msg, err := newNativeMessage(
+		vmdb.GetNonce(suite.address),
+		suite.ctx.BlockHeight(),
+		suite.address,
+		chainCfg,
+		suite.signer,
+		signer,
+		ethtypes.AccessListTxType,
+		nil,
+		nil,
+		big.NewInt(suite.ctx.BlockTime().Unix()).Uint64(),
+	)
+	suite.Require().NoError(err)
+
+	suite.app.EvmKeeper.SetVerifyBTCSupply(func(_ context.Context) error {
+		return errors.New("invalid supply")
+	})
+
+	txConfig := suite.app.EvmKeeper.TxConfig(suite.ctx, common.Hash{})
+	_, _, err = suite.app.EvmKeeper.ApplyMessageWithConfig(
+		suite.ctx,
+		keeper.WrapMessage(msg),
+		nil,
+		true,
+		config,
+		txConfig,
+	)
+
+	suite.Require().ErrorIs(err, types.ErrInvalidSupply)
 }
 
 func (suite *KeeperTestSuite) createContractGethMsg(nonce uint64, signer ethtypes.Signer, cfg *params.ChainConfig, gasPrice, blockTime *big.Int) (core.Message, error) {


### PR DESCRIPTION
### Introduction

This  PR is a follow-up to [Enforce BTC supply invariant on EVM tx commit](https://github.com/mezo-org/mezod/pull/675).

### Changes

Added unit tests for BTC supply invariant check.

### Testing

```
go test ./x/bridge/keeper ./x/evm/keeper
```

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
