### PR TITLE
Bump testnet nodes to v11.0.0-rc0

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -191,7 +191,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v8.0.0`       | 11854127  | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0)                                                                                                           |
 | `v9.0.0`       | 12193600  | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0)                                                                                                           |
 | `v10.0.0`      | 12872000  | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0)                                                                                                         |
-| `v11.0.0`      | TBD       | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0)                                                                                                         |
+| `v11.0.0`      | 13206900  | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0)                                                                                                         |
 
 ### Mainnet
 

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v11.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v11.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v11.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v11.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v11.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1


### PR DESCRIPTION
Closes: MEZO-4076

### Introduction

Here we bump our testnet nodes to v11.0.0-rc0.

### Changes

#### Bump testnet node image tags

Re-add the `image` and `tag` overrides on all five `mezo-staging` validator value files so they pull `v11.0.0-rc0` for the rollout. These overrides will be removed again once `v11.0.0` is promoted to a stable tag.

#### Record the v11.0.0 testnet upgrade block in `docs/upgrades.md`

Replace the `TBD` placeholder in the testnet historical-upgrades table for `v11.0.0` with the agreed halt block `13206900`. The mainnet block for `v11.0.0` stays `TBD` until a mainnet block is selected.

### Testing

Apply using `helmfile apply -l type=validator --context 1 --concurrency 1` at the v11.0.0 testnet halt block.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (\`docs/\`) or specification (\`x/<module>/spec/\`)
- [x] Assigned myself in the \`Assignees\` field
- [x] Assigned \`mezod-developers\` in the \`Reviewers\` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment