### PR TITLE
Add NEW Pyth price pusher Kubernetes manifests

### DIFF
--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/README.md
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/README.md
@@ -12,7 +12,7 @@ It monitors price feeds and submits updates based on time and price deviation th
 The deployment requires a secret named `pyth-pusher-ethereum-config` with the following keys:
 
 - `endpoint`: RPC endpoint for Ethereum network (e.g., "https://ethereum-rpc.publicnode.com")
-- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x4305FB66699C3B2702D4d05CF36551390A4c69C6")
+- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x14b9932cc9AC8Ee03301665a8644A753f46D8552")
 - `price-service-endpoint`: Hermes price service endpoint (e.g., "https://hermes.pyth.network")
 - `hermes-access-token`: Access token for the Hermes price service
 - `mnemonic`: Mnemonic phrase for the wallet used to submit transactions

--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/README.md
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/README.md
@@ -1,0 +1,65 @@
+# Pyth Scheduler (Price Pusher) Deployment
+
+This directory contains Kubernetes deployment manifests for the Pyth Network price pusher service.
+
+## Overview
+
+The Pyth scheduler pushes price updates from the Pyth Network to the configured Ethereum network.
+It monitors price feeds and submits updates based on time and price deviation thresholds.
+
+## Configuration
+
+The deployment requires a secret named `pyth-pusher-ethereum-config` with the following keys:
+
+- `endpoint`: RPC endpoint for Ethereum network (e.g., "https://ethereum-rpc.publicnode.com")
+- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x4305FB66699C3B2702D4d05CF36551390A4c69C6")
+- `price-service-endpoint`: Hermes price service endpoint (e.g., "https://hermes.pyth.network")
+- `hermes-access-token`: Access token for the Hermes price service
+- `mnemonic`: Mnemonic phrase for the wallet used to submit transactions
+
+## Files
+
+- `deployment.yaml`: Main Kubernetes deployment
+- `kustomization.yaml`: Kustomize configuration for resource management
+- `configmap.yaml`: ConfigMap for price feed configuration
+
+## Usage
+
+1. Create the required secret with your configuration
+2. Run:
+
+  ```Shell
+  kubectl create secret generic pyth-pusher-ethereum-config \
+    --from-literal=mnemonic="your twelve word mnemonic phrase here" \
+    --from-literal=endpoint="<rpc_endpoint>" \
+    --from-literal=pyth-contract-address="<pyth_contract_address>" \
+    --from-literal=price-service-endpoint="https://hermes.pyth.network" \
+    --from-literal=hermes-access-token="<hermes_access_token>" \
+    --namespace=default
+  ```
+
+3. Navigate to mezo-<environment> directory and apply the manifests: `kubectl apply -k .`
+
+## Update configuration commands
+
+```Shell
+  kubectl delete configmap pyth-pusher-ethereum-price-config -n default
+  kubectl apply -k .
+  kubectl rollout restart deployment/pyth-pusher-ethereum -n default
+```
+
+## Add a new price feed
+
+- Add a new price feed to the `configmap.yaml` file
+- Find the price feed ID from the Pyth Feed IDs docs: https://docs.pyth.network/feeds/feed-ids
+by copying the "Stable Price Feed ID" from the table
+- Set the rest of the parameters such as `time_difference`, `price_deviation`, and `confidence_ratio`:
+    - `time_difference`: Time difference in seconds between the price feed and the current time
+    - `price_deviation`: Price deviation in percentage
+    - `confidence_ratio`: Confidence ratio in percentage
+- Run the following commands to apply the changes:
+
+```Shell
+  kubectl apply -k .
+  kubectl rollout restart deployment/pyth-pusher-ethereum -n default
+```

--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pyth-pusher-ethereum-price-config
+  labels:
+    app: pyth-pusher-ethereum
+data:
+  price-config.yaml: |
+    - alias: MUSD/USD
+      id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
+      time_difference: 21600
+      price_deviation: 0.5
+      confidence_ratio: 100
+
+

