### PR TITLE
Raise JSON-RPC logs filter address cap on testnet nodes

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -7,7 +7,8 @@ env:
 
 customConfigs:
   enabled: true
-  appTomlTxt: ""
+  appTomlTxt: |
+    json-rpc.logs-filter-addr-cap=100
   clientTomlTxt: ""
   configTomlTxt: |
     statesync.enable=true

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -6,7 +6,8 @@ env:
 
 customConfigs:
   enabled: true
-  appTomlTxt: ""
+  appTomlTxt: |
+    json-rpc.logs-filter-addr-cap=100
   clientTomlTxt: ""
   configTomlTxt: |
     statesync.enable=true

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -6,7 +6,8 @@ env:
 
 customConfigs:
   enabled: true
-  appTomlTxt: ""
+  appTomlTxt: |
+    json-rpc.logs-filter-addr-cap=100
   clientTomlTxt: ""
   configTomlTxt: |
     statesync.enable=true

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -4,6 +4,13 @@ env:
   PUBLIC_IP: "34.170.77.124" # mezo-staging-node-3-external-ip
   MEZOD_MONIKER: "mezo-node-3"
 
+customConfigs:
+  enabled: true
+  appTomlTxt: |
+    json-rpc.logs-filter-addr-cap=100
+  clientTomlTxt: ""
+  configTomlTxt: ""
+
 secrets:
   credentials: "mezo-node-3" # created manually
 

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -6,7 +6,8 @@ env:
 
 customConfigs:
   enabled: true
-  appTomlTxt: ""
+  appTomlTxt: |
+    json-rpc.logs-filter-addr-cap=100
   clientTomlTxt: ""
   configTomlTxt: |
     statesync.enable=true


### PR DESCRIPTION
### Introduction

The testnet nodes accept at most 30 contract addresses per `eth_getLogs` call and per `logs` subscription, which is the `mezod` default for `json-rpc.logs-filter-addr-cap`. Clients watching more contracts than that have to split one query into several. This raises the cap to 100 on all five testnet nodes.

### Changes

#### Custom `app.toml` settings for testnet nodes

Every `mezo-staging` node now carries `json-rpc.logs-filter-addr-cap=100` in its `customConfigs.appTomlTxt`. The chart writes this value into a per-node ConfigMap, and the node entrypoint applies it to `app.toml` on every container start.

`mezo-node-0`, `mezo-node-1`, `mezo-node-2`, and `mezo-node-4` already had a `customConfigs` block, so they only gain the new setting. `mezo-node-3` had none, so it gains the whole block along with the ConfigMap and its volume mounts.

The `mezo-production` cluster is untouched, so mainnet keeps the default cap of 30.

### Testing

The change is already applied on `mezo-staging`, one node at a time, waiting for each pod to become ready before moving to the next. All five nodes are healthy and the chain keeps producing blocks. `helmfile diff` is empty after the rollout, so the cluster matches this branch.

`app.toml` reports `logs-filter-addr-cap = 100` on all five nodes.

`eth_getLogs` against `mezo-node-0` and `mezo-node-3` confirms where the new limit sits:

| Addresses in query | Result |
|---|---|
| 35 | accepted (rejected before this change) |
| 100 | accepted |
| 101 | `max number of addresses exceeded (max allowed 100)` |

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
