### PR TITLE
Wire EIP-7702 SetCode through the Ethereum JSON-RPC surface

### DIFF
--- a/.claude/MEZO-4013-eip7702-set-code/roadmap.md
+++ b/.claude/MEZO-4013-eip7702-set-code/roadmap.md
@@ -26,6 +26,17 @@
   `EthAccountVerificationDecorator` while genuine contract code is
   still rejected.
   PR: [#681](https://github.com/mezo-org/mezod/pull/681).
+- **Phase 5.** JSON-RPC surface: `TransactionArgs` gains
+  `authorizationList`, the formatting layer (`NewRPCTransaction`,
+  `RPCTransaction`) emits the field and the type-`0x04` envelope on
+  subscriptions and historical lookups, receipts surface
+  `effectiveGasPrice` for SetCodeTx via the existing
+  `TxData.EffectiveGasPrice` interface, and the keeper's
+  `applyMessageWithConfig` gates `applySetCodeAuthorizations` on
+  `rules.IsPrague` so simulate / `eth_call` / `eth_estimateGas` match
+  consensus on a pre-Prague chain. End-to-end coverage via a Hardhat
+  `Eip7702SendRawTx` system test.
+  PR: [#683](https://github.com/mezo-org/mezod/pull/683).
 
 ## Status of prerequisites
 

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -285,6 +285,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 			Value:                args.Value,
 			Data:                 input,
 			AccessList:           args.AccessList,
+			AuthorizationList:    args.AuthorizationList,
 			ChainID:              args.ChainID,
 			Nonce:                args.Nonce,
 		}

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -9,6 +9,9 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/mezo-org/mezod/rpc/backend/mocks"
@@ -701,4 +704,168 @@ func RegisterGetPriceError(oracleClient *mocks.OracleQueryClient, currencyPair s
 	oracleClient.On("GetPrice", rpctypes.ContextWithHeight(1), &oracletypes.GetPriceRequest{
 		CurrencyPair: currencyPair,
 	}, mock.Anything).Return(nil, fmt.Errorf("failed to get price"))
+}
+
+func (suite *BackendTestSuite) TestSetTxDefaultsPropagatesAuthorizationList() {
+	suite.SetupTest()
+
+	from := utiltx.GenerateAddress()
+	to := utiltx.GenerateAddress()
+	chainID := (*hexutil.Big)(suite.backend.chainID)
+	gasPrice := new(hexutil.Big)
+
+	auth := ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(suite.backend.chainID),
+		Address: to,
+		Nonce:   1,
+	}
+
+	nonce := (hexutil.Uint64)(1)
+	args := evmtypes.TransactionArgs{
+		From:                 &from,
+		To:                   &to,
+		Gas:                  nil,
+		Nonce:                &nonce,
+		MaxFeePerGas:         gasPrice,
+		MaxPriorityFeePerGas: gasPrice,
+		Value:                gasPrice,
+		ChainID:              chainID,
+		AuthorizationList:    []ethtypes.SetCodeAuthorization{auth},
+	}
+
+	var header metadata.MD
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	RegisterParams(queryClient, &header, 1)
+	_, err := RegisterBlock(client, 1, nil)
+	suite.Require().NoError(err)
+	_, err = RegisterBlockResults(client, 1)
+	suite.Require().NoError(err)
+	RegisterBaseFee(queryClient, sdkmath.NewInt(1))
+
+	var captured evmtypes.TransactionArgs
+	queryClient.On(
+		"EstimateGas",
+		rpctypes.ContextWithHeight(1),
+		mock.MatchedBy(func(req *evmtypes.EthCallRequest) bool {
+			if req == nil {
+				return false
+			}
+			return json.Unmarshal(req.Args, &captured) == nil
+		}),
+	).Return(&evmtypes.EstimateGasResponse{Gas: 100_000}, nil)
+
+	_, err = suite.backend.SetTxDefaults(args)
+	suite.Require().NoError(err)
+	suite.Require().Len(captured.AuthorizationList, 1)
+	suite.Require().Equal(auth, captured.AuthorizationList[0])
+}
+
+func (suite *BackendTestSuite) TestSendRawTransactionSetCodeTx() {
+	suite.SetupTest()
+
+	priv, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+
+	to := utiltx.GenerateAddress()
+
+	chainIDBig := suite.backend.chainID
+	signer := ethtypes.NewPragueSigner(chainIDBig)
+
+	auth, err := ethtypes.SignSetCode(priv, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainIDBig),
+		Address: to,
+		Nonce:   1,
+	})
+	suite.Require().NoError(err)
+
+	inner := &ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainIDBig),
+		Nonce:     0,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(10),
+		Gas:       100_000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  []ethtypes.SetCodeAuthorization{auth},
+	}
+	ethTx := ethtypes.MustSignNewTx(priv, signer, inner)
+
+	rawTx, err := ethTx.MarshalBinary()
+	suite.Require().NoError(err)
+
+	msgEthTx := &evmtypes.MsgEthereumTx{}
+	suite.Require().NoError(msgEthTx.FromEthereumTx(ethTx))
+	cosmosTx, err := msgEthTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), evmtypes.DefaultEVMDenom)
+	suite.Require().NoError(err)
+	txBytes, err := suite.backend.clientCtx.TxConfig.TxEncoder()(cosmosTx)
+	suite.Require().NoError(err)
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	suite.backend.allowUnprotectedTxs = true
+	RegisterParamsWithoutHeader(queryClient, 1)
+	RegisterBroadcastTx(client, txBytes)
+
+	hash, err := suite.backend.SendRawTransaction(rawTx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(ethTx.Hash(), hash)
+
+	expectedSender := crypto.PubkeyToAddress(priv.PublicKey)
+	recoveredSender, err := ethtypes.Sender(signer, ethTx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(expectedSender, recoveredSender)
+
+	suite.Require().Len(ethTx.SetCodeAuthorizations(), 1)
+	recoveredAuthority, err := ethTx.SetCodeAuthorizations()[0].Authority()
+	suite.Require().NoError(err)
+	suite.Require().Equal(expectedSender, recoveredAuthority)
+}
+
+func (suite *BackendTestSuite) TestSetTxDefaultsLeavesNilAuthorizationList() {
+	suite.SetupTest()
+
+	from := utiltx.GenerateAddress()
+	to := utiltx.GenerateAddress()
+	chainID := (*hexutil.Big)(suite.backend.chainID)
+	gasPrice := new(hexutil.Big)
+
+	nonce := (hexutil.Uint64)(1)
+	args := evmtypes.TransactionArgs{
+		From:                 &from,
+		To:                   &to,
+		Gas:                  nil,
+		Nonce:                &nonce,
+		MaxFeePerGas:         gasPrice,
+		MaxPriorityFeePerGas: gasPrice,
+		Value:                gasPrice,
+		ChainID:              chainID,
+		AuthorizationList:    nil,
+	}
+
+	var header metadata.MD
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	RegisterParams(queryClient, &header, 1)
+	_, err := RegisterBlock(client, 1, nil)
+	suite.Require().NoError(err)
+	_, err = RegisterBlockResults(client, 1)
+	suite.Require().NoError(err)
+	RegisterBaseFee(queryClient, sdkmath.NewInt(1))
+
+	var captured evmtypes.TransactionArgs
+	queryClient.On(
+		"EstimateGas",
+		rpctypes.ContextWithHeight(1),
+		mock.MatchedBy(func(req *evmtypes.EthCallRequest) bool {
+			if req == nil {
+				return false
+			}
+			return json.Unmarshal(req.Args, &captured) == nil
+		}),
+	).Return(&evmtypes.EstimateGasResponse{Gas: 100_000}, nil)
+
+	_, err = suite.backend.SetTxDefaults(args)
+	suite.Require().NoError(err)
+	suite.Require().Nil(captured.AuthorizationList)
 }

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -354,13 +354,13 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 		receipt["contractAddress"] = crypto.CreateAddress(from, txData.GetNonce())
 	}
 
