### PR TITLE
Remove equities price feeds from Pyth pusher

### DIFF
--- a/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-ethereum/configmap.yaml
@@ -9,5 +9,5 @@ data:
     - alias: MUSD/USD
       id: "0x0617a9b725011a126a2b9fd53563f4236501f32cf76d877644b943394606c6de"
       time_difference: 21600
-      price_deviation: 0.5
+      price_deviation: 1
       confidence_ratio: 100

--- a/infrastructure/kubernetes/common/pyth-pusher-mezo/configmap.yaml
+++ b/infrastructure/kubernetes/common/pyth-pusher-mezo/configmap.yaml
@@ -41,36 +41,6 @@ data:
       time_difference: 7200
       price_deviation: 2
       confidence_ratio: 75
-    - alias: NVDA/USD
-      id: "0xb1073854ed24cbc755dc527418f52b7d271f6cc967bbf8d8129112b18860a593"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
-    - alias: GOOGL/USD
-      id: "0x5a48c03e9b9cb337801073ed9d166817473697efff0d138874e0f6a33d6d5aa6"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
-    - alias: TSLA/USD
-      id: "0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
-    - alias: MSTR/USD
-      id: "0xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
-    - alias: COIN/USD
-      id: "0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
-    - alias: CRCL/USD
-      id: "0x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365"
-      time_difference: 7200
-      price_deviation: 2
-      confidence_ratio: 75
     - alias: MEZO/USD
       id: "0x80beaaedbdd228e77c5d62dfcd74b0305674b7e27a5cc6a46e71bd3a696826df"
       time_difference: 7200


### PR DESCRIPTION
### Introduction

The new Pyth price service subscription plan does not include equities feeds — only the more expensive Pro plan does. This PR drops the equities feeds from the Pyth pusher configuration.

### Changes

- Removed the NVDA, GOOGL, TSLA, MSTR, COIN, and CRCL feeds from the Mezo pusher configmap.
- Relaxed the MUSD/USD price deviation threshold on the Ethereum pusher from `0.5` to `1` to reduce push frequency.

### Testing

Configuration-only change. Verified the resulting YAML parses and that the remaining feed list is unchanged apart from the removed equities entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)