### PR TITLE
Bump mezod chart to 12.1.0 for shutdown grace period

### DIFF
--- a/infrastructure/kubernetes/mezo-production/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-production/helmfile.yaml
@@ -28,6 +28,6 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     values:
       - ./values/mezo-rpc-node.yaml

--- a/infrastructure/kubernetes/mezo-staging/helmfile.yaml
+++ b/infrastructure/kubernetes/mezo-staging/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     labels:
       type: validator
     values:
@@ -23,7 +23,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     labels:
       type: validator
     values:
@@ -34,7 +34,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     labels:
       type: validator
     values:
@@ -45,7 +45,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     labels:
       type: validator
     values:
@@ -56,7 +56,7 @@ releases:
     installed: true
     namespace: default
     chart: mezo-org/mezod
-    version: 12.0.1
+    version: 12.1.0
     labels:
       type: validator
     values:


### PR DESCRIPTION
Depends on: https://github.com/mezo-org/validator-kit/pull/101

### Introduction

A mezod node killed before it finishes shutting down can be left with a corrupted LevelDB MANIFEST (`leveldb: manifest corrupted (field 'comparer'): missing` on the next start), which makes the node unable to start without a restore. This happened to `mezo-node-3` on the testnet after an unclean stop, and a mainnet validator operator reported the same failure signature independently. The pods currently run with the implicit Kubernetes default of 30 seconds before SIGKILL, which is too tight for a node that must flush state and close five databases on shutdown.

Chart `mezod` 12.1.0 (mezo-org/validator-kit#101) sets `terminationGracePeriodSeconds: 120` on the node pods by default.

### Changes

Bump the `mezo-org/mezod` chart pin from 12.0.1 to 12.1.0 in both helmfiles, covering all five testnet validators (`mezo-staging`) and the mainnet RPC node (`mezo-production`).

### Testing

Both helmfiles parse as valid YAML. `helmfile template` cannot be run until the 12.1.0 chart tag is published from mezo-org/validator-kit#101; the chart itself passes `helm lint` and renders `terminationGracePeriodSeconds: 120` in the StatefulSet pod spec there. Keep this PR as draft until 12.1.0 is published, then roll out with `helmfile apply` per cluster.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
