### PR TITLE
Align StateDB account existence with go-ethereum

### DIFF
--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -39,14 +39,22 @@ var _ statedb.Keeper = &Keeper{}
 // StateDB Keeper implementation
 // ----------------------------------------------------------------------------
 
-// GetAccount returns nil if account is not exist, returns error if it's not `EthAccountI`
+// GetAccount returns the EVM account at addr, or nil if the address has neither
+// an x/auth record nor a native balance. go-ethereum treats an address with a
+// balance as existing, so GetAccount reports one even when x/auth has no record,
+// keeping Exist and Empty aligned with go-ethereum semantics.
 func (k *Keeper) GetAccount(ctx sdk.Context, addr common.Address) *statedb.Account {
 	acct := k.GetAccountWithoutBalance(ctx, addr)
-	if acct == nil {
-		return nil
-	}
 
 	balance := k.GetBalance(ctx, addr)
+
+	if acct == nil {
+		if balance.Sign() == 0 {
+			return nil
+		}
+
+		acct = statedb.NewEmptyAccount()
+	}
 
 	// Use conversion to bytes rather than uint64 to avoid an overflow error.
 	acct.Balance = new(uint256.Int).SetBytes(balance.Bytes())

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -496,6 +496,8 @@ func (suite *KeeperTestSuite) TestSuicide() {
 }
 
 func (suite *KeeperTestSuite) TestExist() {
+	bankOnly := utiltx.GenerateAddress()
+
 	testCases := []struct {
 		name     string
 		address  common.Address
@@ -507,6 +509,9 @@ func (suite *KeeperTestSuite) TestExist() {
 			vmdb.SelfDestruct(suite.address)
 		}, true},
 		{"success, account doesn't exist", utiltx.GenerateAddress(), func(vm.StateDB) {}, false},
+		{"success, balance without auth account", bankOnly, func(vm.StateDB) {
+			suite.fundWithoutAuthAccount(bankOnly, 100)
+		}, true},
 	}
 
 	for _, tc := range testCases {
@@ -520,6 +525,8 @@ func (suite *KeeperTestSuite) TestExist() {
 }
 
 func (suite *KeeperTestSuite) TestEmpty() {
+	bankOnly := utiltx.GenerateAddress()
+
 	testCases := []struct {
 		name     string
 		address  common.Address
@@ -536,6 +543,14 @@ func (suite *KeeperTestSuite) TestEmpty() {
 			false,
 		},
 		{"empty, account doesn't exist", utiltx.GenerateAddress(), func(vm.StateDB) {}, true},
+		{
+			"not empty, balance without auth account",
+			bankOnly,
+			func(vm.StateDB) {
+				suite.fundWithoutAuthAccount(bankOnly, 100)
+			},
+			false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -988,4 +1003,39 @@ func (suite *KeeperTestSuite) TestDeleteAccount() {
 			}
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) fundWithoutAuthAccount(addr common.Address, amount int64) {
+	coins := sdk.NewCoins(sdk.NewInt64Coin(types.DefaultEVMDenom, amount))
+	suite.Require().NoError(suite.app.BankKeeper.MintCoins(suite.ctx, types.ModuleName, coins))
+	suite.Require().NoError(suite.app.BankKeeper.SendCoinsFromModuleToAccount(
+		suite.ctx, types.ModuleName, sdk.AccAddress(addr.Bytes()), coins,
+	))
+
+	acct := suite.app.AccountKeeper.GetAccount(suite.ctx, sdk.AccAddress(addr.Bytes()))
+	suite.Require().NotNil(acct)
+	suite.app.AccountKeeper.RemoveAccount(suite.ctx, acct)
+}
+
+func (suite *KeeperTestSuite) TestGetAccountBalanceWithoutAuthAccount() {
+	suite.SetupTest()
+
+	withAuthAccount := utiltx.GenerateAddress()
+	coins := sdk.NewCoins(sdk.NewInt64Coin(types.DefaultEVMDenom, 100))
+	suite.Require().NoError(suite.app.BankKeeper.MintCoins(suite.ctx, types.ModuleName, coins))
+	suite.Require().NoError(suite.app.BankKeeper.SendCoinsFromModuleToAccount(
+		suite.ctx, types.ModuleName, sdk.AccAddress(withAuthAccount.Bytes()), coins,
+	))
+	withAuth := suite.app.EvmKeeper.GetAccount(suite.ctx, withAuthAccount)
+	suite.Require().NotNil(withAuth)
+	suite.Require().Equal(big.NewInt(100), withAuth.Balance.ToBig())
+
+	bankOnly := utiltx.GenerateAddress()
+	suite.fundWithoutAuthAccount(bankOnly, 100)
+	bankOnlyAcct := suite.app.EvmKeeper.GetAccount(suite.ctx, bankOnly)
+	suite.Require().NotNil(bankOnlyAcct)
+	suite.Require().Equal(big.NewInt(100), bankOnlyAcct.Balance.ToBig())
+
+	unknown := utiltx.GenerateAddress()
+	suite.Require().Nil(suite.app.EvmKeeper.GetAccount(suite.ctx, unknown))
 }


### PR DESCRIPTION
### Introduction

In the StateDB keeper, an address's existence was derived only from whether it had an `x/auth` account record. This diverges from go-ethereum, where an address exists when it has a balance, a nonce, or code. As a result, an address that held a native balance but had no `x/auth` record was reported as non-existent, so `Exist` returned `false` and `Empty` returned `true` for it. This PR brings `GetAccount` in line with go-ethereum's account-existence semantics.

### Changes

#### `GetAccount` reports balance-holding addresses as existing

`GetAccount` now reads the `x/bank` balance for every address. When there is no `x/auth` record but the address holds a native balance, it returns an empty account carrying that balance instead of `nil`. Addresses with neither a record nor a balance still return `nil`. With this change, `Exist` and `Empty`, which are both derived from `GetAccount`, match go-ethereum for balance-holding addresses: such an address now exists and is non-empty.

### Testing

Unit tests in `x/evm/keeper` cover the aligned behavior:

- `TestGetAccountBalanceWithoutAuthAccount` checks the balance read for three cases: an address with an `x/auth` record and a balance, an address funded without an `x/auth` record, and an unknown address (nil).
- `TestExist` and `TestEmpty` gain a case for an address funded without an `x/auth` record, asserting it now exists and is non-empty.

Run with:

```
go test -run TestKeeperTestSuite ./x/evm/keeper/
```

The full `x/evm/keeper` suite passes locally.
