### PR TITLE
System test coverage for EIP-2537 BLS12-381 precompile layout

### DIFF
--- a/tests/system/contracts/Bls12381Check.sol
+++ b/tests/system/contracts/Bls12381Check.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+contract Bls12381Check {
+    function staticCall(address target, bytes calldata payload)
+        external
+        view
+        returns (bool ok, bytes memory out)
+    {
+        (ok, out) = target.staticcall(payload);
+    }
+}

--- a/tests/system/deploy/13_deploy_bls12381_check.ts
+++ b/tests/system/deploy/13_deploy_bls12381_check.ts
@@ -1,0 +1,21 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { getNamedAccounts, deployments } = hre
+  const { deployer } = await getNamedAccounts()
+
+  console.log(`deployer is ${deployer}`)
+  console.log("Deploying Bls12381Check contract...")
+
+  await deployments.deploy("Bls12381Check", {
+    from: deployer,
+    args: [],
+    log: true,
+    waitConfirmations: 1,
+  })
+}
+
+export default func
+
+func.tags = ["Bls12381Check"]

--- a/tests/system/test/Bls12381Check.test.ts
+++ b/tests/system/test/Bls12381Check.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai"
+import hre from "hardhat"
+import type { Bls12381Check } from "../typechain-types"
+import { getDeployedContract } from "./helpers/contract"
+
+const G1 = 128
+const G2 = 256
+const FP = 64
+const FP2 = 128
+const SCALAR = 32
+
+const ZERO_HEX = (n: number) => "0x" + "00".repeat(n)
+
+type Slot = {
+  addr: string
+  name: string
+  validInput: () => string
+  validOutputSize: number
+  expectedOutput?: string
+  wrongSize: () => string
+}
+
+const SLOTS: Slot[] = [
+  {
+    addr: hre.ethers.getAddress("0x000000000000000000000000000000000000000b"),
+    name: "G1Add",
+    validInput: () => ZERO_HEX(2 * G1),
+    validOutputSize: G1,
+    expectedOutput: ZERO_HEX(G1),
+    // Draft G1Mul payload shape; rejected here proves the slot is final G1Add.
+    wrongSize: () => ZERO_HEX(G1 + SCALAR),
+  },
+  {
+    addr: hre.ethers.getAddress("0x000000000000000000000000000000000000000c"),
+    name: "G1MSM",
+    validInput: () => ZERO_HEX(G1 + SCALAR),
+    validOutputSize: G1,
+    expectedOutput: ZERO_HEX(G1),
+    wrongSize: () => ZERO_HEX(2 * G1),
+  },
+  {
+    addr: hre.ethers.getAddress("0x000000000000000000000000000000000000000d"),
+    name: "G2Add",
+    validInput: () => ZERO_HEX(2 * G2),
+    validOutputSize: G2,
+    expectedOutput: ZERO_HEX(G2),
+    // Draft G2Mul payload shape; rejected here proves the slot is final G2Add.
+    wrongSize: () => ZERO_HEX(G2 + SCALAR),
+  },
+  {
+    addr: hre.ethers.getAddress("0x000000000000000000000000000000000000000e"),
+    name: "G2MSM",
+    validInput: () => ZERO_HEX(G2 + SCALAR),
+    validOutputSize: G2,
+    expectedOutput: ZERO_HEX(G2),
+    wrongSize: () => ZERO_HEX(2 * G2),
+  },
+  {
+    addr: hre.ethers.getAddress("0x000000000000000000000000000000000000000f"),
+    name: "PairingCheck",
+    validInput: () => ZERO_HEX(G1 + G2),
+    validOutputSize: 32,
+    expectedOutput: "0x" + "00".repeat(31) + "01",
+    wrongSize: () => ZERO_HEX(200),
+  },
+  {
+    addr: hre.ethers.getAddress("0x0000000000000000000000000000000000000010"),
+    name: "MapFpToG1",
+    validInput: () => ZERO_HEX(FP),
+    validOutputSize: G1,
+    wrongSize: () => ZERO_HEX(FP2),
+  },
+  {
+    addr: hre.ethers.getAddress("0x0000000000000000000000000000000000000011"),
+    name: "MapFp2ToG2",
+    validInput: () => ZERO_HEX(FP2),
+    validOutputSize: G2,
+    wrongSize: () => ZERO_HEX(FP),
+  },
+]
+
+const EMPTY_SLOTS = [
+  hre.ethers.getAddress("0x0000000000000000000000000000000000000012"),
+  hre.ethers.getAddress("0x0000000000000000000000000000000000000013"),
+]
+
+describe("Bls12381Check (EIP-2537 layout)", function () {
+  const { deployments } = hre
+  let bls: Bls12381Check
+
+  before(async function () {
+    await deployments.fixture(["Bls12381Check"])
+    bls = await getDeployedContract("Bls12381Check")
+  })
+
+  for (const slot of SLOTS) {
+    it(`${slot.name} at ${slot.addr} accepts valid input`, async function () {
+      const [ok, out] = await bls.staticCall.staticCall(
+        slot.addr,
+        slot.validInput(),
+      )
+      expect(ok, "staticcall reverted").to.be.true
+      expect(hre.ethers.dataLength(out)).to.equal(slot.validOutputSize)
+      if (slot.expectedOutput !== undefined) {
+        expect(out).to.equal(slot.expectedOutput)
+      }
+    })
+  }
+
+  for (const slot of SLOTS) {
+    it(`${slot.name} reverts on wrong-size payload`, async function () {
+      const [ok] = await bls.staticCall.staticCall(slot.addr, slot.wrongSize())
+      expect(ok, "wrong-size payload accepted").to.be.false
+    })
+  }
+
+  for (const emptyAddr of EMPTY_SLOTS) {
+    it(`${emptyAddr} is not a precompile (empty account)`, async function () {
+      const [ok, out] = await bls.staticCall.staticCall(emptyAddr, ZERO_HEX(64))
+      expect(ok, "staticcall to empty account reverted").to.be.true
+      expect(out).to.equal("0x")
+    })
+  }
+})


