### PR TITLE
Bound and validate eth_getProof storage keys

### DIFF
--- a/rpc/backend/account_info.go
+++ b/rpc/backend/account_info.go
@@ -16,9 +16,11 @@
 package backend
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -52,8 +54,29 @@ func (b *Backend) GetCode(address common.Address, blockNrOrHash rpctypes.BlockNu
 	return res.Code, nil
 }
 
-// GetProof returns an account object with proof and any storage proofs
+// GetProof returns an account object with proof and any storage proofs.
+//
+// The node's GetProofStorageKeysCap setting limits the storage keys as given,
+// which bounds the size of a single request and can be checked before any store
+// is touched. Keys are decoded next, so a malformed key is reported instead of
+// being coerced into the zero key. Repeated keys are then resolved once, so the
+// number of store queries is at most the number of distinct keys.
 func (b *Backend) GetProof(address common.Address, storageKeys []string, blockNrOrHash rpctypes.BlockNumberOrHash) (*rpctypes.AccountResult, error) {
+	if c := b.RPCGetProofStorageKeysCap(); c > 0 && len(storageKeys) > int(c) {
+		return nil, fmt.Errorf("max number of storage keys exceeded (max allowed %v)", c)
+	}
+
+	keys := make([]common.Hash, len(storageKeys))
+
+	for i, storageKey := range storageKeys {
+		key, err := decodeStorageKey(storageKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid storage key at index %d: %w", i, err)
+		}
+
+		keys[i] = key
+	}
+
 	blockNum, err := b.BlockNumberFromTendermint(blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -87,17 +110,35 @@ func (b *Backend) GetProof(address common.Address, storageKeys []string, blockNr
 	// query storage proofs
 	storageProofs := make([]rpctypes.StorageResult, len(storageKeys))
 
-	for i, key := range storageKeys {
-		hexKey := common.HexToHash(key)
-		valueBz, proof, err := b.queryClient.GetProof(clientCtx, evmtypes.StoreKey, evmtypes.StateKey(address, hexKey.Bytes()))
-		if err != nil {
-			return nil, err
+	// A proof is a pure function of the store, the decoded key and the height,
+	// all fixed here, so the same key repeated in one request is queried once.
+	// Each entry gets its own value. The proof slice is shared; nothing
+	// downstream writes to it, it is only serialized into the response.
+	type storageProof struct {
+		valueBz []byte
+		proof   []string
+	}
+	queried := make(map[common.Hash]storageProof, len(keys))
+
+	for i, key := range keys {
+		resolved, ok := queried[key]
+		if !ok {
+			valueBz, proof, err := b.queryClient.GetProof(clientCtx, evmtypes.StoreKey, evmtypes.StateKey(address, key.Bytes()))
+			if err != nil {
+				return nil, err
+			}
+
+			resolved = storageProof{
+				valueBz: valueBz,
+				proof:   GetHexProofs(proof),
+			}
+			queried[key] = resolved
 		}
 
 		storageProofs[i] = rpctypes.StorageResult{
-			Key:   key,
-			Value: (*hexutil.Big)(new(big.Int).SetBytes(valueBz)),
-			Proof: GetHexProofs(proof),
+			Key:   storageKeys[i],
+			Value: (*hexutil.Big)(new(big.Int).SetBytes(resolved.valueBz)),
+			Proof: resolved.proof,
 		}
 	}
 
@@ -133,6 +174,34 @@ func (b *Backend) GetProof(address common.Address, storageKeys []string, blockNr
 		StorageHash:  common.Hash{}, // NOTE: Mezo doesn't have a storage hash. TODO: implement?
 		StorageProof: storageProofs,
 	}, nil
+}
+
+// decodeStorageKey parses an `eth_getProof` storage key into the key it denotes.
+// A key shorter than 32 bytes is left-padded with zeros; an odd number of hex
+// digits is left-padded with one zero digit. Input that is not hex, or longer
+// than 32 bytes, is rejected.
+//
+// The accepted input follows decodeHash from go-ethereum's internal/ethapi
+// package, which cannot be imported.
+func decodeStorageKey(s string) (common.Hash, error) {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
+	}
+
+	if (len(s) & 1) > 0 {
+		s = "0" + s
+	}
+
+	if len(s) > 64 {
+		return common.Hash{}, errors.New("hex string too long, want at most 32 bytes")
+	}
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return common.Hash{}, errors.New("hex string invalid")
+	}
+
+	return common.BytesToHash(b), nil
 }
 
 // GetStorageAt returns the contract storage at the given address, block number, and key.

--- a/rpc/backend/account_info_test.go
+++ b/rpc/backend/account_info_test.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"fmt"
 	"math/big"
+	"strings"
+	"testing"
 
 	"github.com/cometbft/cometbft/libs/bytes"
 
@@ -11,6 +13,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/mezo-org/mezod/rpc/backend/mocks"
@@ -186,6 +189,282 @@ func (suite *BackendTestSuite) TestGetProof() {
 			} else {
 				suite.Require().Error(err)
 			}
+		})
+	}
+}
+
+// registerGetProofMocks wires up everything GetProof queries for a successful
+// call: the block lookup, the EVM account, one proven store query per given
+// storage key, and the account proof. Keys must be given deduplicated, so that
+// the number of registered store queries states how many are expected.
+func (suite *BackendTestSuite) registerGetProofMocks(
+	bn rpctypes.BlockNumber,
+	addr common.Address,
+	storageKeys []string,
+) {
+	suite.backend.ctx = rpctypes.ContextWithHeight(bn.Int64())
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	_, err := RegisterBlock(client, bn.Int64(), nil)
+	suite.Require().NoError(err)
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	RegisterAccount(queryClient, addr, bn.Int64())
+
+	opts := tmrpcclient.ABCIQueryOptions{Height: bn.Int64(), Prove: true}
+
+	for _, key := range storageKeys {
+		RegisterABCIQueryWithOptions(
+			client,
+			bn.Int64(),
+			"store/evm/key",
+			evmtypes.StateKey(addr, common.HexToHash(key).Bytes()),
+			opts,
+		)
+	}
+
+	RegisterABCIQueryWithOptions(
+		client,
+		bn.Int64(),
+		"store/acc/key",
+		bytes.HexBytes(
+			append(
+				authtypes.AddressStoreKeyPrefix,
+				sdk.AccAddress(addr.Bytes())...,
+			),
+		),
+		opts,
+	)
+}
+
+func (suite *BackendTestSuite) TestGetProofStorageKeysCap() {
+	blockNr := rpctypes.NewBlockNumber(big.NewInt(4))
+	address := utiltx.GenerateAddress()
+
+	testCases := []struct {
+		name        string
+		keysCap     int32
+		storageKeys []string
+		expPass     bool
+	}{
+		{
+			"pass - fewer storage keys than the cap",
+			3,
+			[]string{"0x1", "0x2"},
+			true,
+		},
+		{
+			"pass - as many storage keys as the cap",
+			2,
+			[]string{"0x1", "0x2"},
+			true,
+		},
+		{
+			"pass - a cap of zero accepts any number of storage keys",
+			0,
+			[]string{"0x1", "0x2", "0x3"},
+			true,
+		},
+		{
+			"fail - one storage key more than the cap",
+			2,
+			[]string{"0x1", "0x2", "0x3"},
+			false,
+		},
+		{
+			// The cap counts the keys as given, so that it can be applied before
+			// any store is touched, even though repeats cost a single query.
+			"fail - repeated storage keys still count towards the cap",
+			2,
+			[]string{"0x1", "0x1", "0x1"},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest()
+			suite.backend.cfg.JSONRPC.GetProofStorageKeysCap = tc.keysCap
+
+			// Nothing is registered for the failing case on purpose: going over
+			// the cap must be reported before any store is queried.
+			if tc.expPass {
+				suite.registerGetProofMocks(blockNr, address, tc.storageKeys)
+			}
+
+			accRes, err := suite.backend.GetProof(
+				address,
+				tc.storageKeys,
+				rpctypes.BlockNumberOrHash{BlockNumber: &blockNr},
+			)
+
+			if tc.expPass {
+				suite.Require().NoError(err)
+				suite.Require().Len(accRes.StorageProof, len(tc.storageKeys))
+			} else {
+				suite.Require().EqualError(err, "max number of storage keys exceeded (max allowed 2)")
+				suite.Require().Nil(accRes)
+			}
+		})
+	}
+}
+
+func (suite *BackendTestSuite) TestGetProofInvalidStorageKeys() {
+	blockNr := rpctypes.NewBlockNumber(big.NewInt(4))
+	address := utiltx.GenerateAddress()
+
+	testCases := []struct {
+		name        string
+		storageKeys []string
+		expErr      string
+	}{
+		{
+			"fail - storage key is not hex",
+			[]string{"0xzz"},
+			"invalid storage key at index 0: hex string invalid",
+		},
+		{
+			"fail - storage key is longer than 32 bytes",
+			[]string{"0x1", "0x" + strings.Repeat("ff", 33)},
+			"invalid storage key at index 1: hex string too long, want at most 32 bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest()
+
+			// No mocks are registered: a malformed key must be reported before
+			// any store is queried, so any query here fails the test.
+			accRes, err := suite.backend.GetProof(
+				address,
+				tc.storageKeys,
+				rpctypes.BlockNumberOrHash{BlockNumber: &blockNr},
+			)
+
+			suite.Require().EqualError(err, tc.expErr)
+			suite.Require().Nil(accRes)
+		})
+	}
+}
+
+func (suite *BackendTestSuite) TestGetProofRepeatedStorageKeys() {
+	blockNr := rpctypes.NewBlockNumber(big.NewInt(4))
+	address := utiltx.GenerateAddress()
+
+	// Three spellings of the same storage key, so one store query is registered.
+	suite.registerGetProofMocks(blockNr, address, []string{"0x1"})
+
+	accRes, err := suite.backend.GetProof(
+		address,
+		[]string{
+			"0x1",
+			"0x01",
+			"0x0000000000000000000000000000000000000000000000000000000000000001",
+		},
+		rpctypes.BlockNumberOrHash{BlockNumber: &blockNr},
+	)
+	suite.Require().NoError(err)
+
+	// One proven query for the repeated storage key plus one for the account.
+	suite.backend.clientCtx.Client.(*mocks.Client).
+		AssertNumberOfCalls(suite.T(), "ABCIQueryWithOptions", 2)
+
+	// Every position is answered, and each key is echoed as it was asked for.
+	suite.Require().Len(accRes.StorageProof, 3)
+	suite.Require().Equal("0x1", accRes.StorageProof[0].Key)
+	suite.Require().Equal("0x01", accRes.StorageProof[1].Key)
+	suite.Require().Equal(
+		"0x0000000000000000000000000000000000000000000000000000000000000001",
+		accRes.StorageProof[2].Key,
+	)
+
+	for _, storageProof := range accRes.StorageProof {
+		suite.Require().Equal(accRes.StorageProof[0].Value, storageProof.Value)
+		suite.Require().Equal(accRes.StorageProof[0].Proof, storageProof.Proof)
+	}
+}
+
+func TestDecodeStorageKey(t *testing.T) {
+	testCases := []struct {
+		name   string
+		key    string
+		expKey common.Hash
+		expErr string
+	}{
+		{
+			"a full 32-byte key is taken as it is",
+			"0x00000000000000000000000000000000000000000000000000000000000000ff",
+			common.HexToHash("0xff"),
+			"",
+		},
+		{
+			"a key shorter than 32 bytes is left-padded",
+			"0x0102",
+			common.HexToHash("0x0102"),
+			"",
+		},
+		{
+			"an odd number of hex digits is left-padded",
+			"0x1",
+			common.HexToHash("0x01"),
+			"",
+		},
+		{
+			"the 0X prefix is accepted",
+			"0X0102",
+			common.HexToHash("0x0102"),
+			"",
+		},
+		{
+			"a key without a prefix is accepted",
+			"0102",
+			common.HexToHash("0x0102"),
+			"",
+		},
+		{
+			"upper-case hex digits are accepted",
+			"0xABcd",
+			common.HexToHash("0xabcd"),
+			"",
+		},
+		{
+			"an empty key denotes the zero key",
+			"",
+			common.Hash{},
+			"",
+		},
+		{
+			"a bare prefix denotes the zero key",
+			"0x",
+			common.Hash{},
+			"",
+		},
+		{
+			"a key longer than 32 bytes is rejected",
+			"0x" + strings.Repeat("ff", 33),
+			common.Hash{},
+			"hex string too long, want at most 32 bytes",
+		},
+		{
+			"a key that is not hex is rejected",
+			"0xzz",
+			common.Hash{},
+			"hex string invalid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := decodeStorageKey(tc.key)
+
+			if tc.expErr != "" {
+				require.EqualError(t, err, tc.expErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expKey, key)
 		})
 	}
 }