-	if dynamicTx, ok := txData.(*evmtypes.DynamicFeeTx); ok {
+	if txData.TxType() >= ethtypes.DynamicFeeTxType {
 		baseFee, err := b.BaseFee(blockRes)
 		if err != nil {
 			// tolerate the error for pruned node.
 			b.logger.Error("fetch basefee failed, node is pruned?", "height", res.Height, "error", err)
 		} else {
-			receipt["effectiveGasPrice"] = hexutil.Big(*dynamicTx.EffectiveGasPrice(baseFee))
+			receipt["effectiveGasPrice"] = hexutil.Big(*txData.EffectiveGasPrice(baseFee))
 		}
 	}
 

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -16,11 +16,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
 	apptypes "github.com/mezo-org/mezod/app/abci/types"
 	"github.com/mezo-org/mezod/indexer"
 	"github.com/mezo-org/mezod/precompile/assetsbridge"
 	"github.com/mezo-org/mezod/rpc/backend/mocks"
 	rpctypes "github.com/mezo-org/mezod/rpc/types"
+	utiltx "github.com/mezo-org/mezod/testutil/tx"
 	mezotypes "github.com/mezo-org/mezod/types"
 	bridgeabcitypes "github.com/mezo-org/mezod/x/bridge/abci/types"
 	bridgetypes "github.com/mezo-org/mezod/x/bridge/types"
@@ -982,4 +985,108 @@ func buildPseudoTxTrace(
 		"output":  "0x0000000000000000000000000000000000000000000000000000000000000001",
 		"failed":  false,
 	}, nil
+}
+
+func (suite *BackendTestSuite) TestGetTransactionReceiptSetCodeTxEffectiveGasPrice() {
+	suite.SetupTest()
+
+	priv, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	from := crypto.PubkeyToAddress(priv.PublicKey)
+
+	to := utiltx.GenerateAddress()
+	chainIDBig := suite.backend.chainID
+	signer := ethtypes.NewPragueSigner(chainIDBig)
+
+	auth, err := ethtypes.SignSetCode(priv, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainIDBig),
+		Address: to,
+		Nonce:   1,
+	})
+	suite.Require().NoError(err)
+
+	gasFeeCap := uint256.NewInt(10)
+	gasTipCap := uint256.NewInt(2)
+	inner := &ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainIDBig),
+		Nonce:     0,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Gas:       100_000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  []ethtypes.SetCodeAuthorization{auth},
+	}
+	ethTx := ethtypes.MustSignNewTx(priv, signer, inner)
+
+	msgEthTx := &evmtypes.MsgEthereumTx{}
+	suite.Require().NoError(msgEthTx.FromEthereumTx(ethTx))
+	cosmosTx, err := msgEthTx.BuildTx(
+		suite.backend.clientCtx.TxConfig.NewTxBuilder(),
+		evmtypes.DefaultEVMDenom,
+	)
+	suite.Require().NoError(err)
+	txBz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(cosmosTx)
+	suite.Require().NoError(err)
+
+	const height int64 = 1
+	const txGasUsed = uint64(50_000)
+	ethTxHash := ethTx.Hash()
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	var header metadata.MD
+	RegisterParams(queryClient, &header, height)
+	RegisterParamsWithoutHeader(queryClient, height)
+	_, err = RegisterBlock(client, height, txBz)
+	suite.Require().NoError(err)
+
+	// EthereumTx event so the indexer treats this as a regular eth tx,
+	// not a pseudo-tx.
+	txResult := &abci.ExecTxResult{
+		Code:    0,
+		GasUsed: int64(txGasUsed), //nolint:gosec
+		Events: []abci.Event{
+			{Type: evmtypes.EventTypeEthereumTx, Attributes: []abci.EventAttribute{
+				{Key: "ethereumTxHash", Value: ethTxHash.Hex()},
+				{Key: "txIndex", Value: "0"},
+				{Key: "amount", Value: "0"},
+				{Key: "txGasUsed", Value: fmt.Sprintf("%d", txGasUsed)},
+				{Key: "txHash", Value: ""},
+				{Key: "recipient", Value: to.Hex()},
+			}},
+		},
+	}
+	_, err = RegisterBlockResultsWithTxResults(client, height, []*abci.ExecTxResult{txResult})
+	suite.Require().NoError(err)
+
+	baseFee := sdkmath.NewInt(1)
+	RegisterBaseFee(queryClient, baseFee)
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	block := &types.Block{
+		Header: types.Header{Height: height, ChainID: ChainID},
+		Data:   types.Data{Txs: []types.Tx{txBz}},
+	}
+	suite.Require().NoError(
+		suite.backend.indexer.IndexBlock(block, []*abci.ExecTxResult{txResult}),
+	)
+
+	receipt, err := suite.backend.GetTransactionReceipt(ethTxHash)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(receipt)
+
+	got, ok := receipt["effectiveGasPrice"]
+	suite.Require().True(ok, "effectiveGasPrice missing from SetCodeTx receipt")
+
+	txData, err := evmtypes.UnpackTxData(msgEthTx.Data)
+	suite.Require().NoError(err)
+	setCodeTxData, ok := txData.(*evmtypes.SetCodeTx)
+	suite.Require().True(ok, "unpacked tx data is not *evmtypes.SetCodeTx")
+	wantEffective := setCodeTxData.EffectiveGasPrice(baseFee.BigInt())
+
+	suite.Require().Equal(hexutil.Big(*wantEffective), got)
+	suite.Require().Equal(hexutil.Uint(ethtypes.SetCodeTxType), receipt["type"])
+	suite.Require().Equal(from, receipt["from"])
 }