### PR DESCRIPTION
Closes: [MEZO-4004](https://linear.app/thesis-co/issue/MEZO-4004)

### Introduction

This PR adds a system test that pins the BLS12-381 precompile surface to the finalized EIP-2537 layout. Mezo's vendored go-ethereum recently moved from the pre-finalization 9-precompile draft (0x0b–0x13, including standalone G1Mul/G2Mul) to the finalized 7-precompile layout (0x0b–0x11). Until now nothing in CI exercised these precompiles, so a future geth bump or Prague-gating change could silently regress the layout. This suite locks the live precompile surface against the finalized EIP-2537 spec.

### Changes

#### `tests/system/test/Bls12381Check.test.ts`

A table-driven Mocha suite that asserts, for each of the seven finalized EIP-2537 precompiles at addresses 0x0b through 0x11 (G1Add, G1MSM, G2Add, G2MSM, PairingCheck, MapFpToG1, MapFp2ToG2):

- An identity-encoded valid input is accepted and the returned bytes have the EIP-2537-mandated output size — and, where unambiguous, the canonical identity payload (all-zero for `Add` / `MSM`; `0x00…01` for `PairingCheck`, which evaluates `e(O, O) = 1`).
- A deliberately mis-sized payload is rejected. For G1Add and G2Add the rejected payload is shaped exactly like the draft G1Mul / G2Mul input — the strongest disambiguator from the obsolete draft layout.

Plus two negative-space assertions confirming that 0x12 and 0x13 are empty accounts (where the draft layout placed its 8th and 9th BLS precompiles). On a network where Prague is not yet active, the size-positive assertions fail loudly rather than being skipped, so a mis-targeted run is unambiguous.

#### `tests/system/contracts/Bls12381Check.sol`

A minimal generic `STATICCALL` wrapper used by the suite. Routing every assertion through Solidity rather than raw `provider.call` proves precompile invocability from EVM contract code, not only from RPC.

#### `tests/system/deploy/13_deploy_bls12381_check.ts`

A hardhat-deploy script for the wrapper contract; the suite runs via `./tests/system/system-tests.sh Bls12381Check`.

Scope is layout and input-format binding only. Canonical non-identity cryptographic vectors are deliberately out of scope — operation correctness for EIP-2537 is owned by upstream go-ethereum's own test suite.

### Testing

Run against a localnode (`make localnode-bin-start`; Prague is active from genesis there):

```
cd tests/system
./system-tests.sh Bls12381Check
```

Expected: 16 passing cases under `Bls12381Check (EIP-2537 layout)` — 7 positive presence/size checks, 7 wrong-size revert checks, 2 empty-slot checks. Verified locally against a localnode on the current branch.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
