### PR TITLE
Enable go-ethereum metrics collection when --metrics is set

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -51,6 +51,7 @@ import (
 	tmtypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 
+	ethmetrics "github.com/ethereum/go-ethereum/metrics"
 	ethmetricsexp "github.com/ethereum/go-ethereum/metrics/exp"
 
 	errorsmod "cosmossdk.io/errors"
@@ -442,6 +443,14 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, opts StartOpt
 	// Enable metrics if JSONRPC is enabled and --metrics is passed
 	// Flag not added in config to avoid user enabling in config without passing in CLI
 	if config.JSONRPC.Enable && ctx.Viper.GetBool(srvflags.JSONRPCEnableMetrics) {
+		// Turn on the go-ethereum metrics subsystem before serving them.
+		// Until go-ethereum v1.14.8 the metrics package auto-enabled itself
+		// when it spotted the "metrics" CLI flag in os.Args, so starting the
+		// node with --metrics was enough. v1.16.9 dropped that auto-detection,
+		// so without an explicit Enable() every recording call is a no-op and
+		// the exported metrics (e.g. the rpc_duration_* family) stay flat at
+		// zero. Enabling is gated on the same flag that starts the exporter.
+		ethmetrics.Enable()
 		ethmetricsexp.Setup(config.JSONRPC.MetricsAddress)
 	}
 


### PR DESCRIPTION
### Introduction

Node operators expose go-ethereum's JSON-RPC metrics by starting `mezod` with the `--metrics` flag, which serves them on the metrics endpoint (`/debug/metrics/prometheus`). Since the go-ethereum dependency reached v1.16.9, that endpoint still lists the `rpc_duration_*` family and the other go-ethereum RPC metrics (`rpc_requests`, `rpc_success`, `rpc_failure`), but their values stay flat at zero because the metrics are never actually collected. This change restores their collection so the exported values track real RPC activity again.

### Changes

go-ethereum's metrics package used to enable itself automatically when it detected the `metrics` flag among the process arguments, so passing `--metrics` was enough to both serve and populate the metrics. go-ethereum v1.16.9 removed that argument sniffing; enabling the subsystem now requires an explicit `metrics.Enable()` call. Without it, every metric `Update` short-circuits to a no-op and the exported values never move off zero.

`startInProcess` now calls `metrics.Enable()` in the same branch that starts the metrics exporter, so the `--metrics` flag once again both serves and populates the go-ethereum metrics. Collection stays off when the flag is not set, matching the previous behavior.

### Testing

Reproduced the metrics path against the go-ethereum v1.16.9 fork in isolation: a registered RPC serving timer (`rpc/duration/all`) plus the lazily registered per-method histograms (`rpc/duration/<method>/{success,failure}`, backed by a resetting sample, exactly as go-ethereum's rpc package builds them) were updated and then scraped through go-ethereum's Prometheus handler. Without `metrics.Enable()`, every `rpc_duration_*` value read zero even immediately after recording; with `metrics.Enable()`, the counts and percentiles reflected the recorded samples. The same setup recorded real data on the older v1.14.8 fork, where the flag-based auto-enable was still present, confirming the regression and the fix.

`go build ./server/`, `go vet ./server/`, and `gofmt` are clean on the change.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