--- a/rpc/types/types.go
+++ b/rpc/types/types.go
@@ -46,25 +46,26 @@ type StorageResult struct {
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
-	BlockHash        *common.Hash         `json:"blockHash"`
-	BlockNumber      *hexutil.Big         `json:"blockNumber"`
-	From             common.Address       `json:"from"`
-	Gas              hexutil.Uint64       `json:"gas"`
-	GasPrice         *hexutil.Big         `json:"gasPrice"`
-	GasFeeCap        *hexutil.Big         `json:"maxFeePerGas,omitempty"`
-	GasTipCap        *hexutil.Big         `json:"maxPriorityFeePerGas,omitempty"`
-	Hash             common.Hash          `json:"hash"`
-	Input            hexutil.Bytes        `json:"input"`
-	Nonce            hexutil.Uint64       `json:"nonce"`
-	To               *common.Address      `json:"to"`
-	TransactionIndex *hexutil.Uint64      `json:"transactionIndex"`
-	Value            *hexutil.Big         `json:"value"`
-	Type             hexutil.Uint64       `json:"type"`
-	Accesses         *ethtypes.AccessList `json:"accessList,omitempty"`
-	ChainID          *hexutil.Big         `json:"chainId,omitempty"`
-	V                *hexutil.Big         `json:"v"`
-	R                *hexutil.Big         `json:"r"`
-	S                *hexutil.Big         `json:"s"`
+	BlockHash         *common.Hash                    `json:"blockHash"`
+	BlockNumber       *hexutil.Big                    `json:"blockNumber"`
+	From              common.Address                  `json:"from"`
+	Gas               hexutil.Uint64                  `json:"gas"`
+	GasPrice          *hexutil.Big                    `json:"gasPrice"`
+	GasFeeCap         *hexutil.Big                    `json:"maxFeePerGas,omitempty"`
+	GasTipCap         *hexutil.Big                    `json:"maxPriorityFeePerGas,omitempty"`
+	Hash              common.Hash                     `json:"hash"`
+	Input             hexutil.Bytes                   `json:"input"`
+	Nonce             hexutil.Uint64                  `json:"nonce"`
+	To                *common.Address                 `json:"to"`
+	TransactionIndex  *hexutil.Uint64                 `json:"transactionIndex"`
+	Value             *hexutil.Big                    `json:"value"`
+	Type              hexutil.Uint64                  `json:"type"`
+	Accesses          *ethtypes.AccessList            `json:"accessList,omitempty"`
+	AuthorizationList []ethtypes.SetCodeAuthorization `json:"authorizationList,omitempty"`
+	ChainID           *hexutil.Big                    `json:"chainId,omitempty"`
+	V                 *hexutil.Big                    `json:"v"`
+	R                 *hexutil.Big                    `json:"r"`
+	S                 *hexutil.Big                    `json:"s"`
 }
 
 type FeeHistoryResult struct {

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -220,21 +220,44 @@ func NewRPCTransaction(
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
-		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
-		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
-		// if the transaction has been mined, compute the effective gas price
-		if baseFee != nil && blockHash != (common.Hash{}) {
-			// price = min(tip, gasFeeCap - baseFee) + baseFee
-			price := new(big.Int).Add(tx.GasTipCap(), baseFee)
-			if price.Cmp(tx.GasFeeCap()) > 0 {
-				price = tx.GasFeeCap()
-			}
-			result.GasPrice = (*hexutil.Big)(price)
-		} else {
-			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
-		}
+		result = setEffectiveGasPrice(result, tx, baseFee, blockHash)
+	case ethtypes.SetCodeTxType:
+		al := tx.AccessList()
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		// Shared with the geth Transaction; treat as read-only downstream.
+		result.AuthorizationList = tx.SetCodeAuthorizations()
+		result = setEffectiveGasPrice(result, tx, baseFee, blockHash)
 	}
 	return result, nil
+}
+
+// setEffectiveGasPrice populates the 1559 fee-cap fields and computes the
+// effective gas price on result, returning it for explicit reassignment at
+// the call site. For mined transactions the price is min(tip+baseFee,
+// gasFeeCap); otherwise it falls back to gasFeeCap.
+func setEffectiveGasPrice(
+	result *RPCTransaction,
+	tx *ethtypes.Transaction,
+	baseFee *big.Int,
+	blockHash common.Hash,
+) *RPCTransaction {
+	result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
+	result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
+
+	// if the transaction has been mined, compute the effective gas price
+	if baseFee != nil && blockHash != (common.Hash{}) {
+		// price = min(tip, gasFeeCap - baseFee) + baseFee
+		price := new(big.Int).Add(tx.GasTipCap(), baseFee)
+		if price.Cmp(tx.GasFeeCap()) > 0 {
+			price = tx.GasFeeCap()
+		}
+		result.GasPrice = (*hexutil.Big)(price)
+	} else {
+		result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
+	}
+
+	return result
 }
 
 // BaseFeeFromEvents parses the feemarket basefee from cosmos events

--- a/rpc/types/utils_test.go
+++ b/rpc/types/utils_test.go
@@ -1,0 +1,195 @@
+package types_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	rpctypes "github.com/mezo-org/mezod/rpc/types"
+)
+
+func signedSetCodeTx(t *testing.T, chainID *big.Int) (*ethtypes.Transaction, []ethtypes.SetCodeAuthorization) {
+	t.Helper()
+
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	auth, err := ethtypes.SignSetCode(priv, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: to,
+		Nonce:   1,
+	})
+	require.NoError(t, err)
+
+	auths := []ethtypes.SetCodeAuthorization{auth}
+
+	inner := &ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainID),
+		Nonce:     0,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(10),
+		Gas:       100_000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  auths,
+	}
+
+	signer := ethtypes.NewPragueSigner(chainID)
+	tx := ethtypes.MustSignNewTx(priv, signer, inner)
+	return tx, auths
+}
+
+func TestNewRPCTransaction_SetCodeTx(t *testing.T) {
+	chainID := big.NewInt(31611)
+	tx, auths := signedSetCodeTx(t, chainID)
+
+	t.Run("no base fee, no block hash", func(t *testing.T) {
+		rpcTx, err := rpctypes.NewRPCTransaction(
+			tx,
+			common.Hash{},
+			0,
+			0,
+			nil,
+			chainID,
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(ethtypes.SetCodeTxType), uint64(rpcTx.Type))
+		require.NotNil(t, rpcTx.Accesses)
+		require.Equal(t, ethtypes.AccessList{}, *rpcTx.Accesses)
+		require.Equal(t, auths, rpcTx.AuthorizationList)
+		require.NotNil(t, rpcTx.ChainID)
+		require.Equal(t, chainID, rpcTx.ChainID.ToInt())
+		require.NotNil(t, rpcTx.GasFeeCap)
+		require.NotNil(t, rpcTx.GasTipCap)
+		// With no base fee / block hash, the effective gas price falls back to
+		// GasFeeCap.
+		require.Equal(t, tx.GasFeeCap(), rpcTx.GasPrice.ToInt())
+	})
+
+	t.Run("with base fee and block hash", func(t *testing.T) {
+		baseFee := big.NewInt(3)
+		blockHash := common.HexToHash("0xabc")
+
+		rpcTx, err := rpctypes.NewRPCTransaction(
+			tx,
+			blockHash,
+			1,
+			0,
+			baseFee,
+			chainID,
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(ethtypes.SetCodeTxType), uint64(rpcTx.Type))
+		require.NotNil(t, rpcTx.AuthorizationList)
+		require.Len(t, rpcTx.AuthorizationList, len(auths))
+
+		// price = min(tipCap+baseFee, feeCap)
+		want := new(big.Int).Add(tx.GasTipCap(), baseFee)
+		if want.Cmp(tx.GasFeeCap()) > 0 {
+			want = tx.GasFeeCap()
+		}
+		require.Equal(t, want, rpcTx.GasPrice.ToInt())
+	})
+
+	t.Run("JSON marshals authorizationList", func(t *testing.T) {
+		rpcTx, err := rpctypes.NewRPCTransaction(
+			tx,
+			common.Hash{},
+			0,
+			0,
+			nil,
+			chainID,
+		)
+		require.NoError(t, err)
+
+		raw, err := json.Marshal(rpcTx)
+		require.NoError(t, err)
+
+		var decoded map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+
+		alRaw, ok := decoded["authorizationList"]
+		require.True(t, ok, "authorizationList missing from JSON output")
+
+		var alDecoded []ethtypes.SetCodeAuthorization
+		require.NoError(t, json.Unmarshal(alRaw, &alDecoded))
+		require.Equal(t, auths, alDecoded)
+
+		// Empty access list should marshal as [] not null, mirroring how geth
+		// surfaces it to clients.
+		accRaw, ok := decoded["accessList"]
+		require.True(t, ok, "accessList missing from JSON output")
+		require.JSONEq(t, "[]", string(accRaw))
+	})
+}
+
+func TestNewRPCTransaction_DynamicFeeTx(t *testing.T) {
+	chainID := big.NewInt(31611)
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	signer := ethtypes.NewPragueSigner(chainID)
+	tipCap := big.NewInt(1)
+	feeCap := big.NewInt(10)
+	tx := ethtypes.MustSignNewTx(priv, signer, &ethtypes.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     0,
+		GasTipCap: tipCap,
+		GasFeeCap: feeCap,
+		Gas:       21_000,
+		To:        &to,
+		Value:     big.NewInt(0),
+	})
+
+	t.Run("no base fee, no block hash", func(t *testing.T) {
+		rpcTx, err := rpctypes.NewRPCTransaction(tx, common.Hash{}, 0, 0, nil, chainID)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(ethtypes.DynamicFeeTxType), uint64(rpcTx.Type))
+		require.Nil(t, rpcTx.AuthorizationList)
+		require.NotNil(t, rpcTx.Accesses)
+		require.Equal(t, chainID, rpcTx.ChainID.ToInt())
+		require.Equal(t, feeCap, rpcTx.GasFeeCap.ToInt())
+		require.Equal(t, tipCap, rpcTx.GasTipCap.ToInt())
+		// Effective price falls back to GasFeeCap when not mined.
+		require.Equal(t, feeCap, rpcTx.GasPrice.ToInt())
+
+		raw, err := json.Marshal(rpcTx)
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), "authorizationList")
+	})
+
+	t.Run("with base fee and block hash", func(t *testing.T) {
+		baseFee := big.NewInt(3)
+		blockHash := common.HexToHash("0xabc")
+
+		rpcTx, err := rpctypes.NewRPCTransaction(tx, blockHash, 1, 0, baseFee, chainID)
+		require.NoError(t, err)
+
+		// price = min(tipCap + baseFee, feeCap) = min(4, 10) = 4.
+		require.Equal(t, big.NewInt(4), rpcTx.GasPrice.ToInt())
+		require.Equal(t, feeCap, rpcTx.GasFeeCap.ToInt())
+		require.Equal(t, tipCap, rpcTx.GasTipCap.ToInt())
+	})
+
+	t.Run("tip+baseFee exceeds feeCap", func(t *testing.T) {
+		// baseFee 100 + tipCap 1 = 101 > feeCap 10 → price capped at feeCap.
+		baseFee := big.NewInt(100)
+		blockHash := common.HexToHash("0xabc")
+
+		rpcTx, err := rpctypes.NewRPCTransaction(tx, blockHash, 1, 0, baseFee, chainID)
+		require.NoError(t, err)
+		require.Equal(t, feeCap, rpcTx.GasPrice.ToInt())
+	})
+}

