### PR TITLE
Point staging api-metrics scrape at api.testnet.mezo.org

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
+++ b/infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml
@@ -21,8 +21,9 @@ data:
           - targets: ['bridge-worker.default.svc.cluster.local:2112']    
       - job_name: 'api-metrics'
         metrics_path: /api/v2/metrics
+        scheme: https
         static_configs:
-          - targets: ['api.test.mezo.org']
+          - targets: ['api.testnet.mezo.org']
       - job_name: 'blackbox'
         metrics_path: /probe
         params:


### PR DESCRIPTION
References: <!-- add GitHub/Linear issue if one exists -->

### Introduction

We are retiring the legacy `api.test.mezo.org` host in favor of the canonical `api.testnet.mezo.org`. The old host currently 301-redirects to the new one (via the `mezo-api-test-redirect` Worker, soon to be a Cloudflare Redirect Rule). While auditing what still calls the legacy host, staging Prometheus turned out to be the main source of traffic.

### Changes

#### Staging Prometheus `api-metrics` scrape target

`infrastructure/kubernetes/mezo-staging/monitoring/prometheus/configmap.yaml`

- Changed the `api-metrics` job target from `api.test.mezo.org` → `api.testnet.mezo.org`.
- Added `scheme: https` (the job had no scheme, so Prometheus defaulted to `http`; the redirect is `http → https` on a different host, which Prometheus does not follow on scrape). This matches the scheme used by the other jobs and avoids a redirect hop.

Production was already correct (`api.mezo.org`); only staging referenced the legacy host.

### Testing

After deploying the staging monitoring kustomization and reloading Prometheus:

- `up{job="api-metrics"}` should report `1`.
- The target should show `https://api.testnet.mezo.org/api/v2/metrics` and return metrics (HTTP 200), not a 301.

Manually verified out-of-band that `https://api.testnet.mezo.org/api/v2/` is live (auth-gated 403, not 404), and that `http://api.test.mezo.org/api/v2/metrics` returns a `301` to the new host.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord