### PR TITLE
Bump testnet validators and mainnet RPC to v11.0.0

### DIFF
--- a/infrastructure/kubernetes/mezo-production/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-production/helmfile.yaml
@@ -28,6 +28,6 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     values:
       - ./values/mezo-rpc-node.yaml

--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 11.0.0
+    version: 12.0.0
     labels:
       type: validator
     values:

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,6 +1,3 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v11.0.0-rc0
-
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,6 +1,3 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v11.0.0-rc0
-
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,6 +1,3 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v11.0.0-rc0
-
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,6 +1,3 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v11.0.0-rc0
-
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,6 +1,3 @@
-image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
-tag: v11.0.0-rc0
-
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1


### PR DESCRIPTION
Closes: [MEZO-4077](https://linear.app/thesis-co/issue/MEZO-4077/the-v1100-mezod-release-mainnet)

### Introduction

Bump our testnet validator nodes and mainnet RPC to mezod v11.0.0 by switching to Validator Kit 12.0.0 which points to this mezod version.

### Changes

- Bump the V-Kit chart version from 11.0.0 to 12.0.0 for all five testnet validator nodes in the staging helmfile
- Bump the V-Kit chart version from 11.0.0 to 12.0.0 for the mainnet RPC node in the production helmfile
- Drop the per-node `image`/`tag` overrides in the staging values; the V-Kit 12.0.0 chart default already points to mezod v11.0.0

### Testing

Apply the staging helmfile to roll the testnet validators onto the stable v11.0.0 image. The mainnet RPC must wait until the v11.0.0 mainnet upgrade block.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
