### PR TITLE
Bump testnet nodes to v12.0.0-rc0

### DIFF
--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-0.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v12.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-1.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v12.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-2.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v12.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-3.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v12.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1

--- a/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
+++ b/infrastructure/kubernetes/mezo-staging/values/mezo-node-4.yaml
@@ -1,3 +1,6 @@
+image: us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod
+tag: v12.0.0-rc0
+
 env:
   NETWORK: testnet
   MEZOD_CHAIN_ID: mezo_31611-1


### PR DESCRIPTION
References: <!-- Put GitHub/Linear issue here -->

Depends on: https://github.com/mezo-org/mezod/pull/720

### Introduction

Here we bump our testnet nodes to `v12.0.0-rc0`.

### Changes

#### Bump testnet node image tags

Add the `image` and `tag` overrides on all five `mezo-staging` validator value files so they pull `v12.0.0-rc0` for the rollout. The chart version pinned in the staging helmfile points at a stable mezod tag, so a release candidate reaches the nodes only through a per-node override. These overrides will be removed again once `v12.0.0` is promoted to a stable tag.

#### The `v12.0.0` testnet upgrade block

The testnet historical-upgrades table in `docs/upgrades.md` still carries `TBD` for `v12.0.0`. The halt block has not been agreed yet, so the placeholder stays for now and is filled in here once a block is picked. The mainnet block stays `TBD` as well.

### Testing

Apply using `helmfile apply -l type=validator --context 1 --concurrency 1` at the `v12.0.0` testnet halt block.

`yamllint -d relaxed` on the five changed files reports an identical set of findings before and after this change (a pre-existing over-long comment line with trailing spaces in three of them), and no new ones.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