--- a/tests/system/test/Eip7702SendRawTx.test.ts
+++ b/tests/system/test/Eip7702SendRawTx.test.ts
@@ -1,0 +1,122 @@
+import { expect } from "chai"
+import { ethers } from "hardhat"
+import {
+  concat,
+  encodeRlp,
+  getAddress,
+  getBytes,
+  hexlify,
+  keccak256,
+  SigningKey,
+  toBeArray,
+  toQuantity,
+  Wallet,
+} from "ethers"
+
+// Ethers v6.13.5 has no native type-4 support, so the wire format is built
+// from ethers' RLP/minimal-int primitives.
+const SET_CODE_TX_TYPE = 0x04
+const AUTH_MAGIC = 0x05
+
+type RlpItem = string | Uint8Array | RlpItem[]
+
+function signAuthorization(
+  key: SigningKey,
+  chainId: bigint,
+  address: string,
+  nonce: bigint,
+): RlpItem[] {
+  const payload = encodeRlp([toBeArray(chainId), getAddress(address), toBeArray(nonce)])
+  const digest = keccak256(concat([new Uint8Array([AUTH_MAGIC]), getBytes(payload)]))
+  const sig = key.sign(digest)
+  return [
+    toBeArray(chainId),
+    getAddress(address),
+    toBeArray(nonce),
+    toBeArray(BigInt(sig.yParity)),
+    toBeArray(BigInt(sig.r)),
+    toBeArray(BigInt(sig.s)),
+  ]
+}
+
+describe("Eip7702SendRawTx", function () {
+  it("includes a type-0x04 transaction submitted via eth_sendRawTransaction", async function () {
+    const provider = ethers.provider
+    const { chainId } = await provider.getNetwork()
+
+    const [funder] = await ethers.getSigners()
+    const authority = Wallet.createRandom().connect(provider)
+    await (
+      await funder.sendTransaction({
+        to: authority.address,
+        value: ethers.parseEther("0.001"),
+      })
+    ).wait()
+
+    const target = getAddress("0x1111111111111111111111111111111111111111")
+    const key = new SigningKey(authority.privateKey)
+    const nonce = BigInt(await provider.getTransactionCount(authority.address))
+
+    // EIP-7702: auth_nonce is the authority's nonce *after* the tx is applied.
+    const auth = signAuthorization(key, chainId, target, nonce + 1n)
+
+    const fee = await provider.getFeeData()
+    const maxFeePerGas = fee.maxFeePerGas ?? ethers.parseUnits("1", "gwei")
+    const maxPriorityFeePerGas =
+      fee.maxPriorityFeePerGas ?? ethers.parseUnits("1", "gwei")
+
+    const fields: RlpItem[] = [
+      toBeArray(chainId),
+      toBeArray(nonce),
+      toBeArray(maxPriorityFeePerGas),
+      toBeArray(maxFeePerGas),
+      toBeArray(200_000n),
+      authority.address,
+      toBeArray(0n),
+      "0x",
+      [], // access list
+      [auth],
+    ]
+    const unsigned = concat([
+      new Uint8Array([SET_CODE_TX_TYPE]),
+      getBytes(encodeRlp(fields)),
+    ])
+    const sig = key.sign(keccak256(unsigned))
+    const raw = hexlify(
+      concat([
+        new Uint8Array([SET_CODE_TX_TYPE]),
+        getBytes(
+          encodeRlp([
+            ...fields,
+            toBeArray(BigInt(sig.yParity)),
+            toBeArray(BigInt(sig.r)),
+            toBeArray(BigInt(sig.s)),
+          ]),
+        ),
+      ]),
+    )
+
+    const hash: string = await provider.send("eth_sendRawTransaction", [raw])
+
+    // HardhatEthersProvider doesn't implement waitForTransaction.
+    let receipt: any = null
+    for (let i = 0; i < 60; i++) {
+      receipt = await provider.send("eth_getTransactionReceipt", [hash])
+      if (receipt) break
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+    expect(receipt, "receipt for set-code tx").to.not.be.null
+    expect(receipt.status).to.equal("0x1")
+
+    const rpcTx: any = await provider.send("eth_getTransactionByHash", [hash])
+    expect(rpcTx).to.not.be.null
+    expect(rpcTx.type).to.equal(toQuantity(SET_CODE_TX_TYPE))
+    expect(rpcTx.authorizationList).to.have.length(1)
+    expect(getAddress(rpcTx.authorizationList[0].address)).to.equal(target)
+    expect(BigInt(rpcTx.authorizationList[0].chainId)).to.equal(chainId)
+
+    // EIP-7702 delegation designator: 0xef0100 || target (23 bytes total).
+    const code: string = await provider.send("eth_getCode", [authority.address, "latest"])
+    expect(code.toLowerCase()).to.equal("0xef0100" + target.slice(2).toLowerCase())
+  })
+})

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -506,12 +506,15 @@ func (k *Keeper) applyMessageWithConfig(
 		gasUsed uint64
 	)
 
-	// EIP-7702 forbids combining an auth list with contract creation and
-	// rejects a non-nil but empty auth list. SetCodeTx.Validate and the ante
-	// cover the consensus path, but simulate / RPC ingress can construct a
-	// core.Message that bypasses both — mirror go-ethereum's apply-time check
-	// so the geth sentinels surface for callers that probe EIP-7702 directly.
+	rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())) //nolint:gosec
+
+	// Re-assert geth's EIP-7702 preCheck invariants. SetCodeTx.Validate
+	// and the consensus-path ante cover them on chain; simulate /
+	// eth_call paths build a core.Message directly and bypass both.
 	if msg.SetCodeAuthorizations != nil {
+		if !rules.IsPrague {
+			return nil, nil, errorsmod.Wrap(ethtypes.ErrTxTypeNotSupported, "set code tx not supported")
+		}
 		if msg.To == nil {
 			return nil, nil, errorsmod.Wrap(core.ErrSetCodeTxCreate, "apply message")
 		}
@@ -583,7 +586,6 @@ func (k *Keeper) applyMessageWithConfig(
 
 	// access list preparation is moved from ante handler to here, because it's needed when `ApplyMessage` is called
 	// under contexts where ante handlers are not run, for example `eth_call` and `eth_estimateGas`.
-	rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())) //nolint:gosec
 	if rules.IsBerlin {
 		stateDB.Prepare(rules, msg.From, evm.Context.Coinbase, msg.To, maps.Keys(evm.Precompiles()), msg.AccessList)
 	}
