### PR TITLE
Monitor liquidation-bot balance on Mezo in production

### DIFF
--- a/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
@@ -8,6 +8,7 @@ data:
     passport-mezo-relayer:0xf35c1a20303ddcA464Ebf5b3b023588Cf3181c8a
     pyth-updater:0x2585618FD0b5656C72918CC7b92207e5B6022DfD
     safety-buffer-keeper:0x1cBbC5f210031fF947F4a17D87fcFbBe02A7a8f7
+    liquidation-bot:0x8D24443B3386A61bBEA7A052c158091DfAa8e029
   addresses-ethereum.txt: |
     bridge-reimbursement-pool:0x700C8840aCDd035cFE35847bFD928C576f9C92A7
     bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8


### PR DESCRIPTION
Resolves: https://linear.app/thesis-co/issue/MEZO-4494/set-up-the-operator-account-and-pin-to-balance-monitoring

### Introduction
This PR adds the liquidation-bot account to the production balance-exporter ConfigMap so its native BTC balance on the Mezo chain is scraped by Prometheus and surfaced on the "Account Balances on Mezo" Grafana dashboard alongside the other operational accounts.

The liquidation-bot account must be topped up before this PR is merged.

### Testing

Grafana is already configured and sending alerts

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
