### PR TITLE
Monitor earn-bot wallet balance on Mezo and Ethereum

### DIFF
--- a/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-production/monitoring/balance-exporter/configmap.yaml
@@ -9,7 +9,9 @@ data:
     pyth-updater:0x2585618FD0b5656C72918CC7b92207e5B6022DfD
     safety-buffer-keeper:0x1cBbC5f210031fF947F4a17D87fcFbBe02A7a8f7
     liquidation-bot:0x8D24443B3386A61bBEA7A052c158091DfAa8e029
+    earn-bot:0xf8176Df5B9FbCf0Ed38c06970371ba89B7701bBb
   addresses-ethereum.txt: |
     bridge-reimbursement-pool:0x700C8840aCDd035cFE35847bFD928C576f9C92A7
     bridge-worker:0x419b505186fe3880Ac6407AcD14dD0398d6e8Ec8
     pyth-updater:0x2585618FD0b5656C72918CC7b92207e5B6022DfD
+    earn-bot:0xf8176Df5B9FbCf0Ed38c06970371ba89B7701bBb


### PR DESCRIPTION
References: <!-- Put GitHub/Linear issue here -->

### Introduction

The earn-bot wallet holds gas on both Mezo and Ethereum mainnet, but its native balance was not tracked by any monitoring. This adds the account to the production balance-exporter so a low or draining balance surfaces before the bot runs out of gas.

### Changes

#### earn-bot added to the production balance-exporter config

The `balance-exporter-config` ConfigMap now lists the earn-bot account (`0xf8176Df5B9FbCf0Ed38c06970371ba89B7701bBb`) in both `addresses-mezo.txt` and `addresses-ethereum.txt`. The balance-exporter Deployment runs one container per chain against these files (port `9115` for Mezo, `9116` for Ethereum), so the account's native balance is now exported as `mezo_account_balance` and `ethereum_account_balance` series labelled `earn-bot`. Prometheus already scrapes the `balance-exporter` job, and the "Account Balances on Mezo" / "Account Balances on Ethereum" panels on the accounts dashboard query those metrics generically, so the new series appears automatically without any Prometheus or dashboard changes.

### Testing

Rendered the production monitoring overlay with `kubectl kustomize infrastructure/kubernetes/mezo-production/monitoring` and confirmed it builds cleanly (exit 0) with the earn-bot entry present in both address lists of the generated ConfigMap.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