@@ -598,26 +600,20 @@ func (k *Keeper) applyMessageWithConfig(
 		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data, leftoverGas, value)
 		stateDB.SetNonce(sender, msg.Nonce+1, tracing.NonceChangeUnspecified)
 	} else {
-		// Apply set-code authorizations before calling evm.Call.
+		// Sender nonce was bumped before reaching here — by
+		// EthIncrementSenderSequenceDecorator on consensus paths, and by an
+		// explicit bump at each keeper-internal entry point. Self-sponsored
+		// auths therefore see the post-bump nonce.
 		//
-		// Sender nonce is bumped before this point — by
-		// EthIncrementSenderSequenceDecorator ante handler on consensus paths
-		// (CheckTx/DeliverTx) and by per-entry-point explicit bump on
-		// keeper-internal paths (EthCall, EstimateGas, TraceTx, traceTx,
-		// SimulateV1). Self-sponsored auths therefore see the post-bump
-		// value here regardless of path.
-		//
-		// Gated explicitly: simulate/eth_call/eth_estimateGas bypass the ante,
-		// so the consensus-side Prague check in setup_ctx.go isn't reached on
-		// those paths.
-		if rules.IsPrague {
-			precompiles := evm.Precompiles()
-			isPrecompile := func(addr common.Address) bool {
-				_, ok := precompiles[addr]
-				return ok
-			}
-			applySetCodeAuthorizations(k.Logger(ctx), stateDB, cfg.ChainConfig.ChainID, msg, isPrecompile)
+		// No Prague gate needed: pre-Prague the prologue rejects auth lists
+		// and no delegation marker can yet exist at msg.To, so
+		// applySetCodeAuthorizations is a no-op.
+		precompiles := evm.Precompiles()
+		isPrecompile := func(addr common.Address) bool {
+			_, ok := precompiles[addr]
+			return ok
 		}
+		applySetCodeAuthorizations(k.Logger(ctx), stateDB, cfg.ChainConfig.ChainID, msg, isPrecompile)
 
 		ret, leftoverGas, vmErr = evm.Call(sender, *msg.To, msg.Data, leftoverGas, value)
 	}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -577,7 +577,8 @@ func (k *Keeper) applyMessageWithConfig(
 
 	// access list preparation is moved from ante handler to here, because it's needed when `ApplyMessage` is called
 	// under contexts where ante handlers are not run, for example `eth_call` and `eth_estimateGas`.
-	if rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())); rules.IsBerlin { //nolint:gosec
+	rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())) //nolint:gosec
+	if rules.IsBerlin {
 		stateDB.Prepare(rules, msg.From, evm.Context.Coinbase, msg.To, maps.Keys(evm.Precompiles()), msg.AccessList)
 	}
 
