### PR TITLE
Bump testnet validators and mainnet RPC to v11.0.1

### DIFF
--- a/infrastructure/kubernetes/mezo-production/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-production/helmfile.yaml
@@ -28,6 +28,6 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     values:
       - ./values/mezo-rpc-node.yaml

--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.0
+    version: 12.0.1
     labels:
       type: validator
     values:


### PR DESCRIPTION
### Introduction

Bump our testnet validator nodes and mainnet RPC to mezod v11.0.1 by switching to Validator Kit 12.0.1 which points to this mezod version.

### Changes

- Bump the V-Kit chart version from 12.0.0 to 12.0.1 for all five testnet validator nodes in the staging helmfile
- Bump the V-Kit chart version from 12.0.0 to 12.0.1 for the mainnet RPC node in the production helmfile

### Testing

Already applied everywhere.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
