### PR TITLE
Make EVM trace query tracers and timeout configurable

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -379,6 +379,7 @@ func NewMezo(
 	tracer := cast.ToString(appOpts.Get(srvflags.EVMTracer))
 	ethCallGasCap := cast.ToUint64(appOpts.Get(srvflags.JSONRPCGasCap))
 	ethCallTimeout := cast.ToDuration(appOpts.Get(srvflags.JSONRPCEVMTimeout))
+	enableJSTracers := cast.ToBool(appOpts.Get(srvflags.JSONRPCEnableJSTracers))
 
 	app.FeeMarketKeeper = feemarketkeeper.NewKeeper(
 		appCodec, authority,
@@ -412,6 +413,7 @@ func NewMezo(
 		tracer,
 		ethCallGasCap,
 		ethCallTimeout,
+		enableJSTracers,
 		app.GetSubspace(evmtypes.ModuleName),
 	)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -124,6 +124,12 @@ const (
 	// key, so the cap keeps the work of one call bounded. The value is well above
 	// what regular proof consumers ask for in one call.
 	DefaultGetProofStorageKeysCap int32 = 1000
+
+	// DefaultEnableJSTracers is the default setting for custom JavaScript tracers
+	// in trace queries. Disabled because such a tracer runs caller-supplied code
+	// that cannot be interrupted, so it can exhaust node resources. Enable it for
+	// debugging only, and only temporarily.
+	DefaultEnableJSTracers = false
 )
 
 var evmTracers = []string{"json", "markdown", "struct", "access_list"}
@@ -200,6 +206,9 @@ type JSONRPCConfig struct {
 	// GetProofStorageKeysCap defines the maximum number of storage keys accepted in a
 	// single `eth_getProof` query.
 	GetProofStorageKeysCap int32 `mapstructure:"get-proof-storage-keys-cap"`
+	// EnableJSTracers lets trace queries run custom JavaScript tracers. While
+	// false, only the native tracers are accepted.
+	EnableJSTracers bool `mapstructure:"enable-js-tracers"`
 }
 
 // TLSConfig defines the certificate and matching private key for the server.
@@ -329,6 +338,7 @@ func DefaultJSONRPCConfig() *JSONRPCConfig {
 		LogsFilterAddrCap:        DefaultLogsFilterAddrCap,
 		GetProofStorageKeysCap:   DefaultGetProofStorageKeysCap,
 		SimulateDisabled:         false,
+		EnableJSTracers:          DefaultEnableJSTracers,
 	}
 }
 
@@ -486,6 +496,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			LogsFilterAddrCap:        v.GetInt32("json-rpc.logs-filter-addr-cap"),
 			GetProofStorageKeysCap:   v.GetInt32("json-rpc.get-proof-storage-keys-cap"),
 			SimulateDisabled:         v.GetBool("json-rpc.simulate-disabled"),
+			EnableJSTracers:          v.GetBool("json-rpc.enable-js-tracers"),
 		},
 		TLS: TLSConfig{
 			CertificatePath: v.GetString("tls.certificate-path"),

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -48,6 +48,14 @@ enable = {{ .JSONRPC.Enable }}
 # gRPC layer, restrict access to that port at the network level.
 simulate-disabled = {{ .JSONRPC.SimulateDisabled }}
 
+# EnableJSTracers lets trace queries run custom JavaScript tracers. Such a
+# tracer runs caller-supplied code that cannot be interrupted and can exhaust
+# node resources, so it is disabled by default and only the native tracers
+# (callTracer, prestateTracer, ...) are accepted. Enable it for debugging only,
+# and only temporarily. The setting is enforced in the keeper, so it covers the
+# SDK gRPC port (default 9090) and the REST gateway as well.
+enable-js-tracers = {{ .JSONRPC.EnableJSTracers }}
+
 # Address defines the EVM RPC HTTP server address to bind to.
 address = "{{ .JSONRPC.Address }}"
 

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -73,6 +73,7 @@ const (
 	JSONRPCFixRevertGasRefundHeight = "json-rpc.fix-revert-gas-refund-height"
 	JSONRPCLogsFilterAddrCap        = "json-rpc.logs-filter-addr-cap"
 	JSONRPCGetProofStorageKeysCap   = "json-rpc.get-proof-storage-keys-cap"
+	JSONRPCEnableJSTracers          = "json-rpc.enable-js-tracers"
 )
 
 // EVM flags

--- a/server/start.go
+++ b/server/start.go
@@ -217,7 +217,8 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Bool(srvflags.JSONRPCEnableMetrics, false, "Define if EVM rpc metrics server should be enabled")
 	cmd.Flags().String(srvflags.JSONRPCMetricsAddress, config.DefaultJSONRPCMetricsAddress, "the JSON-RPC metrics server address to listen on")
 	cmd.Flags().Int32(srvflags.JSONRPCLogsFilterAddrCap, config.DefaultLogsFilterAddrCap, "Sets the maximum number of contract addresses in the filter query for logs calls. Value 0 means no cap")
-	cmd.Flags().Int32(srvflags.JSONRPCGetProofStorageKeysCap, config.DefaultGetProofStorageKeysCap, "Sets the maximum number of storage keys accepted in a single 'eth_getProof' query. Value 0 means no cap") //nolint:lll
+	cmd.Flags().Int32(srvflags.JSONRPCGetProofStorageKeysCap, config.DefaultGetProofStorageKeysCap, "Sets the maximum number of storage keys accepted in a single 'eth_getProof' query. Value 0 means no cap")     //nolint:lll
+	cmd.Flags().Bool(srvflags.JSONRPCEnableJSTracers, config.DefaultEnableJSTracers, "Allow trace queries to run custom JavaScript tracers. Disabled by default; enable for debugging only, and only temporarily") //nolint:lll
 
 	cmd.Flags().String(srvflags.EVMTracer, config.DefaultEVMTracer, "the EVM tracer type to collect execution traces from the EVM transaction execution (json|struct|access_list|markdown)") //nolint:lll
 	cmd.Flags().Uint64(srvflags.EVMMaxTxGasWanted, config.DefaultMaxTxGasWanted, "the gas wanted for each eth tx returned in ante handler in check tx mode")                                 //nolint:lll

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -799,6 +799,17 @@ func (k *Keeper) traceTx(
 	}
 
 	if len(traceConfig.Tracer) != 0 {
+		// An unknown tracer name is evaluated as JavaScript. Such a tracer runs
+		// caller-supplied code during construction, before the timeout below is
+		// in place, and cannot be interrupted once it starts. Accept it only
+		// when the operator opted in.
+		if !k.enableJSTracers && tracers.DefaultDirectory.IsJS(traceConfig.Tracer) {
+			return nil, 0, status.Error(
+				codes.InvalidArgument,
+				"custom JavaScript tracers are disabled, only native tracers are accepted",
+			)
+		}
+
 		tracer, err = tracers.DefaultDirectory.New(traceConfig.Tracer, tCtx, tracerJSONConfig, cfg.ChainConfig)
 		if err != nil {
 			return nil, 0, status.Error(codes.Internal, err.Error())
@@ -810,6 +821,12 @@ func (k *Keeper) traceTx(
 		if timeout, err = time.ParseDuration(traceConfig.Timeout); err != nil {
 			return nil, 0, status.Errorf(codes.InvalidArgument, "timeout value: %s", err.Error())
 		}
+	}
+
+	// Cap the caller-supplied timeout at the node's json-rpc.evm-timeout.
+	// A zero server timeout disables the cap ("0=infinite").
+	if k.ethCallTimeout > 0 && timeout > k.ethCallTimeout {
+		timeout = k.ethCallTimeout
 	}
 
 	// Handle timeouts and RPC cancellations

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -1004,6 +1004,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 		{
 			msg: "javascript tracer",
 			malleate: func() {
+				suite.app.EvmKeeper.SetEnableJSTracers(true)
 				traceConfig = &types.TraceConfig{
 					Tracer: "{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0)); }, result: function() { return this.data; }}",
 				}
@@ -1029,6 +1030,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 		{
 			msg: "javascript tracer with enableFeemarket",
 			malleate: func() {
+				suite.app.EvmKeeper.SetEnableJSTracers(true)
 				traceConfig = &types.TraceConfig{
 					Tracer: "{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0)); }, result: function() { return this.data; }}",
 				}
@@ -1249,6 +1251,118 @@ func (suite *KeeperTestSuite) TestTraceTxNativeTracers() {
 	suite.Require().NotNil(keccakTrace)
 }
 
+// TestTraceJSTracersDisabled checks that trace queries reject a custom
+// JavaScript tracer while the operator has not enabled them. The payload runs
+// an endless loop as soon as it is constructed, so a regression here hangs the
+// query instead of failing it, and the test times out rather than reporting a
+// wrong result.
+func (suite *KeeperTestSuite) TestTraceJSTracersDisabled() {
+	suite.SetupTest()
+
+	contractAddr := suite.DeployTestContract(
+		suite.T(),
+		suite.address,
+		sdkmath.NewIntWithDecimal(1000, 18).BigInt(),
+	)
+	suite.Commit()
+
+	recipient := common.HexToAddress("0x378c50D9264C63F3F92B806d4ee56E9D86FfB3Ec")
+	txMsg := suite.TransferERC20Token(
+		suite.T(),
+		contractAddr,
+		suite.address,
+		recipient,
+		sdkmath.NewIntWithDecimal(1, 18).BigInt(),
+	)
+	suite.Commit()
+
+	endlessLoopTracer := &types.TraceConfig{Tracer: "function(){for(;;){}}()"}
+
+	_, err := suite.queryClient.TraceTx(suite.ctx, &types.QueryTraceTxRequest{
+		Msg:         txMsg,
+		TraceConfig: endlessLoopTracer,
+	})
+	suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+	suite.Require().ErrorContains(err, "custom JavaScript tracers are disabled")
+
+	_, err = suite.queryClient.TraceBlock(suite.ctx, &types.QueryTraceBlockRequest{
+		Txs:         []*types.MsgEthereumTx{txMsg},
+		TraceConfig: endlessLoopTracer,
+	})
+	suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+	suite.Require().ErrorContains(err, "custom JavaScript tracers are disabled")
+}
+
+// TestTraceJSTracersEnabled checks that the operator opt-in actually lets a
+// custom JavaScript tracer run.
+func (suite *KeeperTestSuite) TestTraceJSTracersEnabled() {
+	suite.SetupTest()
+	suite.app.EvmKeeper.SetEnableJSTracers(true)
+
+	contractAddr := suite.DeployTestContract(
+		suite.T(),
+		suite.address,
+		sdkmath.NewIntWithDecimal(1000, 18).BigInt(),
+	)
+	suite.Commit()
+
+	recipient := common.HexToAddress("0x378c50D9264C63F3F92B806d4ee56E9D86FfB3Ec")
+	txMsg := suite.TransferERC20Token(
+		suite.T(),
+		contractAddr,
+		suite.address,
+		recipient,
+		sdkmath.NewIntWithDecimal(1, 18).BigInt(),
+	)
+	suite.Commit()
+
+	opcodeCounter := "{counts: {}, fault: function(log) {}, step: function(log) { var op = log.op.toString(); this.counts[op] = (this.counts[op] || 0) + 1; }, result: function() { return this.counts; }}"
+
+	trace, err := suite.queryClient.TraceTx(suite.ctx, &types.QueryTraceTxRequest{
+		Msg:         txMsg,
+		TraceConfig: &types.TraceConfig{Tracer: opcodeCounter},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Contains(string(trace.Data), "SSTORE")
+}
+
+// TestTraceTimeoutCappedAtEthCallTimeout checks that a caller-supplied trace
+// timeout is capped at the node's json-rpc.evm-timeout. The tracer loops inside
+// step(), so it only stops when the deadline watcher interrupts it. With a huge
+// caller timeout, the query returns only because the cap shrinks the deadline
+// to the node ceiling; without the cap the deadline would be an hour and the
+// test would hang.
+func (suite *KeeperTestSuite) TestTraceTimeoutCappedAtEthCallTimeout() {
+	suite.SetupTest()
+	suite.app.EvmKeeper.SetEnableJSTracers(true)
+	suite.app.EvmKeeper.SetEthCallTimeout(200 * time.Millisecond)
+
+	contractAddr := suite.DeployTestContract(
+		suite.T(),
+		suite.address,
+		sdkmath.NewIntWithDecimal(1000, 18).BigInt(),
+	)
+	suite.Commit()
+
+	recipient := common.HexToAddress("0x378c50D9264C63F3F92B806d4ee56E9D86FfB3Ec")
+	txMsg := suite.TransferERC20Token(
+		suite.T(),
+		contractAddr,
+		suite.address,
+		recipient,
+		sdkmath.NewIntWithDecimal(1, 18).BigInt(),
+	)
+	suite.Commit()
+
+	stepLoopTracer := "{fault:function(){}, step:function(){for(;;){}}, result:function(){return {}}}"
+
+	_, err := suite.queryClient.TraceTx(suite.ctx, &types.QueryTraceTxRequest{
+		Msg:         txMsg,
+		TraceConfig: &types.TraceConfig{Tracer: stepLoopTracer, Timeout: "1h"},
+	})
+	suite.Require().Error(err)
+}
+
 func (suite *KeeperTestSuite) TestTraceBlock() {
 	var (
 		txs         []*types.MsgEthereumTx
@@ -1286,6 +1400,7 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 		{
 			msg: "javascript tracer",
 			malleate: func() {
+				suite.app.EvmKeeper.SetEnableJSTracers(true)
 				traceConfig = &types.TraceConfig{
 					Tracer: "{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0)); }, result: function() { return this.data; }}",
 				}
@@ -1309,6 +1424,7 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 		{
 			msg: "javascript tracer with enableFeemarket",
 			malleate: func() {
+				suite.app.EvmKeeper.SetEnableJSTracers(true)
 				traceConfig = &types.TraceConfig{
 					Tracer: "{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0)); }, result: function() { return this.data; }}",
 				}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -85,6 +85,8 @@ type Keeper struct {
 	ethCallGasCap uint64
 	// Execution timeout used by direct EthCall queries.
 	ethCallTimeout time.Duration
+	// Whether trace queries accept custom JavaScript tracers.
+	enableJSTracers bool
 
 	// EVM Hooks for tx post-processing
 	hooks types.EvmHooks
@@ -108,6 +110,7 @@ func NewKeeper(
 	tracer string,
 	ethCallGasCap uint64,
 	ethCallTimeout time.Duration,
+	enableJSTracers bool,
 	ss paramstypes.Subspace,
 ) *Keeper {
 	// ensure evm module account is set
@@ -134,6 +137,7 @@ func NewKeeper(
 		tracer:            tracer,
 		ethCallGasCap:     ethCallGasCap,
 		ethCallTimeout:    ethCallTimeout,
+		enableJSTracers:   enableJSTracers,
 		ss:                ss,
 		customPrecompiles: make(map[common.Address]*precompile.VersionMap),
 	}
@@ -148,6 +152,12 @@ func (k *Keeper) SetEthCallGasCap(gasCap uint64) {
 // timeout means no timeout.
 func (k *Keeper) SetEthCallTimeout(timeout time.Duration) {
 	k.ethCallTimeout = timeout
+}
+
+// SetEnableJSTracers sets whether trace queries accept custom JavaScript
+// tracers.
+func (k *Keeper) SetEnableJSTracers(enabled bool) {
+	k.enableJSTracers = enabled
 }
 
 // SetVerifyBTCSupply registers the post-commit invariant check. Wired


### PR DESCRIPTION
### Introduction

This PR brings the EVM trace queries (`TraceTx`, `TraceBlock`) in line with the other EVM query methods. They let the caller choose the tracer and timeout, with no upper bound and any non-native name treated as custom JavaScript, while
`EthCall`/`EstimateGas`/`SimulateV1` already apply operator-side limits.

### Changes

- Add `json-rpc.enable-js-tracers` (default `false`). While off, trace queries  accept only native tracers (`callTracer`, `prestateTracer`, ...); a custom JS   tracer is rejected. The check runs in the keeper, so it also covers the SDK  gRPC and REST gateway paths. Wired through app config, CLI flag, and keeper.
- Cap the caller timeout at the node's `json-rpc.evm-timeout`, like `SimulateV1`.  Defaults are unchanged (both 5s).

### Testing

Unit tests cover tracer gating and the timeout cap. Verified on a local node
over JSON-RPC (`8545`) and SDK gRPC (`9090`):

| Request | Result |
|---|---|
| native `callTracer`, option off | accepted |
| custom JS tracer, option off | rejected |
| custom JS tracer, option on | accepted |
| caller timeout `1h`, node `evm-timeout=2s` | stops at ~2s |

---

### Author's checklist

- [X] Provided the appropriate description of the pull request
- [X] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Assigned myself in the `Assignees` field
- [X] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
