### PR TITLE
Add v12.0.0 planned upgrade with chain halt

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mezo-org/mezod/app/upgrades/v0_7"
 	"github.com/mezo-org/mezod/app/upgrades/v10_0"
 	"github.com/mezo-org/mezod/app/upgrades/v11_0"
+	"github.com/mezo-org/mezod/app/upgrades/v12_0"
 	"github.com/mezo-org/mezod/app/upgrades/v1_0"
 	"github.com/mezo-org/mezod/app/upgrades/v2_0"
 	"github.com/mezo-org/mezod/app/upgrades/v3_0"
@@ -40,6 +41,7 @@ var (
 		v9_0.Upgrade,
 		v10_0.Upgrade,
 		v11_0.Upgrade,
+		v12_0.Upgrade,
 	}
 	Forks = []upgrades.Fork{v0_3.Fork, v0_4.Fork, v0_5.Fork, v0_6.Fork, v0_7.Fork}
 )

--- a/app/upgrades/v12_0/constants.go
+++ b/app/upgrades/v12_0/constants.go
@@ -1,0 +1,16 @@
+//nolint:revive,stylecheck
+package v12_0
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+// UpgradeName defines the name of the upgrade.
+const UpgradeName = "v12.0.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/v12_0/upgrades.go
+++ b/app/upgrades/v12_0/upgrades.go
@@ -1,0 +1,29 @@
+//nolint:revive,stylecheck
+package v12_0
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/mezo-org/mezod/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx context.Context,
+		_ upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		sdkCtx.Logger().Info("running v12.0.0 upgrade handler")
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -192,6 +192,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v9.0.0`       | 12193600  | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0)                                                                                                           |
 | `v10.0.0`      | 12872000  | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0)                                                                                                         |
 | `v11.0.0`      | 13206900  | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0)                                                                                                         |
+| `v12.0.0`      | TBD       | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0)                                                                                                         |
 
 ### Mainnet
 
@@ -208,3 +209,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v9.0.0` | 8194500 | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0) |
 | `v10.0.0` | 8773000 | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0) |
 | `v11.0.0` | 9275000 | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0) |
+| `v12.0.0` | TBD     | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0) |


### PR DESCRIPTION
References: <!-- Put GitHub/Linear issue here -->

### Introduction

`v12.0.0` requires a planned upgrade with chain halt: it changes EVM state-transition behavior, so every validator has to switch binaries at the same height instead of rolling out node by node. This PR adds the `v12.0.0` upgrade handler and registers it, so a halt height can be scheduled through the `Upgrade` precompile.

### Changes

#### The `v12_0` upgrade package

`app/upgrades/v12_0` follows the same shape as `v10_0`: `UpgradeName` is `v12.0.0`, `StoreUpgrades` is empty, and the handler logs and calls `mm.RunMigrations`. There is no store migration to run, so the coordinated halt is the whole point of the upgrade.

`v12_0.Upgrade` is appended to the `Upgrades` list in `app/upgrades.go`, and the package is imported alongside the other upgrade packages. `Forks` is untouched: this is a planned upgrade, not a hard fork.

#### `docs/upgrades.md`

The testnet and mainnet historical-upgrade tables each gain a `v12.0.0` row typed `Planned upgrade with chain halt`, with `TBD` heights. Both are filled in at deployment time, once the halt blocks are agreed.

### Testing

No unit test accompanies the handler. Every upgrade package in the tree ships without tests, and a handler that mutates no store gives a test nothing to assert beyond `RunMigrations` itself. The live effect is verified at deployment time on testnet first, then mainnet.

| Check | Result |
|---|---|
| `go build ./app/...` | pass |
| `go vet ./app/ ./app/upgrades/...` | pass |
| `go test ./app/...` | pass (all packages) |
| `gofumpt -l` on changed files | clean |
| `golangci-lint run ./app/` | no findings in `app/upgrades/v12_0`; the pre-existing typecheck findings are unchanged from `main` |
| `markdownlint docs/upgrades.md` | pass |

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
