### PR TITLE
Exempt EIP-7702 delegated EOAs from EIP-3607 sender check

### DIFF
--- a/.claude/MEZO-4013-eip7702-set-code/roadmap.md
+++ b/.claude/MEZO-4013-eip7702-set-code/roadmap.md
@@ -20,6 +20,12 @@
   `validateAuthorization`/`applyAuthorization` mirroring geth
   `v1.16.9`, and exposure of the auth list on the `TxData` interface.
   PR: [#680](https://github.com/mezo-org/mezod/pull/680).
+- **Phase 4.** Ante handler EIP-3607 exemption: delegated EOAs
+  (accounts whose code parses as a valid `0xef0100‖target` designator)
+  bypass the contract-coded-sender reject in
+  `EthAccountVerificationDecorator` while genuine contract code is
+  still rejected.
+  PR: [#681](https://github.com/mezo-org/mezod/pull/681).
 
 ## Status of prerequisites
 
@@ -177,17 +183,23 @@ deployment. Reviewing it in isolation is the safest path. Run
 rejecting delegated EOAs.
 
 **Scope.**
-- Add an `IsDelegated()` helper on `statedb.Account` that returns true
-  when the account's code is exactly 23 bytes and starts with the
-  `0xef0100` delegation prefix. Compute once at account load.
 - In `app/ante/evm/eth.go`, replace the unconditional
   `acct.IsContract()` reject with: reject only if the account has code
-  AND the code is not a delegation designator.
+  AND the code is not a delegation designator. The check is inlined
+  inside `EthAccountVerificationDecorator.AnteHandle` using
+  `evmKeeper.GetCode` + `ethtypes.ParseDelegation`; no helper is added
+  to `statedb.Account` because the exemption is purely an ante-layer
+  concern. A shared helper can be extracted in Phase 5 if RPC
+  formatting needs the same detection.
 - Audit the rest of `app/ante/` and the cosmos-side decorators for
-  other assumptions about EOA-vs-contract on the sender. Document any
-  gaps; fix or carve out follow-ups.
-- Unit tests for the new branch (delegated sender accepted; contract
-  sender still rejected; uncoded sender unchanged).
+  other assumptions about EOA-vs-contract on the sender. Outcome:
+  the only sender EOA/contract assumption in the ante chain is the
+  decorator we're modifying; no other carve-outs needed.
+- Unit tests for the new branch (delegated sender accepted; balance
+  shortfall on a delegated sender to pin that the exemption only
+  bypasses the EOA check). Contract-sender rejection and uncoded
+  sender behavior are already covered by the existing
+  `TestNewEthAccountVerificationDecorator` cases.
 
 **Out of scope.** Delegated-account behavior beyond the sender check;
 RPC.

--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -93,8 +93,11 @@ func (avd EthAccountVerificationDecorator) AnteHandle(
 			avd.ak.SetAccount(ctx, acc)
 			acct = statedb.NewEmptyAccount()
 		} else if acct.IsContract() {
-			return ctx, errorsmod.Wrapf(errortypes.ErrInvalidType,
-				"the sender is not EOA: address %s, codeHash <%s>", fromAddr, acct.CodeHash)
+			code := avd.evmKeeper.GetCode(ctx, common.BytesToHash(acct.CodeHash))
+			if _, isDelegated := ethtypes.ParseDelegation(code); !isDelegated {
+				return ctx, errorsmod.Wrapf(errortypes.ErrInvalidType,
+					"the sender is not EOA: address %s, codeHash <%s>", fromAddr, acct.CodeHash)
+			}
 		}
 
 		if err := keeper.CheckSenderBalance(sdkmath.NewIntFromBigInt(acct.Balance.ToBig()), txData); err != nil {

--- a/app/ante/evm/eth_test.go
+++ b/app/ante/evm/eth_test.go
@@ -27,6 +27,8 @@ func (suite *AnteTestSuite) TestNewEthAccountVerificationDecorator() {
 	)
 
 	addr := testutiltx.GenerateAddress()
+	delegatedAddr := testutiltx.GenerateAddress()
+	target := testutiltx.GenerateAddress()
 
 	ethContractCreationTxParams := &evmtypes.EvmTxArgs{
 		ChainID:  suite.app.EvmKeeper.ChainID(),
@@ -38,6 +40,9 @@ func (suite *AnteTestSuite) TestNewEthAccountVerificationDecorator() {
 
 	tx := evmtypes.NewTx(ethContractCreationTxParams)
 	tx.From = addr.Hex()
+
+	delegatedTx := evmtypes.NewTx(ethContractCreationTxParams)
+	delegatedTx.From = delegatedAddr.Hex()
 
 	var vmdb *statedb.StateDB
 
@@ -94,6 +99,24 @@ func (suite *AnteTestSuite) TestNewEthAccountVerificationDecorator() {
 				suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
 
 				vmdb.AddBalance(addr, uint256.NewInt(1000000), tracing.BalanceChangeUnspecified)
+			},
+			true,
+			true,
+		},
+		{
+			"delegated sender then balance shortfall",
+			delegatedTx,
+			func() {
+				vmdb.SetCode(delegatedAddr, ethtypes.AddressToDelegation(target), tracing.CodeChangeUnspecified)
+			},
+			true,
+			false,
+		},
+		{
+			"delegated sender accepted",
+			delegatedTx,
+			func() {
+				vmdb.AddBalance(delegatedAddr, uint256.NewInt(1000000), tracing.BalanceChangeUnspecified)
 			},
 			true,
 			true,


### PR DESCRIPTION
References: [MEZO-4013](https://linear.app/thesis-co/issue/MEZO-4013)
Depends on: https://github.com/mezo-org/mezod/pull/680

### Introduction

Carves EIP-7702 delegation designators out of the long-standing EIP-3607 contract-coded-sender reject inside `EthAccountVerificationDecorator`. After this PR, an EOA that has installed a `0xef0100||target` delegation on its own code field can submit its very next transaction without bouncing at CheckTx, while a sender holding genuine contract code is still rejected. The exemption lives entirely in the ante layer and only fires for `IsCheckTx`; the EVM keeper's authorization-application path (already correct from #680) handles delegated execution natively, so this is the last consensus-relevant surface that needed an EIP-7702-aware update before the JSON-RPC and activation phases.

### Changes

#### `app/ante/evm/eth.go`

`EthAccountVerificationDecorator.AnteHandle`'s `acct.IsContract()` reject branch now fetches the sender's stored bytecode via the embedded `statedb.Keeper.GetCode` and runs `ethtypes.ParseDelegation` on it. If the bytes parse as a 23-byte delegation designator the decorator falls through to the existing balance check; otherwise the original "the sender is not EOA" error is returned. Senders without code keep skipping the new branch entirely (the outer `IsContract()` guard already excludes empty-code accounts), so the hot path for plain EOAs is unchanged. The check is inlined rather than extracted onto `statedb.Account` because the exemption is purely an ante-layer concern today; `statedb` does not need to learn EIP-7702 semantics for a single caller, and a shared helper can be extracted later if the JSON-RPC layer needs the same detection.

The resulting truth table:

| Sender state                          | `IsContract()` | `ParseDelegation` ok? | Outcome  |
| ------------------------------------- | -------------- | --------------------- | -------- |
| No account                            | n/a            | n/a                   | created, proceed |
| Plain EOA (no code)                   | false          | not invoked           | proceed  |
| EOA with EIP-7702 designator          | true           | true                  | proceed  |
| Contract code (any non-designator)    | true           | false                 | reject   |

#### `app/ante/evm/eth_test.go`

`TestNewEthAccountVerificationDecorator` gains two cases on a fresh address so they don't perturb the existing subtests' state expectations: `delegated sender accepted` (designator + balance, expects pass) and `delegated sender then balance shortfall` (designator without balance, expects fail). The shortfall case pins that the new branch only bypasses the EOA gate — the downstream `CheckSenderBalance` call still runs. Contract-coded sender rejection and uncoded-sender behavior remain covered by the existing `sender not EOA` and `not enough balance to cover tx cost` cases.

#### `.claude/MEZO-4013-eip7702-set-code/roadmap.md`

Phase 4 is marked done in the progress section and the Phase 4 scope is updated to reflect the inlined approach (no `IsDelegated()` method on `statedb.Account`) and the audit outcome (no other sender-shape EOA/contract assumptions found in the ante chain).

### Testing

`go test -race -count=1 ./app/ante/evm/...` passes with the two new cases plus all three EIP-712 suite reruns. End-to-end coverage of the exemption against `eth_sendRawTransaction` is part of Phase 6 (`Eip7702Security.test.ts`) and is intentionally out of scope here.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
