### PR TITLE
Cap vote extension size at 32 KiB in VerifyVoteExtensionHandler

### DIFF
--- a/app/abci/vote_extension.go
+++ b/app/abci/vote_extension.go
@@ -40,6 +40,14 @@ func (vep VoteExtensionPart) String() string {
 	}
 }
 
+// maxVoteExtensionSize bounds the size of raw vote extension bytes
+// accepted by VerifyVoteExtensionHandler. Realistic legitimate VEs
+// (bridge AssetsLockedEventsLimit events + a handful of Connect oracle
+// pairs + wrapper) are ~2.65 KiB; 32 KiB gives generous headroom for
+// future growth while preventing storage-bloat attacks via unknown-field
+// padding, which gogoproto.Unmarshal silently skips.
+const maxVoteExtensionSize = 32 * 1024
+
 // IVoteExtensionHandler is an interface representing a vote extension handler.
 type IVoteExtensionHandler interface {
 	// ExtendVoteHandler returns the handler for the ExtendVote ABCI request.
@@ -238,12 +246,13 @@ func (veh *VoteExtensionHandler) ExtendVoteHandler() sdk.ExtendVoteHandler {
 //
 // Invariants summary:
 //  1. Accepts empty app-level vote extension.
-//  2. Rejects app-level vote extension that cannot be unmarshaled.
-//  3. Rejects app-level vote extension with incorrect height.
-//  4. Rejects app-level vote extension with no parts.
-//  5. Accepts app-level vote extension only if each part corresponds to
+//  2. Rejects app-level vote extension exceeding maxVoteExtensionSize.
+//  3. Rejects app-level vote extension that cannot be unmarshaled.
+//  4. Rejects app-level vote extension with incorrect height.
+//  5. Rejects app-level vote extension with no parts.
+//  6. Accepts app-level vote extension only if each part corresponds to
 //     a known sub-handler.
-//  6. Accepts app-level vote extension only if each part is accepted by the
+//  7. Accepts app-level vote extension only if each part is accepted by the
 //     corresponding sub-handler.
 //
 // TODO: Currently, this function either ACCEPT the vote extension or return
@@ -288,6 +297,14 @@ func (veh *VoteExtensionHandler) VerifyVoteExtensionHandler() sdk.VerifyVoteExte
 			return &cmtabci.ResponseVerifyVoteExtension{
 				Status: cmtabci.ResponseVerifyVoteExtension_ACCEPT,
 			}, nil
+		}
+
+		if len(req.VoteExtension) > maxVoteExtensionSize {
+			return nil, fmt.Errorf(
+				"vote extension size %d exceeds limit %d",
+				len(req.VoteExtension),
+				maxVoteExtensionSize,
+			)
 		}
 
 		// Unmarshal the vote extension.

--- a/app/abci/vote_extension_test.go
+++ b/app/abci/vote_extension_test.go
@@ -1,6 +1,7 @@
 package abci
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -572,6 +573,82 @@ func (s *VoteExtensionHandlerTestSuite) TestVerifyVoteExtension() {
 		return ve.Parts[uint32(part)]
 	}
 
+	// veBytesOfSize returns a valid marshaled VoteExtension whose total
+	// byte length is exactly `size`. It works by sizing the value of
+	// Parts[1] and iterating to compensate for varint length growth at
+	// the 127/16383 thresholds.
+	veBytesOfSize := func(size int) []byte {
+		base := types.VoteExtension{
+			Height: s.requestHeight,
+			Parts:  map[uint32][]byte{1: nil},
+		}
+		baseBytes, err := base.Marshal()
+		s.Require().NoError(err)
+		pad := size - len(baseBytes)
+		s.Require().GreaterOrEqual(pad, 0)
+		base.Parts[1] = make([]byte, pad)
+		out, err := base.Marshal()
+		s.Require().NoError(err)
+		for len(out) > size {
+			base.Parts[1] = base.Parts[1][:len(base.Parts[1])-1]
+			out, err = base.Marshal()
+			s.Require().NoError(err)
+		}
+		for len(out) < size {
+			base.Parts[1] = append(base.Parts[1], 0x00)
+			out, err = base.Marshal()
+			s.Require().NoError(err)
+		}
+		return out
+	}
+
+	encodeVarint := func(n int) []byte {
+		var out []byte
+		for n >= 0x80 {
+			out = append(out, byte(n)|0x80)
+			n >>= 7
+		}
+		return append(out, byte(n))
+	}
+
+	// veBytesWithUnknownFieldPadding builds a small valid VoteExtension
+	// and appends raw bytes for a synthetic unknown protobuf field
+	// (field 99, wire type 2 length-delimited). gogoproto.Unmarshal
+	// silently skips unknown fields, so without the size check this
+	// padded extension would unmarshal cleanly and pass sub-handler
+	// validation. The returned bytes are guaranteed to be larger than
+	// maxVoteExtensionSize.
+	veBytesWithUnknownFieldPadding := func() []byte {
+		veBytes := marshalVE(types.VoteExtension{
+			Height: s.requestHeight,
+			Parts:  map[uint32][]byte{1: []byte("part1")},
+		})
+		tag := encodeVarint((99 << 3) | 2)
+		payloadLen := maxVoteExtensionSize - len(veBytes)
+		lenVarint := encodeVarint(payloadLen)
+		out := append([]byte{}, veBytes...)
+		out = append(out, tag...)
+		out = append(out, lenVarint...)
+		out = append(out, bytes.Repeat([]byte{0xAB}, payloadLen)...)
+		return out
+	}
+
+	acceptingPart1SubHandler := func() map[VoteExtensionPart]IVoteExtensionHandler {
+		subHandler := newMockVoteExtensionHandler()
+		subHandler.verifyVoteExtensionHandler.On(
+			"call",
+			mock.Anything,
+			mock.Anything,
+		).Return(
+			&cmtabci.ResponseVerifyVoteExtension{
+				Status: cmtabci.ResponseVerifyVoteExtension_ACCEPT,
+			}, nil,
+		)
+		return map[VoteExtensionPart]IVoteExtensionHandler{
+			VoteExtensionPart(1): subHandler,
+		}
+	}
+
 	tests := []struct {
 		name              string
 		subHandlersFn     func() map[VoteExtensionPart]IVoteExtensionHandler
@@ -607,6 +684,52 @@ func (s *VoteExtensionHandlerTestSuite) TestVerifyVoteExtension() {
 			expectedRes:       nil,
 			subHandlersCalled: nil,
 			errContains:       "failed to unmarshal vote extension",
+		},
+		{
+			name:          "vote extension just under size limit",
+			subHandlersFn: acceptingPart1SubHandler,
+			voteExtensionFn: func() []byte {
+				return veBytesOfSize(maxVoteExtensionSize - 1)
+			},
+			expectedRes: &cmtabci.ResponseVerifyVoteExtension{
+				Status: cmtabci.ResponseVerifyVoteExtension_ACCEPT,
+			},
+			subHandlersCalled: map[VoteExtensionPart]bool{
+				VoteExtensionPart(1): true,
+			},
+			errContains: "",
+		},
+		{
+			name:          "vote extension at size limit",
+			subHandlersFn: acceptingPart1SubHandler,
+			voteExtensionFn: func() []byte {
+				return veBytesOfSize(maxVoteExtensionSize)
+			},
+			expectedRes: &cmtabci.ResponseVerifyVoteExtension{
+				Status: cmtabci.ResponseVerifyVoteExtension_ACCEPT,
+			},
+			subHandlersCalled: map[VoteExtensionPart]bool{
+				VoteExtensionPart(1): true,
+			},
+			errContains: "",
+		},
+		{
+			name:          "vote extension exceeds size limit",
+			subHandlersFn: func() map[VoteExtensionPart]IVoteExtensionHandler { return nil },
+			voteExtensionFn: func() []byte {
+				return veBytesOfSize(maxVoteExtensionSize + 1)
+			},
+			expectedRes:       nil,
+			subHandlersCalled: nil,
+			errContains:       "vote extension size",
+		},
+		{
+			name:              "vote extension with unknown-field padding exceeds size limit",
+			subHandlersFn:     func() map[VoteExtensionPart]IVoteExtensionHandler { return nil },
+			voteExtensionFn:   veBytesWithUnknownFieldPadding,
+			expectedRes:       nil,
+			subHandlersCalled: nil,
+			errContains:       "vote extension size",
 		},
 		{
 			name:          "wrong-height vote extension",


### PR DESCRIPTION
Closes: [MEZO-4070](https://linear.app/thesis-co/issue/MEZO-4070)

### Introduction

`VerifyVoteExtensionHandler` is the chokepoint where every peer's vote extension flows in for validation before its bytes are committed into the extended commit that CometBFT persists on every node. The handler runs sub-handler validation on the unmarshaled payload but never bounds the size of the raw bytes it accepts. Because `gogoproto.Unmarshal` silently skips unknown protobuf fields, a malicious validator can pad each vote extension with hundreds of KiB of arbitrary data that pass every sub-handler check, get signed into the vote, and are stored verbatim on every node's disk — a storage-amplification vector visible to anyone who can run a validator. This PR closes that gap by capping the raw vote-extension size at 32 KiB before unmarshaling, on the same outer composite layer where the persisted bytes are received.

### Changes

#### `app/abci/vote_extension.go`

A new package-scope constant `maxVoteExtensionSize = 32 * 1024` sits beside `VoteExtensionPart`. The cap was picked against the realistic legitimate payload of ~2.65 KiB (bridge `AssetsLockedEventsLimit` events at ~252 B each, three Connect oracle pairs at ~38 B each, plus the composite wrapper), giving roughly an order-of-magnitude of headroom for future growth — raising `AssetsLockedEventsLimit`, expanding the market map, or adding a new VE sub-handler will not trigger a re-cap.

`VerifyVoteExtensionHandler` gains a single `len(req.VoteExtension) > maxVoteExtensionSize` guard inserted between the existing empty-VE accept branch and the `Unmarshal` call. The branch returns `nil, error` like every other invalid-VE branch already in the function — the docstring at the top of the handler explicitly documents this convention, and the function's existing TODO about a future REJECT-vs-error split is left untouched. Placing the cap on the outer composite layer covers padding on the wrapper, padding inside the bridge part, padding inside the Connect part, or any combination, with one check.

The handler's invariants-summary doc comment is renumbered to insert "Rejects app-level vote extension exceeding maxVoteExtensionSize" as item 2, between "Accepts empty app-level vote extension" and "Rejects app-level vote extension that cannot be unmarshaled".

No Fork gate is wired up. The new branch only fails for vote extensions that exceed 32 KiB; legitimate VEs are orders of magnitude smaller, so an upgraded and a non-upgraded validator agree on ACCEPT for every honest VE. The only divergent case is a padded vote extension produced by a misbehaving validator, who is removable through PoA governance regardless. There is no upgrade handler, no consensus-parameter change, and no proto change.

#### `app/abci/vote_extension_test.go`

Four new entries extend the `TestVerifyVoteExtension` table. Two assert ACCEPT on a marshaled vote extension sized exactly at `maxVoteExtensionSize` and one byte below it (the strict `>` comparison means equality must pass). One asserts the new size error on a valid VE one byte over the cap, with no sub-handler being invoked. The fourth case documents the unknown-field-padding threat model the cap defends against: it builds a small valid VE, appends raw protobuf bytes for a synthetic unknown length-delimited field (field 99, wire type 2), and verifies the size check fires — without the cap, those bytes would unmarshal cleanly and pass every sub-handler.

Three inline helpers support the new cases: `veBytesOfSize` builds a marshaled VE of an exact target byte length by sizing `Parts[1]` and iterating across the varint length-prefix transitions; `encodeVarint` produces the tag and length bytes for the synthetic unknown field; `acceptingPart1SubHandler` returns a mock that accepts any input for the at-/under-limit ACCEPT paths.

### Testing

- `go test -race ./app/abci/...` — full package with race detector. Passes (existing cases plus the four new ones).
- `go test -run TestVoteExtensionHandlerTestSuite/TestVerifyVoteExtension -race ./app/abci/...` — focused run on the affected suite. Passes.
- `go vet ./app/abci/...` — clean.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
