### PR TITLE
Add per-validator bridge-out attestation count metric

### DIFF
--- a/ethereum/bindings/portal/portal.go
+++ b/ethereum/bindings/portal/portal.go
@@ -38,6 +38,7 @@ func MezoBridgeAddress(network ethconfig.Network) string {
 type (
 	MezoBridge                      = ethereumcontract.MezoBridge
 	MezoBridgeAssetsLocked          = ethereumabi.MezoBridgeAssetsLocked
+	MezoBridgeAssetsUnlockAttested  = ethereumabi.MezoBridgeAssetsUnlockAttested
 	MezoBridgeAssetsUnlockConfirmed = ethereumabi.MezoBridgeAssetsUnlockConfirmed
 	MezoBridgeAssetsUnlocked        = ethereumabi.MezoBridgeAssetsUnlocked
 	BitcoinTxUTXO                   = ethereumabi.BitcoinTxUTXO

--- a/infrastructure/kubernetes/common/monitoring/metrics-scraper/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/metrics-scraper/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: metrics-scraper
-          image: mezo/metrics-scraper@sha256:762c4a51a3d41082ed15923023c8c017e01a8d90eea8351a16cd47b8af1e4959
+          image: mezo/metrics-scraper@sha256:629cfbbc21bb8500a6fb8d66bc0b0efe15f2bc7d22c16ee096de3985ee355d66
           imagePullPolicy: Always
           args:
             - --chain-id=$(CHAIN_ID)

--- a/metrics-scraper/bridge_monitoring.go
+++ b/metrics-scraper/bridge_monitoring.go
@@ -30,6 +30,9 @@ const (
 	// of the attestation process on Ethereum. Missing those events could result
 	// in false positives in the pending_assets_unlocked metric.
 	ethereumAssetsUnlockedConfirmedLookBackBlocks = uint64(100800) // ~14 days (assuming 1 block per 12s)
+	// Look-back period for AssetsUnlockAttested events used to initialize
+	// per-validator attestation counts on first poll.
+	ethereumAssetsUnlockAttestedLookBackBlocks = uint64(50400) // ~7 days (assuming 1 block per 12s)
 )
 
 var pendingAssetsUnlockedCache = map[string]bool{} // unlock seqno -> bool
@@ -40,6 +43,7 @@ type ethereumChain struct {
 	tbtcBankAddress common.Address
 
 	assetsUnlockedConfirmedCheckpointHeight uint64
+	assetsUnlockAttestedCheckpointHeight    uint64
 }
 
 type mezoChain struct {
@@ -284,6 +288,15 @@ func pollBridgeData(
 	err = outflowLimitSaturation(
 		mezoChainID,
 		mezo,
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = bridgeValAttestationCounts(
+		ctx,
+		mezoChainID,
+		ethereum,
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -697,4 +710,98 @@ func outflowLimitSaturation(
 	}
 
 	return nil
+}
+
+func bridgeValAttestationCounts(
+	ctx context.Context,
+	mezoChainID string,
+	ethereum *ethereumChain,
+) error {
+	currentHeight, err := ethereum.client.LatestBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current Ethereum height: [%w]", err)
+	}
+
+	startHeight := ethereum.assetsUnlockAttestedCheckpointHeight
+	endHeight := currentHeight.Uint64()
+
+	if startHeight == 0 {
+		if endHeight > ethereumAssetsUnlockAttestedLookBackBlocks {
+			startHeight = endHeight - ethereumAssetsUnlockAttestedLookBackBlocks
+		}
+	}
+
+	log.Printf(
+		"getting AssetsUnlockAttested events from [%d] to [%d] on Ethereum chain",
+		startHeight,
+		endHeight,
+	)
+
+	events, err := withBatchFetch(
+		ethereum.assetsUnlockAttestedEvents,
+		startHeight,
+		endHeight,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get AssetsUnlockAttested events on Ethereum chain: [%w]",
+			err,
+		)
+	}
+
+	ethereum.assetsUnlockAttestedCheckpointHeight = endHeight + 1
+
+	counts := make(map[common.Address]int)
+	for _, event := range events {
+		counts[event.Validator]++
+	}
+
+	// Get all registered bridge validators so we emit a 0 for validators
+	// that haven't attested at all.
+	validatorsCount, err := ethereum.mezoBridge.BridgeValidatorsCount()
+	if err != nil {
+		return fmt.Errorf("failed to get bridge validators count: [%w]", err)
+	}
+
+	for i := uint64(0); i < validatorsCount.Uint64(); i++ {
+		//nolint:gosec
+		validator, err := ethereum.mezoBridge.BridgeValidators(big.NewInt(int64(i)))
+		if err != nil {
+			return fmt.Errorf(
+				"failed to get bridge validator [%d] address: [%w]",
+				i,
+				err,
+			)
+		}
+
+		if _, ok := counts[validator]; !ok {
+			counts[validator] = 0
+		}
+	}
+
+	for validator, count := range counts {
+		bridgeValAttestationCounter.WithLabelValues(
+			validator.Hex(),
+			mezoChainID,
+		).Add(float64(count))
+	}
+
+	log.Printf(
+		"fetched [%d] AssetsUnlockAttested events for [%d] validators",
+		len(events),
+		len(counts),
+	)
+
+	return nil
+}
+
+func (ec *ethereumChain) assetsUnlockAttestedEvents(
+	startHeight, endHeight uint64,
+) ([]*portal.MezoBridgeAssetsUnlockAttested, error) {
+	return ec.mezoBridge.PastAssetsUnlockAttestedEvents(
+		startHeight,
+		&endHeight,
+		nil,
+		nil,
+	)
 }

--- a/metrics-scraper/prometheus.go
+++ b/metrics-scraper/prometheus.go
@@ -98,6 +98,14 @@ var (
 		},
 		[]string{"token", "chain_id"},
 	)
+
+	bridgeValAttestationCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bridge_val_attestation_count",
+			Help: "the cumulative number of bridge-out attestations submitted by a bridge validator",
+		},
+		[]string{"address", "chain_id"},
+	)
 )
 
 func startPrometheus(port uint) {


### PR DESCRIPTION
## Summary

- Adds `bridge_val_attestation_count` Prometheus counter to the metrics-scraper, tracking per-bridge-validator attestation activity on the MezoBridge contract
- Exposes the `MezoBridgeAssetsUnlockAttested` event type from the portal bindings package

## Motivation

During the 2026-05-09 bridge-out halt, 2 of 9 bridge validators had silently stopped attesting for an extended period. The system was running at exactly 7/9 quorum with zero fault tolerance. When a 3rd validator dropped off (likely due to ETH balance exhaustion), quorum broke and all bridge-outs from sequence 8068 onward stalled for 12+ hours.

The existing `pending_assets_unlocked` metric only fires _after_ quorum is already lost — a lagging indicator. This new metric enables detecting non-participating validators _before_ they cause a halt.

## Intended usage

Example Grafana alert (warning severity):

```promql
increase(bridge_val_attestation_count[6h]) == 0
  AND ON ()
max(increase(bridge_val_attestation_count[6h])) > 0
```

This fires when a validator has zero attestations in 6 hours while others are actively attesting. It won't trigger during quiet periods with no bridge-out activity.

## Test plan

- [ ] Verify `go vet ./metrics-scraper/...` passes (confirmed locally)
- [ ] Deploy to staging metrics-scraper and confirm the counter appears in Prometheus with per-validator labels
- [ ] Verify counter increments when bridge-out attestations occur on testnet
- [ ] Configure Grafana alert rule using the PromQL above

🤖 Generated with [Claude Code](https://claude.com/claude-code)