### PR TITLE
Record v11.0.0 mainnet upgrade block

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -207,4 +207,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v8.0.0` | 7739500 | Planned upgrade with chain halt      | [v8.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v8.0.0) |
 | `v9.0.0` | 8194500 | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0) |
 | `v10.0.0` | 8773000 | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0) |
-| `v11.0.0` | TBD     | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0) |
+| `v11.0.0` | 9275000 | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0) |


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/MEZO-4077

### Introduction

The v11.0.0 mainnet upgrade block has been scheduled. This PR records the block height in the historical upgrades table.

### Changes

#### Mainnet upgrades table

Set the v11.0.0 mainnet upgrade block from TBD to 9275000 in `docs/upgrades.md`.

### Testing

Documentation-only change; no tests required.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
