### PR TITLE
Decreasing frequency of price feed updates

### DIFF
--- a/infrastructure/kubernetes/common/pyth-scheduler-ethereum/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-ethereum/configmap.yaml
@@ -9,11 +9,11 @@ data:
     - alias: MUSD/USD
       id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
       time_difference: 21600
-      price_deviation: 0.1
+      price_deviation: 0.5
       confidence_ratio: 100
     - alias: USDT/USD
       id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
       time_difference: 21600
-      price_deviation: 0.1
+      price_deviation: 0.5
       confidence_ratio: 100
 

--- a/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
@@ -13,13 +13,13 @@ data:
       confidence_ratio: 75
     - alias: BTC/USD
       id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
-      time_difference: 600
-      price_deviation: 0.5
+      time_difference: 3600
+      price_deviation: 1
       confidence_ratio: 75
     - alias: MUSD/USD
       id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
-      time_difference: 600
-      price_deviation: 0.1
+      time_difference: 3600
+      price_deviation: 0.5
       confidence_ratio: 75
     - alias: cbBTC/USD
       id: "0x2817d7bfe5c64b8ea956e9a26f573ef64e72e4d7891f2d6af9bcc93f7aff9a97"
@@ -33,6 +33,11 @@ data:
       confidence_ratio: 75
     - alias: USDT/USD
       id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
+      time_difference: 3600
+      price_deviation: 1
+      confidence_ratio: 75
+    - alias: T/USD
+      id: "0x7a072b799215196b0ecb6a58636ec312bce8461dcc33c28c3a046b1e636d121d"
       time_difference: 3600
       price_deviation: 1
       confidence_ratio: 75
@@ -68,6 +73,6 @@ data:
       confidence_ratio: 75
     - alias: MEZO/USD
       id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
-      time_difference: 600
+      time_difference: 3600
       price_deviation: 1
       confidence_ratio: 75


### PR DESCRIPTION
In an effort of lowering update cost of the price feed updater, we gradually decrease the frequency of price update actions. We can adjust it back if needed.

Adding T/USD price feed back.

### Testing

Changes were updated in GCP for Mezo `pyth-scheduler` pusher

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
