### PR TITLE
Fix Grafana crash loop: pin image tag and raise memory limit

### DIFF
--- a/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           resources:
             limits:
               cpu: 300m
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 512Mi

--- a/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
+++ b/infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         runAsNonRoot: true
       containers:
         - name: grafana
-          image: grafana/grafana:latest
+          image: grafana/grafana:13.1.0
+          imagePullPolicy: IfNotPresent
           ports:
             - name: grafana
               containerPort: 3000
@@ -65,10 +66,10 @@ spec:
           resources:
             limits:
               cpu: 300m
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
           volumeMounts:
             - name: grafana-grafana-ini
               mountPath: /etc/grafana/grafana.ini


### PR DESCRIPTION
References: <!-- add GitHub/Linear issue if one exists -->

### Introduction

The Grafana pod in the `monitoring` namespace on `mezo-production` was stuck in `CrashLoopBackOff`, repeatedly `OOMKilled` (exit code 137). The node had no memory pressure, so the kill came from the container exceeding its own memory limit rather than a node-level eviction.

Two things combined. First, the deployment ran `grafana/grafana:latest` with `imagePullPolicy: Always`, so every pod restart silently pulled the newest published image; the running version had drifted to 13.1.0 even though the deployment spec had not changed in over a year. Second, a sustained brute-force flood against the internet-exposed admin login drives process memory up roughly linearly, so the container overran its limit within minutes.

### Changes

#### Grafana deployment in the shared monitoring base

- Pin the image from `grafana/grafana:latest` to `grafana/grafana:13.1.0` and set `imagePullPolicy: IfNotPresent`, so a restart no longer pulls an unvetted newer image. 13.1.0 is the version currently running, so this freezes behavior rather than changing it.
- Raise the container memory limit from `512Mi` to `2Gi` and the request from `256Mi` to `512Mi`. CPU is unchanged. The larger limit is headroom to keep the pod up; it is a buffer for the memory growth, not a fix for its cause.

The change is in `infrastructure/kubernetes/common/monitoring/grafana/deployment.yaml`, the base shared by the `mezo-production` and `mezo-staging` monitoring overlays, so both environments pick it up.

#### Follow-up needed (not in this PR)

The memory growth is driven by a brute-force login flood from a single source IP against `monitoring.mezo.org/grafana`. Raising the limit only delays the OOM under a sustained attack. The exposure should be addressed separately by restricting the Grafana ingress source ranges (or fronting it with IAP) and/or blocking the attacking IP.

### Testing

- `kubectl kustomize` of the `mezo-production` and `mezo-staging` monitoring overlays both render successfully, with the Grafana deployment showing `image: grafana/grafana:13.1.0`, `imagePullPolicy: IfNotPresent`, `limits.memory: 2Gi`, and `requests.memory: 512Mi`.
- The image tag `grafana/grafana:13.1.0` is published and pullable, confirmed against the Docker Hub tags API and a registry v2 manifest request (HTTP 200).
- Applied to the live `mezo-production` cluster; the pod rolls out on the pinned image with the raised limit.