--- a/rpc/backend/node_info.go
+++ b/rpc/backend/node_info.go
@@ -360,3 +360,9 @@ func (b *Backend) SimulateDisabled() bool {
 func (b *Backend) RPCLogsFilterAddrCap() int32 {
 	return b.cfg.JSONRPC.LogsFilterAddrCap
 }
+
+// RPCGetProofStorageKeysCap returns the maximum number of storage keys accepted in a
+// single `eth_getProof` query.
+func (b *Backend) RPCGetProofStorageKeysCap() int32 {
+	return b.cfg.JSONRPC.GetProofStorageKeysCap
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -118,6 +118,12 @@ const (
 	// DefaultLogsFilterAddrCap is the default maximum number of contract addresses in the
 	// filter query for logs calls (`eth_getLogs` and `eth_subscribe` with `logs` parameter).
 	DefaultLogsFilterAddrCap = 30
+
+	// DefaultGetProofStorageKeysCap is the default maximum number of storage keys
+	// accepted in a single `eth_getProof` query. A proof is computed per distinct
+	// key, so the cap keeps the work of one call bounded. The value is well above
+	// what regular proof consumers ask for in one call.
+	DefaultGetProofStorageKeysCap int32 = 1000
 )
 
 var evmTracers = []string{"json", "markdown", "struct", "access_list"}
@@ -191,6 +197,9 @@ type JSONRPCConfig struct {
 	// LogsFilterAddrCap returns the maximum number of contract addresses in the filter query for
 	// logs calls (`eth_getLogs` and `eth_subscribe` with `logs` parameter).
 	LogsFilterAddrCap int32 `mapstructure:"logs-filter-addr-cap"`
+	// GetProofStorageKeysCap defines the maximum number of storage keys accepted in a
+	// single `eth_getProof` query.
+	GetProofStorageKeysCap int32 `mapstructure:"get-proof-storage-keys-cap"`
 }
 
 // TLSConfig defines the certificate and matching private key for the server.
@@ -318,6 +327,7 @@ func DefaultJSONRPCConfig() *JSONRPCConfig {
 		MetricsAddress:           DefaultJSONRPCMetricsAddress,
 		FixRevertGasRefundHeight: DefaultFixRevertGasRefundHeight,
 		LogsFilterAddrCap:        DefaultLogsFilterAddrCap,
+		GetProofStorageKeysCap:   DefaultGetProofStorageKeysCap,
 		SimulateDisabled:         false,
 	}
 }
@@ -362,6 +372,10 @@ func (c JSONRPCConfig) Validate() error {
 
 	if c.LogsFilterAddrCap < 0 {
 		return errors.New("JSON-RPC logs filter address cap cannot be negative")
+	}
+
+	if c.GetProofStorageKeysCap < 0 {
+		return errors.New("JSON-RPC get proof storage keys cap cannot be negative")
 	}
 
 	// check for duplicates
@@ -470,6 +484,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			FixRevertGasRefundHeight: v.GetInt64("json-rpc.fix-revert-gas-refund-height"),
 			AllowUnprotectedTxs:      v.GetBool("json-rpc.allow-unprotected-txs"),
 			LogsFilterAddrCap:        v.GetInt32("json-rpc.logs-filter-addr-cap"),
+			GetProofStorageKeysCap:   v.GetInt32("json-rpc.get-proof-storage-keys-cap"),
 			SimulateDisabled:         v.GetBool("json-rpc.simulate-disabled"),
 		},
 		TLS: TLSConfig{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +12,41 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, cfg.JSONRPC.Enable)
 	require.Equal(t, cfg.JSONRPC.Address, DefaultJSONRPCAddress)
 	require.Equal(t, cfg.JSONRPC.WsAddress, DefaultJSONRPCWsAddress)
+}
+
+func TestDefaultConfigLimitsGetProofStorageKeys(t *testing.T) {
+	// A zero cap means no limit, so the default must be a real number to keep
+	// the work of a single `eth_getProof` call bounded out of the box.
+	require.Positive(t, DefaultGetProofStorageKeysCap)
+	require.Equal(t, DefaultGetProofStorageKeysCap, DefaultConfig().JSONRPC.GetProofStorageKeysCap)
+}
+
+func TestJSONRPCConfigValidate(t *testing.T) {
+	t.Run("accepts the defaults", func(t *testing.T) {
+		require.NoError(t, DefaultJSONRPCConfig().Validate())
+	})
+
+	t.Run("accepts a get proof storage keys cap of zero", func(t *testing.T) {
+		cfg := DefaultJSONRPCConfig()
+		cfg.GetProofStorageKeysCap = 0
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("rejects a negative get proof storage keys cap", func(t *testing.T) {
+		cfg := DefaultJSONRPCConfig()
+		cfg.GetProofStorageKeysCap = -1
+		require.EqualError(t, cfg.Validate(), "JSON-RPC get proof storage keys cap cannot be negative")
+	})
+}
+
+// TestGetConfigReadsGetProofStorageKeysCap pins the name the setting is read
+// under. Without it, reading the value under a name that does not match the
+// `app.toml` key and the CLI flag would leave the setting with no effect.
+func TestGetConfigReadsGetProofStorageKeysCap(t *testing.T) {
+	v := viper.New()
+	v.Set("json-rpc.get-proof-storage-keys-cap", 7)
+
+	cfg, err := GetConfig(v)
+	require.NoError(t, err)
+	require.Equal(t, int32(7), cfg.JSONRPC.GetProofStorageKeysCap)
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -107,6 +107,10 @@ fix-revert-gas-refund-height = {{ .JSONRPC.FixRevertGasRefundHeight }}
 # logs calls ('eth_getLogs' and 'eth_subscribe' with 'logs' parameter). Value 0 means no cap.
 logs-filter-addr-cap = {{ .JSONRPC.LogsFilterAddrCap }}
 
+# GetProofStorageKeysCap defines the maximum number of storage keys accepted in a single
+# 'eth_getProof' query. Value 0 means no cap.
+get-proof-storage-keys-cap = {{ .JSONRPC.GetProofStorageKeysCap }}
+
 ###############################################################################
 ###                             TLS Configuration                           ###
 ###############################################################################

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -72,6 +72,7 @@ const (
 	JSONRPCMetricsAddress           = "json-rpc.metrics-address"
 	JSONRPCFixRevertGasRefundHeight = "json-rpc.fix-revert-gas-refund-height"
 	JSONRPCLogsFilterAddrCap        = "json-rpc.logs-filter-addr-cap"
+	JSONRPCGetProofStorageKeysCap   = "json-rpc.get-proof-storage-keys-cap"
 )
 
 // EVM flags

--- a/server/start.go
+++ b/server/start.go
@@ -217,6 +217,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Bool(srvflags.JSONRPCEnableMetrics, false, "Define if EVM rpc metrics server should be enabled")
 	cmd.Flags().String(srvflags.JSONRPCMetricsAddress, config.DefaultJSONRPCMetricsAddress, "the JSON-RPC metrics server address to listen on")
 	cmd.Flags().Int32(srvflags.JSONRPCLogsFilterAddrCap, config.DefaultLogsFilterAddrCap, "Sets the maximum number of contract addresses in the filter query for logs calls. Value 0 means no cap")
+	cmd.Flags().Int32(srvflags.JSONRPCGetProofStorageKeysCap, config.DefaultGetProofStorageKeysCap, "Sets the maximum number of storage keys accepted in a single 'eth_getProof' query. Value 0 means no cap") //nolint:lll
 
 	cmd.Flags().String(srvflags.EVMTracer, config.DefaultEVMTracer, "the EVM tracer type to collect execution traces from the EVM transaction execution (json|struct|access_list|markdown)") //nolint:lll
 	cmd.Flags().Uint64(srvflags.EVMMaxTxGasWanted, config.DefaultMaxTxGasWanted, "the gas wanted for each eth tx returned in ante handler in check tx mode")                                 //nolint:lll


### PR DESCRIPTION
### Introduction

`eth_getProof` computes one proven store query per entry in the `storageKeys` array. Until now the length of that array was unbounded, a key repeated within one call was queried once per occurrence, and the key format was never validated. That left it as the only heavy read method on the `eth` namespace without a configurable bound on the work a single call can request, while its peers already have one: `eth_call` is bounded by `json-rpc.gas-cap` and `json-rpc.evm-timeout`, and `eth_getLogs` by `json-rpc.logs-cap` and `json-rpc.block-range-cap`.

This PR brings `eth_getProof` in line with those methods and corrects how it handles storage keys, so the work of a single call is bounded and predictable and malformed input is reported instead of being silently reinterpreted. Responses are unchanged for every input: storage keys are echoed back exactly as the caller sent them, as before.

### Changes

#### New `json-rpc.get-proof-storage-keys-cap` setting

A new node setting limits how many storage keys a single `eth_getProof` call may ask for. It defaults to `1000`, and `0` means no cap, which is the same convention `logs-filter-addr-cap` already uses. A call above the cap is rejected with `max number of storage keys exceeded (max allowed N)`.

The setting is plumbed through the same seven places as the existing caps: the default constant and struct field in `server/config/config.go`, `JSONRPCConfig.Validate` (a negative value fails node startup), the viper read in `GetConfig`, the `app.toml` template in `server/config/toml.go`, the flag name in `server/flags/flags.go`, the flag registration in `server/start.go`, and a backend accessor in `rpc/backend/node_info.go`. The keys are counted as given, including repeats, so the limit applies before any store is touched.

Because the start command binds its flags into the server context that the JSON-RPC backend reads its config from, existing nodes pick up the default without editing `app.toml`. Operators who need the previous unbounded behaviour can set `get-proof-storage-keys-cap = 0`.

#### Storage keys are decoded before any store access

`rpc/backend/account_info.go` now decodes every storage key up front and rejects input that is not valid hex or is longer than 32 bytes, naming the index of the offending key. Previously `common.HexToHash` silently coerced such input, so a caller naming a malformed key was answered with a proof of slot 0, and a key longer than 32 bytes was answered with a proof of a slot it had not named. The accepted input follows `decodeHash` from go-ethereum's `internal/ethapi` package, which cannot be imported, so keys shorter than 32 bytes are still accepted and left-padded, as before.

#### A repeated storage key is resolved once

A proof depends only on the store, the decoded key and the height, all of which are fixed within a single call, so a key appearing more than once in one request is now queried once and the result reused for each position that asks for it. The response keeps one entry per requested position, so this is not observable on the wire.

### Testing

Unit tests were added in `rpc/backend/account_info_test.go` and `server/config/config_test.go`:

- the cap boundary from both sides (a call at the cap is served, one key more is rejected), the `0` means no cap branch, and that repeats count towards the cap
- rejection of non-hex and over-long keys, asserted with no store mocks registered, which pins that decoding happens before any store access rather than only pinning the error text
- de-duplication, pinned by the number of store queries actually issued rather than by the response alone
- the decode helper against the full range of key spellings, including `0x`/`0X` prefixes, unprefixed input, odd digit counts, empty input and the two rejection cases
- that the setting is read under the same name it is written under in `app.toml` and registered under as a flag

`make test-unit` passes (43 packages, `-race`).

The behaviour was also verified end to end against a localnode, comparing a binary built from this branch against one built from `main`:

- for a normal request of two canonical 32-byte keys, and for a request at the cap, the full JSON response is **identical** between the two binaries, confirming no change for ordinary callers
- for a request repeating one key under several spellings the response is served from a single store query, with one entry per requested position and each key echoed as it was sent
- a malformed key and an over-long key are rejected with the index named; a request above the cap is rejected
- the cap was observed taking effect at three different values, set via the default, via `app.toml` and via the CLI flag, and `0` restored the previous unbounded behaviour
- a fresh `init` renders `get-proof-storage-keys-cap = 1000` into `app.toml`

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