--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
@@ -11,5 +11,3 @@ data:
       time_difference: 21600
       price_deviation: 0.5
       confidence_ratio: 100
-
-

--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/deployment.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyth-pusher-ethereum
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pyth-pusher-ethereum
+  template:
+    metadata:
+      labels:
+        app: pyth-pusher-ethereum
+    spec:
+      containers:
+        - name: pyth-pusher-ethereum
+          image: public.ecr.aws/pyth-network/xc-price-pusher:v10.5.0
+          imagePullPolicy: Always
+          command:
+            - "npm"
+            - "run"
+            - "start"
+            - "--"
+            - "evm"
+            - "--endpoint"
+            - "$(ETHEREUM_RPC_ENDPOINT)"
+            - "--mnemonic-file"
+            - "$(MNEMONIC_FILE)"
+            - "--pyth-contract-address"
+            - "$(PYTH_CONTRACT_ADDRESS)"
+            - "--price-service-endpoint"
+            - "$(PRICE_SERVICE_ENDPOINT)"
+            - "--price-config-file"
+            - "/etc/pyth-pusher-ethereum/config/price-config.yaml"
+            - "--hermes-access-token"
+            - "$(HERMES_ACCESS_TOKEN)"
+          env:
+            - name: ETHEREUM_RPC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-ethereum-config
+                  key: endpoint
+            - name: MNEMONIC_FILE
+              value: /etc/pyth-pusher-ethereum/secrets/mnemonic
+            - name: PYTH_CONTRACT_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-ethereum-config
+                  key: pyth-contract-address
+            - name: PRICE_SERVICE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-ethereum-config
+                  key: price-service-endpoint
+            - name: HERMES_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-ethereum-config
+                  key: hermes-access-token
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: pyth-pusher-ethereum-config
+              mountPath: /etc/pyth-pusher-ethereum/secrets
+            - name: price-config
+              mountPath: /etc/pyth-pusher-ethereum/config
+      volumes:
+        - name: pyth-pusher-ethereum-config
+          secret:
+            secretName: pyth-pusher-ethereum-config
+            items:
+              - key: mnemonic
+                path: mnemonic
+        - name: price-config
+          configMap:
+            name: pyth-pusher-ethereum-price-config
+            items:
+              - key: price-config.yaml
+                path: price-config.yaml

--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/kustomization.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - configmap.yaml
+
+commonLabels:
+  component: pyth-pusher-ethereum
+  app: pyth-pusher-ethereum
+
+namespace: default

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/README.md
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/README.md
@@ -1,0 +1,65 @@
+# Pyth Scheduler (Price Pusher) Deployment
+
+This directory contains Kubernetes deployment manifests for the Pyth Network price pusher service.
+
+## Overview
+
+The Pyth scheduler pushes price updates from the Pyth Network to the configured Mezo network.
+It monitors price feeds and submits updates based on time and price deviation thresholds.
+
+## Configuration
+
+The deployment requires a secret named `pyth-pusher-mezo-config` with the following keys:
+
+- `endpoint`: RPC endpoint for Mezo network (e.g., "https://rpc.test.mezo.org")
+- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x2880aB155794e7179c9eE2e38200202908C17B43")
+- `price-service-endpoint`: Hermes price service endpoint (e.g., "https://hermes.pyth.network")
+- `hermes-access-token`: Access token for the Hermes price service
+- `mnemonic`: Mnemonic phrase for the wallet used to submit transactions
+
+## Files
+
+- `deployment.yaml`: Main Kubernetes deployment
+- `kustomization.yaml`: Kustomize configuration for resource management
+- `configmap.yaml`: ConfigMap for price feed configuration
+
+## Usage
+
+1. Create the required secret with your configuration
+2. Run:
+
+  ```Shell
+  kubectl create secret generic pyth-pusher-mezo-config \
+    --from-literal=mnemonic="your twelve word mnemonic phrase here" \
+    --from-literal=endpoint="<rpc_endpoint>" \
+    --from-literal=pyth-contract-address="<pyth_contract_address>" \
+    --from-literal=price-service-endpoint="https://hermes.pyth.network" \
+    --from-literal=hermes-access-token="<hermes_access_token>" \
+    --namespace=default
+  ```
+
+3. Navigate to mezo-<environment> directory and apply the manifests: `kubectl apply -k .`
+
+## Update configuration commands
+
+```Shell
+  kubectl delete configmap pyth-pusher-mezo-price-config -n default
+  kubectl apply -k .
+  kubectl rollout restart deployment/pyth-pusher-mezo -n default
+```
+
+## Add a new price feed
+
+- Add a new price feed to the `configmap.yaml` file
+- Find the price feed ID from the Pyth Feed IDs docs: https://docs.pyth.network/feeds/feed-ids
+by copying the "Stable Price Feed ID" from the table
+- Set the rest of the parameters such as `time_difference`, `price_deviation`, and `confidence_ratio`:
+    - `time_difference`: Time difference in seconds between the price feed and the current time
+    - `price_deviation`: Price deviation in percentage
+    - `confidence_ratio`: Confidence ratio in percentage
+- Run the following commands to apply the changes:
+
+```Shell
+  kubectl apply -k .
+  kubectl rollout restart deployment/pyth-pusher-mezo -n default
+```

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/README.md
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/README.md
@@ -12,7 +12,7 @@ It monitors price feeds and submits updates based on time and price deviation th
 The deployment requires a secret named `pyth-pusher-mezo-config` with the following keys:
 
 - `endpoint`: RPC endpoint for Mezo network (e.g., "https://rpc.test.mezo.org")
-- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x2880aB155794e7179c9eE2e38200202908C17B43")
+- `pyth-contract-address`: Address of the Pyth contract on the EVM network (e.g., "0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167")
 - `price-service-endpoint`: Hermes price service endpoint (e.g., "https://hermes.pyth.network")
 - `hermes-access-token`: Access token for the Hermes price service
 - `mnemonic`: Mnemonic phrase for the wallet used to submit transactions

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/configmap.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pyth-pusher-mezo-price-config
+  labels:
+    app: pyth-pusher-mezo
+data:
+  price-config.yaml: |
+    - alias: SolvBTC/USD
+      id: "0xf253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: BTC/USD
+      id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: MUSD/USD
+      id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
+      time_difference: 3600
+      price_deviation: 1
+      confidence_ratio: 75
+    - alias: cbBTC/USD
+      id: "0x2817d7bfe5c64b8ea956e9a26f573ef64e72e4d7891f2d6af9bcc93f7aff9a97"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: USDC/USD
+      id: "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
+      time_difference: 7200
+      price_deviation: 1
+      confidence_ratio: 75
+    - alias: USDT/USD
+      id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
+      time_difference: 7200
+      price_deviation: 1
+      confidence_ratio: 75
+    - alias: T/USD
+      id: "0x7a072b799215196b0ecb6a58636ec312bce8461dcc33c28c3a046b1e636d121d"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: NVDA/USD
+      id: "0xb1073854ed24cbc755dc527418f52b7d271f6cc967bbf8d8129112b18860a593"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: GOOGL/USD
+      id: "0x5a48c03e9b9cb337801073ed9d166817473697efff0d138874e0f6a33d6d5aa6"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: TSLA/USD
+      id: "0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: MSTR/USD
+      id: "0xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: COIN/USD
+      id: "0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: CRCL/USD
+      id: "0x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75
+    - alias: MEZO/USD
+      id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
+      time_difference: 7200
+      price_deviation: 2
+      confidence_ratio: 75

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/deployment.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyth-pusher-mezo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pyth-pusher-mezo
+  template:
+    metadata:
+      labels:
+        app: pyth-pusher-mezo
+    spec:
+      containers:
+        - name: pyth-pusher-mezo
+          image: public.ecr.aws/pyth-network/xc-price-pusher:v10.5.0
+          imagePullPolicy: Always
+          command:
+            - "npm"
+            - "run"
+            - "start"
+            - "--"
+            - "evm"
+            - "--endpoint"
+            - "$(MEZO_RPC_ENDPOINT)"
+            - "--mnemonic-file"
+            - "$(MNEMONIC_FILE)"
+            - "--pyth-contract-address"
+            - "$(PYTH_CONTRACT_ADDRESS)"
+            - "--price-service-endpoint"
+            - "$(PRICE_SERVICE_ENDPOINT)"
+            - "--price-config-file"
+            - "/etc/pyth-pusher-mezo/config/price-config.yaml"
+            - "--hermes-access-token"
+            - "$(HERMES_ACCESS_TOKEN)"
+          env:
+            - name: MEZO_RPC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-mezo-config
+                  key: endpoint
+            - name: MNEMONIC_FILE
+              value: /etc/pyth-pusher-mezo/secrets/mnemonic
+            - name: PYTH_CONTRACT_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-mezo-config
+                  key: pyth-contract-address
+            - name: PRICE_SERVICE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-mezo-config
+                  key: price-service-endpoint
+            - name: HERMES_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-pusher-mezo-config
+                  key: hermes-access-token
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: pyth-pusher-mezo-config
+              mountPath: /etc/pyth-pusher-mezo/secrets
+            - name: price-config
+              mountPath: /etc/pyth-pusher-mezo/config
+      volumes:
+        - name: pyth-pusher-mezo-config
+          secret:
+            secretName: pyth-pusher-mezo-config
+            items:
+              - key: mnemonic
+                path: mnemonic
+        - name: price-config
+          configMap:
+            name: pyth-pusher-mezo-price-config
+            items:
+              - key: price-config.yaml
+                path: price-config.yaml

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/kustomization.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - configmap.yaml
+
+commonLabels:
+  component: pyth-pusher-mezo
+  app: pyth-pusher-mezo
+
+namespace: default

--- a/infrastructure/kubernetes/mezo-production/pyth-pusher-ethereum/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-production/pyth-pusher-ethereum/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common/pyth-pusher-ethereum

--- a/infrastructure/kubernetes/mezo-production/pyth-pusher-mezo/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-production/pyth-pusher-mezo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common/pyth-pusher-mezo

--- a/infrastructure/kubernetes/mezo-staging/pyth-pusher-ethereum/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-staging/pyth-pusher-ethereum/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common/pyth-pusher-ethereum

--- a/infrastructure/kubernetes/mezo-staging/pyth-pusher-mezo/kustomization.yaml
+++ b/infrastructure/kubernetes/mezo-staging/pyth-pusher-mezo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common/pyth-pusher-mezo


### PR DESCRIPTION
## Introduction

Adds Kubernetes deployment manifests for the NEW Pyth Network price pushers targeting the Mezo and Ethereum networks, with staging and production kustomize overlays.

## Changes

- Add `pyth-pusher-mezo` and `pyth-pusher-ethereum` base manifests (deployment, configmap, kustomization, README).
- Add staging and production overlays for both pushers.
- Wire the `--hermes-access-token` flag on both deployments, sourced from the per-deployment config secret, so the pushers authenticate to the Hermes price service.
- Changed Pyth contracts addresses.

## Testing

Manifests validated via kustomize.

New Pyth Core contracts are [here](https://docs.pyth.network/price-feeds/core/upgrade/contracts). Prices are updated by `0x2585618FD0b5656C72918CC7b92207e5B6022DfD` on Mezo and Ethereum.

---

The old Pyth configs will be deleted in a follow up PR once we switch to the new Pyth addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)