### PR TITLE
Refresh stale geth-version references in simulate v1 comments

### DIFF
--- a/x/evm/keeper/simulate_v1.go
+++ b/x/evm/keeper/simulate_v1.go
@@ -71,7 +71,7 @@ func (b *simGasBudget) consume(amount uint64) error {
 // via the plain error channel.
 //
 // Design mirrors go-ethereum's internal/ethapi/simulate.go::sanitizeChain
-// (v1.15.4 source). Divergences: we never propagate a nil slice input
+// (v1.16.9 source). Divergences: we never propagate a nil slice input
 // (caller has already enforced len > 0 at the RPC boundary), and the
 // span check against types.MaxSimulateBlocks is performed BEFORE gap-fill
 // allocation so a pathological `[{Number: base+1}, {Number:
@@ -557,9 +557,9 @@ func (k *Keeper) processSimBlock(
 		// `(*state.StateDB).SetTxContext(thash, ti)` — it only updates
 		// the StateDB's per-call TxHash / TxIndex while leaving the
 		// pre-set BlockHash and LogIndex alone.
-		// DynamicFeeTxType matches go-ethereum v1.16's eth_simulateV1
-		// driver (`internal/ethapi/simulate.go`), so when Mezo upgrades
-		// off v1.14 the wire-shape of the response stays stable.
+		// DynamicFeeTxType matches the default chosen by go-ethereum's
+		// eth_simulateV1 driver (`internal/ethapi/simulate.go`),
+		// keeping the wire shape aligned with upstream.
 		simTx := buildSimTx(&args, cfg.ChainConfig.ChainID, ethtypes.DynamicFeeTxType)
 		callTxHash := simTx.Hash()
 		callIdx := len(txs)
@@ -846,10 +846,10 @@ func sameForks(a, b params.Rules) bool {
 // lets the driver pass the same value into NewBlock to derive
 // transactionsRoot and into the Senders map without rebuilding it.
 //
-// The envelope shape mirrors go-ethereum v1.16's
-// `internal/ethapi.TransactionArgs.ToTransaction(defaultType)` so that
-// Mezo's wire shape stays consistent across the pinned v1.14 baseline
-// and the v1.16 upgrade target. The selection rule, in order:
+// The envelope shape mirrors go-ethereum's
+// `internal/ethapi.TransactionArgs.ToTransaction(defaultType)`
+// (v1.16.9 source), keeping Mezo's wire shape aligned with upstream.
+// The selection rule, in order:
 //
 //  1. `MaxFeePerGas` set, or `defaultType == DynamicFeeTxType` →
 //     DynamicFeeTx (accessList is nested if provided).

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -143,8 +143,7 @@ func (s *StateDB) Keeper() Keeper {
 // Safe to call between calls; the txConfig is read-only from AddLog's
 // perspective and never participates in the journal.
 //
-// TODO (geth-upgrade): once go-ethereum v1.16.9 lands, decide whether
-// the simulate driver should call geth's native
+// TODO: decide whether the simulate driver should call geth's native
 // `(*state.StateDB).SetTxContext` directly — and whether this wrapper
 // can be dropped in favor of it.
 func (s *StateDB) SetTxContext(thash common.Hash, ti int) {


### PR DESCRIPTION
### Introduction

The `eth_simulateV1` driver carries several comments that pre-date the recent go-ethereum upgrade. `x/evm/keeper/simulate_v1.go` still cites a `v1.15.4` upstream source for `sanitizeSimChain`, frames the `DynamicFeeTxType` choice in the per-call hot loop as "when Mezo upgrades off v1.14", and describes the `buildSimTx` envelope shape as bridging a "pinned v1.14 baseline" with a "v1.16 upgrade target". `x/evm/statedb/statedb.go` gates a `SetTxContext` TODO on "once go-ethereum v1.16.9 lands". The chain is now on `v1.16.9-mezo1` (`go.mod`), so each of those qualifiers misleads a reader who comes in fresh. This PR refreshes the comments so they describe the current upstream pin directly.

### Changes

#### `sanitizeSimChain` upstream pin (`x/evm/keeper/simulate_v1.go`)

The "Design mirrors go-ethereum's internal/ethapi/simulate.go::sanitizeChain" header now reads `(v1.16.9 source)` instead of `(v1.15.4 source)`, matching the actual `go.mod` pin.

#### `DynamicFeeTxType` selection comment (`x/evm/keeper/simulate_v1.go`)

The per-call `buildSimTx` callsite no longer frames the default tx type as a forward-compatibility hedge ("when Mezo upgrades off v1.14 the wire-shape stays stable"). It now states the durable reason: `DynamicFeeTxType` matches the default chosen by go-ethereum's `eth_simulateV1` driver, keeping the wire shape aligned with upstream.

#### `buildSimTx` doc block (`x/evm/keeper/simulate_v1.go`)

The header on `buildSimTx` dropped the "consistent across the pinned v1.14 baseline and the v1.16 upgrade target" framing. It now cites the v1.16.9 source of `internal/ethapi.TransactionArgs.ToTransaction` directly. The selection-rule list below it is untouched.

#### `StateDB.SetTxContext` TODO (`x/evm/statedb/statedb.go`)

The TODO no longer gates the decision on "once go-ethereum v1.16.9 lands" (that condition is met). It now reads as an open question about whether the simulate driver can drop this wrapper in favor of geth's native `(*state.StateDB).SetTxContext`.

### Testing

Comment-only changes; no behavior change. `go build ./x/evm/keeper/... ./x/evm/statedb/...` and `go vet` on the same packages run clean.
