### PR TITLE
Record v12.0.0 upgrade blocks in upgrades doc

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -192,7 +192,7 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v9.0.0`       | 12193600  | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0)                                                                                                           |
 | `v10.0.0`      | 12872000  | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0)                                                                                                         |
 | `v11.0.0`      | 13206900  | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0)                                                                                                         |
-| `v12.0.0`      | TBD       | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0)                                                                                                         |
+| `v12.0.0`      | 14705350  | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0)                                                                                                         |
 
 ### Mainnet
 
@@ -209,4 +209,4 @@ Consult the [tags list](https://github.com/mezo-org/mezod/tags) for full version
 | `v9.0.0` | 8194500 | Planned upgrade with chain halt      | [v9.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v9.0.0) |
 | `v10.0.0` | 8773000 | Planned upgrade with chain halt      | [v10.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v10.0.0) |
 | `v11.0.0` | 9275000 | Planned upgrade with chain halt      | [v11.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v11.0.0) |
-| `v12.0.0` | TBD     | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0) |
+| `v12.0.0` | 10885900 | Planned upgrade with chain halt      | [v12.0.0 release notes](https://github.com/mezo-org/mezod/releases/tag/v12.0.0) |


### PR DESCRIPTION
References: <!-- Put GitHub/Linear issue here -->

### Introduction

The `v12.0.0` halt blocks have been agreed, so the historical-upgrade tables in `docs/upgrades.md` no longer need their `TBD` placeholders.

### Changes

#### Record the `v12.0.0` upgrade blocks

Replace `TBD` with the agreed halt block in both historical-upgrade tables: `14705350` in the testnet table and `10885900` in the mainnet table.

Each value sits above the corresponding `v11.0.0` block (`13206900` on testnet, `9275000` on mainnet), so both tables stay in ascending block order.

### Testing

`markdownlint docs/upgrades.md --config .markdownlint.yml` passes. This is a documentation-only change; no code paths are touched.

---

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [ ] Updated relevant unit and integration tests
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [ ] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [ ] Confirmed all author's checklist items have been addressed
- [ ] Considered security implications of the code changes
- [ ] Considered performance implications of the code changes
- [ ] Tested the changes and summarized covered scenarios and results in a comment
