### PR TITLE
Cut Pyth price-pusher update cost on Mezo

### DIFF
--- a/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml
@@ -6,73 +6,100 @@ metadata:
     app: pyth-scheduler
 data:
   price-config.yaml: |
+    # --- BTC cluster: the push DRIVERS. Deviation 3%. ---
     - alias: SolvBTC/USD
       id: "0xf253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
     - alias: BTC/USD
       id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
-      time_difference: 3600
-      price_deviation: 1
-      confidence_ratio: 75
-    - alias: MUSD/USD
-      id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
-      time_difference: 3600
-      price_deviation: 0.5
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
     - alias: cbBTC/USD
       id: "0x2817d7bfe5c64b8ea956e9a26f573ef64e72e4d7891f2d6af9bcc93f7aff9a97"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+    # --- Stables: near-flat. Rely on the 1h heartbeat; only ride a batch when
+    #     they genuinely move >=3%. early_update suppresses default bundling. ---
+    - alias: MUSD/USD
+      id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
+      time_difference: 7200
+      price_deviation: 3
+      confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: USDC/USD
       id: "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: USDT/USD
       id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: T/USD
       id: "0x7a072b799215196b0ecb6a58636ec312bce8461dcc33c28c3a046b1e636d121d"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
+    # --- Equities ---
     - alias: NVDA/USD
       id: "0xb1073854ed24cbc755dc527418f52b7d271f6cc967bbf8d8129112b18860a593"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: GOOGL/USD
       id: "0x5a48c03e9b9cb337801073ed9d166817473697efff0d138874e0f6a33d6d5aa6"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: TSLA/USD
       id: "0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: MSTR/USD
       id: "0xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: COIN/USD
       id: "0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
     - alias: CRCL/USD
       id: "0x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3
+    # --- MEZO: governance token. 2h heartbeat + only rides a batch on a >=3% move. ---
     - alias: MEZO/USD
       id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
-      time_difference: 3600
-      price_deviation: 1
+      time_difference: 7200
+      price_deviation: 3
       confidence_ratio: 75
+      early_update:
+        price_deviation: 3

--- a/infrastructure/kubernetes/common/pyth-scheduler-mezo/deployment.yaml
+++ b/infrastructure/kubernetes/common/pyth-scheduler-mezo/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - "$(PRICE_SERVICE_ENDPOINT)"
             - "--price-config-file"
             - "/etc/pyth-scheduler/config/price-config.yaml"
+            - "--pushing-frequency"
+            - "30"
           env:
             - name: MEZO_RPC_ENDPOINT
               valueFrom:


### PR DESCRIPTION
## Summary

- Lowers the on-chain cost of the Mezo Pyth scheduler (price pusher) by ~5x
- The tradeoff is that a contract that liquidates or prices collateral off these feeds now need to tolerate up to a 2h-stale price in quiet markets, plus the 3% deviation band.

## Changes

- `infrastructure/kubernetes/common/pyth-scheduler-mezo/configmap.yaml`
  - `price_deviation` raised to **3%** on all feeds (fewer trigger events).
  - **`early_update` block added to every non-driver feed**, restricting it to join a batch only when it has itself moved ≥3% — suppresses the default bundling of feeds that didn't move (the biggest, most reliable lever, since ~80% of cost is per-feed).
  - `time_difference` raised to **7200** (2h staleness heartbeat) on all feeds.
- `infrastructure/kubernetes/common/pyth-scheduler-mezo/deployment.yaml`
  - Added `--pushing-frequency 30` as a burst cap so rapid BTC moves can't push more than every 30s.