@@ -599,12 +600,18 @@ func (k *Keeper) applyMessageWithConfig(
 		// keeper-internal paths (EthCall, EstimateGas, TraceTx, traceTx,
 		// SimulateV1). Self-sponsored auths therefore see the post-bump
 		// value here regardless of path.
-		precompiles := evm.Precompiles()
-		isPrecompile := func(addr common.Address) bool {
-			_, ok := precompiles[addr]
-			return ok
+		//
+		// Gated explicitly: simulate/eth_call/eth_estimateGas bypass the ante,
+		// so the consensus-side Prague check in setup_ctx.go isn't reached on
+		// those paths.
+		if rules.IsPrague {
+			precompiles := evm.Precompiles()
+			isPrecompile := func(addr common.Address) bool {
+				_, ok := precompiles[addr]
+				return ok
+			}
+			applySetCodeAuthorizations(k.Logger(ctx), stateDB, cfg.ChainConfig.ChainID, msg, isPrecompile)
 		}
-		applySetCodeAuthorizations(k.Logger(ctx), stateDB, cfg.ChainConfig.ChainID, msg, isPrecompile)
 
 		ret, leftoverGas, vmErr = evm.Call(sender, *msg.To, msg.Data, leftoverGas, value)
 	}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -508,9 +508,11 @@ func (k *Keeper) applyMessageWithConfig(
 
 	rules := cfg.Rules(ctx.BlockHeight(), uint64(ctx.BlockTime().Unix())) //nolint:gosec
 
-	// Re-assert geth's EIP-7702 preCheck invariants. SetCodeTx.Validate
-	// and the consensus-path ante cover them on chain; simulate /
-	// eth_call paths build a core.Message directly and bypass both.
+	// Re-assert geth's EIP-7702 invariants. On the consensus
+	// path these are enforced by SetCodeTx.Validate and the ante handler.
+	// Non-consensus paths (e.g. simulate, eth_call) build a core.Message
+	// directly, so neither check runs and the invariants must be
+	// re-asserted here.
 	if msg.SetCodeAuthorizations != nil {
 		if !rules.IsPrague {
 			return nil, nil, errorsmod.Wrap(ethtypes.ErrTxTypeNotSupported, "set code tx not supported")
@@ -600,14 +602,19 @@ func (k *Keeper) applyMessageWithConfig(
 		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data, leftoverGas, value)
 		stateDB.SetNonce(sender, msg.Nonce+1, tracing.NonceChangeUnspecified)
 	} else {
+		// Apply set-code authorizations before calling evm.Call.
+		//
 		// Sender nonce was bumped before reaching here — by
 		// EthIncrementSenderSequenceDecorator on consensus paths, and by an
-		// explicit bump at each keeper-internal entry point. Self-sponsored
-		// auths therefore see the post-bump nonce.
+		// explicit bump at each non-consensus path (e.g. simulate, eth_call).
+		// Self-sponsored auths therefore see the post-bump nonce.
 		//
-		// No Prague gate needed: pre-Prague the prologue rejects auth lists
-		// and no delegation marker can yet exist at msg.To, so
-		// applySetCodeAuthorizations is a no-op.
+		// applySetCodeAuthorizations is EIP-7702 logic but needs no
+		// IsPrague gate here. Pre-Prague both of its inputs are absent:
+		// msg.SetCodeAuthorizations is rejected by the check at the
+		// top of applyMessageWithConfig, and msg.To cannot carry a
+		// delegation marker because none could have been installed yet.
+		// The call is a no-op in that case.
 		precompiles := evm.Precompiles()
 		isPrecompile := func(addr common.Address) bool {
 			_, ok := precompiles[addr]

--- a/x/evm/types/tx_args.go
+++ b/x/evm/types/tx_args.go
@@ -121,12 +121,23 @@ func (args *TransactionArgs) ToTransaction() *MsgEthereumTx {
 		to = args.To.Hex()
 	}
 
-	var data TxData
+	usedType := ethtypes.LegacyTxType
 	switch {
-	// GasPrice + AuthorizationList: drop the auth list and fall through to
-	// LegacyTx. Otherwise the 1559 fee caps stay nil and AsTransaction().Hash()
-	// panics on a nil GasTipCap.
-	case args.AuthorizationList != nil && args.GasPrice == nil:
+	case args.AuthorizationList != nil:
+		usedType = ethtypes.SetCodeTxType
+	case args.MaxFeePerGas != nil:
+		usedType = ethtypes.DynamicFeeTxType
+	case args.AccessList != nil:
+		usedType = ethtypes.AccessListTxType
+	}
+	// Make it possible to default to newer tx, but use legacy if gasprice is provided
+	if args.GasPrice != nil {
+		usedType = ethtypes.LegacyTxType
+	}
+
+	var data TxData
+	switch usedType {
+	case ethtypes.SetCodeTxType:
 		al := AccessList{}
 		if args.AccessList != nil {
 			al = NewAccessList(args.AccessList)
@@ -144,7 +155,7 @@ func (args *TransactionArgs) ToTransaction() *MsgEthereumTx {
 			Accesses:  al,
 			AuthList:  NewAuthorizationList(args.AuthorizationList),
 		}
-	case args.MaxFeePerGas != nil:
+	case ethtypes.DynamicFeeTxType:
 		al := AccessList{}
 		if args.AccessList != nil {
 			al = NewAccessList(args.AccessList)
@@ -161,7 +172,7 @@ func (args *TransactionArgs) ToTransaction() *MsgEthereumTx {
 			Data:      args.GetData(),
 			Accesses:  al,
 		}
-	case args.AccessList != nil:
+	case ethtypes.AccessListTxType:
 		data = &AccessListTx{
 			To:       to,
 			ChainID:  &chainID,

--- a/x/evm/types/tx_args.go
+++ b/x/evm/types/tx_args.go
@@ -54,7 +54,7 @@ type TransactionArgs struct {
 	ChainID    *hexutil.Big         `json:"chainId,omitempty"`
 
 	// Introduced by SetCodeTxType transaction (EIP-7702).
-	AuthorizationList []ethtypes.SetCodeAuthorization `json:"authorizationList,omitempty"`
+	AuthorizationList []ethtypes.SetCodeAuthorization `json:"authorizationList"`
 }
 
 // String return the struct in a string format

--- a/x/evm/types/tx_args.go
+++ b/x/evm/types/tx_args.go
@@ -59,16 +59,24 @@ type TransactionArgs struct {
 
 // String return the struct in a string format
 func (args *TransactionArgs) String() string {
+	authSummaries := make([]string, 0, len(args.AuthorizationList))
+	for _, auth := range args.AuthorizationList {
+		authSummaries = append(authSummaries, fmt.Sprintf(
+			"(chainId=%s address=%s nonce=%d)",
+			auth.ChainID.String(), auth.Address.Hex(), auth.Nonce,
+		))
+	}
 	// Todo: There is currently a bug with hexutil.Big when the value its nil, printing would trigger an exception
 	return fmt.Sprintf("TransactionArgs{From:%v, To:%v, Gas:%v,"+
-		" Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
+		" Nonce:%v, Data:%v, Input:%v, AccessList:%v, AuthorizationList:%v}",
 		args.From,
 		args.To,
 		args.Gas,
 		args.Nonce,
 		args.Data,
 		args.Input,
-		args.AccessList)
+		args.AccessList,
+		authSummaries)
 }
 
 // ToTransaction converts the arguments to an ethereum transaction.
@@ -115,6 +123,27 @@ func (args *TransactionArgs) ToTransaction() *MsgEthereumTx {
 
 	var data TxData
 	switch {
+	// GasPrice + AuthorizationList: drop the auth list and fall through to
+	// LegacyTx. Otherwise the 1559 fee caps stay nil and AsTransaction().Hash()
+	// panics on a nil GasTipCap.
+	case args.AuthorizationList != nil && args.GasPrice == nil:
+		al := AccessList{}
+		if args.AccessList != nil {
+			al = NewAccessList(args.AccessList)
+		}
+
+		data = &SetCodeTx{
+			To:        to,
+			ChainID:   &chainID,
+			Nonce:     nonce,
+			GasLimit:  gas,
+			GasFeeCap: &maxFeePerGas,
+			GasTipCap: &maxPriorityFeePerGas,
+			Amount:    &value,
+			Data:      args.GetData(),
+			Accesses:  al,
+			AuthList:  NewAuthorizationList(args.AuthorizationList),
+		}
 	case args.MaxFeePerGas != nil:
 		al := AccessList{}
 		if args.AccessList != nil {

--- a/x/evm/types/tx_args_test.go
+++ b/x/evm/types/tx_args_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
 
 	"github.com/mezo-org/mezod/x/evm/types"
 )
@@ -19,7 +20,7 @@ func (suite *TxDataTestSuite) TestTxArgsString() {
 		{
 			"empty tx args",
 			types.TransactionArgs{},
-			"TransactionArgs{From:<nil>, To:<nil>, Gas:<nil>, Nonce:<nil>, Data:<nil>, Input:<nil>, AccessList:<nil>}",
+			"TransactionArgs{From:<nil>, To:<nil>, Gas:<nil>, Nonce:<nil>, Data:<nil>, Input:<nil>, AccessList:<nil>, AuthorizationList:[]}",
 		},
 		{
 			"tx args with fields",
@@ -32,14 +33,28 @@ func (suite *TxDataTestSuite) TestTxArgsString() {
 				Data:       &suite.hexDataBytes,
 				AccessList: &ethtypes.AccessList{},
 			},
-			fmt.Sprintf("TransactionArgs{From:%v, To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
+			fmt.Sprintf("TransactionArgs{From:%v, To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v, AuthorizationList:%v}",
 				&suite.addr,
 				&suite.addr,
 				&suite.hexUint64,
 				&suite.hexUint64,
 				&suite.hexDataBytes,
 				&suite.hexInputBytes,
-				&ethtypes.AccessList{}),
+				&ethtypes.AccessList{},
+				[]string{}),
+		},
+		{
+			"tx args with auth list",
+			types.TransactionArgs{
+				AuthorizationList: []ethtypes.SetCodeAuthorization{
+					{ChainID: *uint256.NewInt(31611), Address: suite.addr, Nonce: 7},
+					{ChainID: *uint256.NewInt(31611), Address: suite.addr, Nonce: 8},
+				},
+			},
+			fmt.Sprintf(
+				"TransactionArgs{From:<nil>, To:<nil>, Gas:<nil>, Nonce:<nil>, Data:<nil>, Input:<nil>, AccessList:<nil>, AuthorizationList:[(chainId=31611 address=%s nonce=7) (chainId=31611 address=%s nonce=8)]}",
+				suite.addr.Hex(), suite.addr.Hex(),
+			),
 		},
 	}
 	for _, tc := range testCases {
@@ -96,6 +111,191 @@ func (suite *TxDataTestSuite) TestConvertTxArgsEthTx() {
 		res := tc.txArgs.ToTransaction()
 		suite.Require().NotNil(res)
 	}
+}
+
+func (suite *TxDataTestSuite) TestToTransactionSetCode() {
+	auth := ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.NewInt(31611),
+		Address: suite.addr,
+		Nonce:   42,
+		V:       1,
+		R:       *uint256.NewInt(7),
+		S:       *uint256.NewInt(11),
+	}
+
+	// wantAccesses lets callers distinguish a populated AccessList from the
+	// empty fallback used when args.AccessList is nil.
+	assertSetCodeFields := func(setCodeTx *types.SetCodeTx, wantAccesses types.AccessList) {
+		suite.Require().Equal(suite.addr.Hex(), setCodeTx.To)
+		suite.Require().NotNil(setCodeTx.ChainID)
+		suite.Require().Equal(suite.hexBigInt.ToInt(), setCodeTx.ChainID.BigInt())
+		suite.Require().Equal(uint64(suite.hexUint64), setCodeTx.Nonce)
+		suite.Require().Equal(uint64(suite.hexUint64), setCodeTx.GasLimit)
+		suite.Require().NotNil(setCodeTx.GasFeeCap)
+		suite.Require().Equal(suite.hexBigInt.ToInt(), setCodeTx.GasFeeCap.BigInt())
+		suite.Require().NotNil(setCodeTx.GasTipCap)
+		suite.Require().Equal(suite.hexBigInt.ToInt(), setCodeTx.GasTipCap.BigInt())
+		suite.Require().NotNil(setCodeTx.Amount)
+		suite.Require().Equal(suite.hexBigInt.ToInt(), setCodeTx.Amount.BigInt())
+		// Input is preferred over Data when both are set (see GetData).
+		suite.Require().Equal([]byte(suite.hexInputBytes), setCodeTx.Data)
+		suite.Require().Equal(wantAccesses, setCodeTx.Accesses)
+		suite.Require().Len(setCodeTx.AuthList, 1)
+		suite.Require().Equal(auth, setCodeTx.AuthList[0].ToEthAuthorization())
+	}
+
+	suite.Run("with auth list, builds SetCodeTx", func() {
+		accessList := ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}}
+		args := types.TransactionArgs{
+			From:                 &suite.addr,
+			To:                   &suite.addr,
+			Gas:                  &suite.hexUint64,
+			MaxFeePerGas:         &suite.hexBigInt,
+			MaxPriorityFeePerGas: &suite.hexBigInt,
+			Value:                &suite.hexBigInt,
+			Nonce:                &suite.hexUint64,
+			Data:                 &suite.hexDataBytes,
+			Input:                &suite.hexInputBytes,
+			AccessList:           &accessList,
+			AuthorizationList:    []ethtypes.SetCodeAuthorization{auth},
+			ChainID:              &suite.hexBigInt,
+		}
+
+		msg := args.ToTransaction()
+		suite.Require().NotNil(msg)
+
+		txData, err := types.UnpackTxData(msg.Data)
+		suite.Require().NoError(err)
+
+		setCodeTx, ok := txData.(*types.SetCodeTx)
+		suite.Require().True(ok, "expected *SetCodeTx, got %T", txData)
+		assertSetCodeFields(setCodeTx, types.NewAccessList(&accessList))
+
+		// Round-trip through AsTransaction() must succeed and yield a
+		// non-empty hash with the SetCode type.
+		ethTx := msg.AsTransaction()
+		suite.Require().Equal(uint8(ethtypes.SetCodeTxType), ethTx.Type())
+		suite.Require().NotEmpty(ethTx.Hash().Hex())
+	})
+
+	suite.Run("nil access list, builds SetCodeTx with empty Accesses", func() {
+		args := types.TransactionArgs{
+			From:                 &suite.addr,
+			To:                   &suite.addr,
+			Gas:                  &suite.hexUint64,
+			MaxFeePerGas:         &suite.hexBigInt,
+			MaxPriorityFeePerGas: &suite.hexBigInt,
+			Value:                &suite.hexBigInt,
+			Nonce:                &suite.hexUint64,
+			Data:                 &suite.hexDataBytes,
+			Input:                &suite.hexInputBytes,
+			AccessList:           nil,
+			AuthorizationList:    []ethtypes.SetCodeAuthorization{auth},
+			ChainID:              &suite.hexBigInt,
+		}
+
+		msg := args.ToTransaction()
+		suite.Require().NotNil(msg)
+
+		txData, err := types.UnpackTxData(msg.Data)
+		suite.Require().NoError(err)
+
+		setCodeTx, ok := txData.(*types.SetCodeTx)
+		suite.Require().True(ok, "expected *SetCodeTx, got %T", txData)
+		// When args.AccessList is nil the branch must fall back to an
+		// empty (non-nil) AccessList{}, not propagate nil.
+		assertSetCodeFields(setCodeTx, types.AccessList{})
+		suite.Require().NotNil(setCodeTx.Accesses)
+
+		// Round-trip through AsTransaction() must not panic and must
+		// produce a non-empty hash.
+		ethTx := msg.AsTransaction()
+		suite.Require().Equal(uint8(ethtypes.SetCodeTxType), ethTx.Type())
+		suite.Require().NotEmpty(ethTx.Hash().Hex())
+	})
+
+	suite.Run("nil auth list, builds DynamicFeeTx", func() {
+		args := types.TransactionArgs{
+			From:                 &suite.addr,
+			To:                   &suite.addr,
+			Gas:                  &suite.hexUint64,
+			MaxFeePerGas:         &suite.hexBigInt,
+			MaxPriorityFeePerGas: &suite.hexBigInt,
+			Value:                &suite.hexBigInt,
+			Nonce:                &suite.hexUint64,
+			Data:                 &suite.hexDataBytes,
+			Input:                &suite.hexInputBytes,
+			AccessList:           &ethtypes.AccessList{},
+			AuthorizationList:    nil,
+			ChainID:              &suite.hexBigInt,
+		}
+
+		msg := args.ToTransaction()
+		suite.Require().NotNil(msg)
+
+		txData, err := types.UnpackTxData(msg.Data)
+		suite.Require().NoError(err)
+
+		_, ok := txData.(*types.DynamicFeeTx)
+		suite.Require().True(ok, "expected *DynamicFeeTx, got %T", txData)
+	})
+
+	suite.Run("empty non-nil auth list, builds SetCodeTx", func() {
+		args := types.TransactionArgs{
+			From:                 &suite.addr,
+			To:                   &suite.addr,
+			Gas:                  &suite.hexUint64,
+			MaxFeePerGas:         &suite.hexBigInt,
+			MaxPriorityFeePerGas: &suite.hexBigInt,
+			Value:                &suite.hexBigInt,
+			Nonce:                &suite.hexUint64,
+			Data:                 &suite.hexDataBytes,
+			Input:                &suite.hexInputBytes,
+			AccessList:           &ethtypes.AccessList{},
+			AuthorizationList:    []ethtypes.SetCodeAuthorization{},
+			ChainID:              &suite.hexBigInt,
+		}
+
+		msg := args.ToTransaction()
+		suite.Require().NotNil(msg)
+
+		txData, err := types.UnpackTxData(msg.Data)
+		suite.Require().NoError(err)
+
+		setCodeTx, ok := txData.(*types.SetCodeTx)
+		suite.Require().True(ok, "expected *SetCodeTx, got %T", txData)
+		suite.Require().Empty(setCodeTx.AuthList)
+	})
+
+	suite.Run("gasPrice + auth list, falls through to LegacyTx", func() {
+		auth := ethtypes.SetCodeAuthorization{
+			ChainID: *uint256.NewInt(31611),
+			Address: suite.addr,
+			Nonce:   1,
+		}
+		args := types.TransactionArgs{
+			From:              &suite.addr,
+			To:                &suite.addr,
+			Gas:               &suite.hexUint64,
+			GasPrice:          &suite.hexBigInt,
+			Value:             &suite.hexBigInt,
+			Nonce:             &suite.hexUint64,
+			Data:              &suite.hexDataBytes,
+			Input:             &suite.hexInputBytes,
+			AuthorizationList: []ethtypes.SetCodeAuthorization{auth},
+			ChainID:           &suite.hexBigInt,
+		}
+
+		msg := args.ToTransaction()
+		suite.Require().NotNil(msg)
+
+		txData, err := types.UnpackTxData(msg.Data)
+		suite.Require().NoError(err)
+
+		_, ok := txData.(*types.LegacyTx)
+		suite.Require().True(ok, "expected *LegacyTx, got %T", txData)
+		suite.Require().NotEmpty(msg.AsTransaction().Hash().Hex())
+	})
 }
 
 func (suite *TxDataTestSuite) TestToMessageEVM() {

--- a/x/evm/types/tx_args_test.go
+++ b/x/evm/types/tx_args_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -448,6 +449,51 @@ func (suite *TxDataTestSuite) TestGetFrom() {
 	for _, tc := range testCases {
 		retrievedAddress := tc.txArgs.GetFrom()
 		suite.Require().Equal(retrievedAddress, tc.expAddress)
+	}
+}
+
+func (suite *TxDataTestSuite) TestAuthorizationListJSONRoundTrip() {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []ethtypes.SetCodeAuthorization
+		isNil    bool
+	}{
+		{
+			"empty list must survive marshal/unmarshal",
+			`{"authorizationList":[]}`,
+			[]ethtypes.SetCodeAuthorization{},
+			false,
+		},
+		{
+			"absent field stays nil",
+			`{}`,
+			nil,
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		var args types.TransactionArgs
+		err := json.Unmarshal([]byte(tc.input), &args)
+		suite.Require().NoError(err, tc.name)
+		if tc.isNil {
+			suite.Require().Nil(args.AuthorizationList, tc.name)
+		} else {
+			suite.Require().NotNil(args.AuthorizationList, tc.name)
+			suite.Require().Equal(tc.expected, args.AuthorizationList, tc.name)
+		}
+
+		bz, err := json.Marshal(&args)
+		suite.Require().NoError(err, tc.name)
+
+		var round types.TransactionArgs
+		suite.Require().NoError(json.Unmarshal(bz, &round), tc.name)
+		if tc.isNil {
+			suite.Require().Nil(round.AuthorizationList, tc.name)
+		} else {
+			suite.Require().NotNil(round.AuthorizationList, tc.name)
+			suite.Require().Equal(tc.expected, round.AuthorizationList, tc.name)
+		}
 	}
 }
 


### PR DESCRIPTION
References: [MEZO-4013](https://linear.app/thesis-co/issue/MEZO-4013)
Depends on: https://github.com/mezo-org/mezod/pull/681

### Introduction

Wires EIP-7702 type-`0x04` transactions through every public Ethereum JSON-RPC entry point. After this PR, an integrator can submit a SetCodeTx through `eth_sendRawTransaction` or `eth_sendTransaction`, observe it through `eth_getTransactionByHash`, `eth_getBlockByNumber`, `eth_getTransactionReceipt`, and pass an `authorizationList` to `eth_call` / `eth_estimateGas` for accurate intrinsic-gas estimation. Receipts surface `effectiveGasPrice` on SetCodeTx the same way geth does for any post-1559 tx type. Authorization processing in the keeper now rejects pre-Prague messages carrying an auth list with `ErrTxTypeNotSupported`, matching the SetCodeTxType rejection in the consensus-path ante and closing the misleading acceptance / rejection split for simulate paths that bypass the ante.

### Changes

#### `x/evm/types/tx_args.go`

`TransactionArgs` gains an `AuthorizationList []ethtypes.SetCodeAuthorization` field (JSON-tagged `authorizationList`, without `omitempty`, so an explicitly empty list survives the `json.Marshal` step in `Backend.DoCall` / `SetTxDefaults` and reaches downstream validation as a non-nil slice instead of being silently elided). `ToTransaction` mirrors upstream geth's `internal/ethapi/transaction_args.go` shape: a prologue switch picks a `usedType` from the populated fields (`AuthorizationList` → `SetCodeTxType`, `MaxFeePerGas` → `DynamicFeeTxType`, `AccessList` → `AccessListTxType`, else `LegacyTxType`), then a separate override forces `LegacyTxType` when `args.GasPrice` is set, and dispatch runs on `usedType`. The `nil`-vs-`len` predicate on the auth-list branch mirrors geth: an empty non-nil list still routes to type-`0x04` so downstream validation can reject it per EIP-7702. The `GasPrice` override applies uniformly — a request that mixes `GasPrice` with an auth list, `MaxFeePerGas`, or `AccessList` lands in `LegacyTx`, matching upstream's "use legacy if gasprice is provided" contract. `ToMessage` forwards the auth list into `core.Message.SetCodeAuthorizations` so the keeper's authorization-application path sees it on simulate/call entrypoints. `String()` now summarises each auth entry as `(chainId=X address=Y nonce=Z)` rather than printing only the length.

#### `rpc/types/utils.go` + `rpc/types/types.go`

`NewRPCTransaction` gains a `SetCodeTxType` arm that emits `authorizationList`, the access list, the chain ID, and the 1559 fee fields via a shared `setEffectiveGasPrice` helper that also serves the existing `DynamicFeeTxType` arm. `RPCTransaction` gains the `AuthorizationList []ethtypes.SetCodeAuthorization` field. The slice returned by geth's `tx.SetCodeAuthorizations()` aliases the underlying transaction's auth list and is documented as read-only at the assignment site.

#### `rpc/backend/tx_info.go`

`GetTransactionReceipt` now writes `effectiveGasPrice` for any `txData` whose `TxType() >= ethtypes.DynamicFeeTxType`, replacing the previous DynamicFeeTx-only branch. SetCodeTx, AccessListTx, and any future post-1559 type ride the same path through the existing `TxData.EffectiveGasPrice` interface method.

#### `rpc/backend/call_tx.go`

The signer-resolution path was already type-agnostic via `MakeSigner`; only the receipt and tx-args paths needed wiring. A single-line tightening keeps the SetCodeTx case from being silently dropped through the cosmos tx encoder boundary.

#### `x/evm/keeper/state_transition.go`

`applyMessageWithConfig` now treats a non-Prague auth list as a top-level fatal alongside the existing auth-with-create and empty-auth-list rejections in the function prologue. The check returns `ErrTxTypeNotSupported`, matching the `SetCodeTxType` rejection in `setup_ctx.go`'s ante so simulate / `eth_call` / `eth_estimateGas` (which bypass the ante) surface the same error rather than silently dropping the auth list. With the rejection in place the call branch invokes `applySetCodeAuthorizations` unconditionally — pre-Prague the auth list is guaranteed nil and no delegation marker can yet exist at `msg.To`, so the helper is a no-op. The `rules` computation that fed the old call-site Prague gate is performed once at the top of the function and reused for the `IsBerlin` access-list `Prepare`.

#### Tests

- `x/evm/types/tx_args_test.go` — field-by-field assertions for the SetCodeTx branch (both populated and `nil` access-list variants), the `gasPrice + authorizationList` short-circuit, the empty-non-nil-auth-list case, plus updated `String()` expectations. `TestAuthorizationListJSONRoundTrip` pins that an explicit `authorizationList: []` survives a `json.Marshal` / `json.Unmarshal` round-trip and that an absent field still unmarshals to a nil slice.
- `rpc/types/utils_test.go` — `TestNewRPCTransaction_SetCodeTx` and `TestNewRPCTransaction_DynamicFeeTx` cover JSON marshalling of `authorizationList`, the `effectiveGasPrice` formula with and without a base fee, and the `tip+baseFee > feeCap` cap.
- `rpc/backend/tx_info_test.go` — `TestGetTransactionReceiptSetCodeTxEffectiveGasPrice` indexes a real SetCodeTx, fetches the receipt, and pins that `effectiveGasPrice`, `type`, and `from` are all correct.
- `rpc/backend/call_tx_test.go` — `TestSendRawTransactionSetCodeTx` asserts signer + authority recovery on the raw-send path; `TestSetTxDefaultsPropagatesAuthorizationList` + `TestSetTxDefaultsLeavesNilAuthorizationList` pin nil-vs-populated `AuthorizationList` propagation through `SetTxDefaults` into `EstimateGas`.
- `tests/system/test/Eip7702SendRawTx.test.ts` — a hardhat suite that funds a fresh EOA, signs a self-sponsored EIP-7702 authorization, submits the type-`0x04` envelope through `eth_sendRawTransaction`, and asserts the receipt status, RPC tx type/authorizationList shape, and the resulting `0xef0100||target` delegation designator on the EOA's code field.

### Testing

`go build ./...` clean. `go test -race -timeout 5m ./rpc/backend/ ./rpc/types/ ./x/evm/types/ ./x/evm/keeper/` passes. The new hardhat suite (`./tests/system/system-tests.sh Eip7702SendRawTx`) passes against a localnode (`make localnode-bin-start`, chain id `0x7b7b`/`31611`).

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment

