### PR TITLE
Enforce the bridge-in pause on the validator-observed path

### DIFF
--- a/docs/emergency-controls.md
+++ b/docs/emergency-controls.md
@@ -154,14 +154,18 @@ Ethereum and to Bitcoin. The check sits in `SaveAssetsUnlocked` in the
 with `bridge-out is paused`, the sequence tip does not advance, and no outflow
 is recorded.
 
-`bridgeIn = true` stops the triparty inbound path. `bridgeTriparty` calls fail
-with `bridge-in is paused` and the `PreBlocker` stops processing pending
-triparty requests. Pending requests stay in state.
+`bridgeIn = true` stops both inbound paths: the triparty path and the
+validator-observed path.
 
-**The lockdown does not cover the validator-observed bridge-in path.**
-`AssetsLocked` events observed on Ethereum are still executed while `bridgeIn`
-is true. Today level 1 stops the triparty path only. MEZO-5000 extends the same
-flag to the validator-observed path.
+On the triparty path, `bridgeTriparty` calls fail with `bridge-in is paused`
+and the `PreBlocker` stops processing pending triparty requests. Pending
+requests stay in state.
+
+On the validator-observed path, the check sits in the proposal handlers of the
+`x/bridge` module. `PrepareProposal` skips the injection of the `AssetsLocked`
+pseudo-transaction, and `ProcessProposal` rejects any proposal that carries
+one. No `AssetsLocked` event observed on Ethereum is executed while `bridgeIn`
+is true, and the sequence tip does not advance.
 
 Lockdown never touches the bridge outflow limits. Limits stay a separate PoA
 owner tool, and the lockdown state is readable through `getBridgeLockdown`
@@ -190,6 +194,12 @@ current `bridgeOut`. The `PreBlocker` resumes the pending triparty requests,
 subject to the block delay and the triparty limits. Requests that controllers
 attempted during the lockdown were rejected at submission, so those controllers
 must submit them again.
+
+The validator-observed path needs no manual step. The lockdown defers the
+`AssetsLocked` events; it does not drop them. The sequence tip stays frozen
+while `bridgeIn` is true, so the Ethereum sidecar keeps serving the events from
+the tip. After the release, the next proposal injects them again and the chain
+processes them in sequence order. No event is lost.
 
 Confirm the result with `getBridgeLockdown` and with the `BridgeLockdownSet`
 event of the transaction.
@@ -266,7 +276,3 @@ them exists yet; the names are fixed here so the vocabulary stays stable.
   arguments and is one-way on chain. The only recovery is validators restarting
   with the next-version binary, so this level has no on-chain disable and no
   view.
-
-MEZO-5000 also extends the `bridgeIn` flag of level 1 to the validator-observed
-bridge-in path, which closes the gap described in
-[Level 1: bridge lockdown](#level-1-bridge-lockdown).

--- a/x/bridge/abci/interfaces.go
+++ b/x/bridge/abci/interfaces.go
@@ -34,4 +34,5 @@ type BridgeKeeper interface {
 	GetAssetsLockedSequenceTip(ctx sdk.Context) math.Int
 	AcceptAssetsLocked(ctx sdk.Context, events types.AssetsLockedEvents) error
 	ProcessTripartyBridgeRequests(ctx sdk.Context) error
+	IsBridgeInPaused(ctx sdk.Context) bool
 }

--- a/x/bridge/abci/proposal.go
+++ b/x/bridge/abci/proposal.go
@@ -112,6 +112,18 @@ func (ph *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 			"height", req.Height,
 		)
 
+		// While bridge-in is paused, do not inject the AssetsLocked
+		// pseudo-transaction. The sequence tip stays frozen, so the sidecar
+		// re-serves the deferred events after unpause.
+		if ph.keeper.IsBridgeInPaused(ctx) {
+			ph.logger.Info(
+				"bridge-in is paused; skipping AssetsLocked events injection",
+				"height", req.Height,
+			)
+
+			return &cmtabci.ResponsePrepareProposal{Txs: req.Txs}, nil
+		}
+
 		// According to the app-level proposal handler requirements, this
 		// handler must validate signatures of the commit's vote extensions
 		// on their own.
@@ -288,6 +300,15 @@ func (ph *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 			return &cmtabci.ResponseProcessProposal{
 				Status: cmtabci.ResponseProcessProposal_ACCEPT,
 			}, nil
+		}
+
+		// While bridge-in is paused, a proposal that carries an AssetsLocked
+		// pseudo-transaction is invalid, no matter its content. The pause flag
+		// lives in state, so every validator evaluates it identically.
+		if ph.keeper.IsBridgeInPaused(ctx) {
+			return &cmtabci.ResponseProcessProposal{
+				Status: cmtabci.ResponseProcessProposal_REJECT,
+			}, fmt.Errorf("bridge-in is paused; rejecting proposal with injected tx")
 		}
 
 		var injectedTx types.InjectedTx

--- a/x/bridge/abci/proposal_test.go
+++ b/x/bridge/abci/proposal_test.go
@@ -219,6 +219,11 @@ func (s *ProposalHandlerTestSuite) TestPrepareProposal() {
 		s.Run(test.name, func() {
 			s.SetupTest()
 
+			s.bridgeKeeper.On(
+				"IsBridgeInPaused",
+				s.ctx,
+			).Return(false)
+
 			valStore := newMockValidatorStore()
 			voteExtensionsValidator := test.voteExtensionsValidator
 
@@ -308,6 +313,94 @@ func (s *ProposalHandlerTestSuite) TestPrepareProposal() {
 	}
 }
 
+func (s *ProposalHandlerTestSuite) TestPrepareProposalBridgeInPaused() {
+	s.bridgeKeeper.On(
+		"IsBridgeInPaused",
+		s.ctx,
+	).Return(true)
+
+	valStore := newMockValidatorStore()
+	voteExtensionsValidator := newMockVoteExtensionsValidator(nil)
+
+	s.handler = NewProposalHandler(
+		s.logger,
+		valStore,
+		s.bridgeKeeper,
+		// No need for the vote extension decomposer in this test.
+		// The decomposer is used to construct the default assetsLockedExtractor
+		// but, we are overriding it with a test one.
+		nil,
+		voteExtensionsValidator.call,
+	)
+
+	// A canonical sequence sticking to the current tip is available. The
+	// pause must take precedence over it.
+	events := []bridgetypes.AssetsLockedEvent{
+		mockEvent(201, recipient1, 100, token),
+		mockEvent(202, recipient2, 200, token),
+		mockEvent(203, recipient3, 300, token),
+	}
+
+	extendedCommitInfo := cmtabci.ExtendedCommitInfo{
+		Round: 1, // Just an arbitrary value.
+		Votes: []cmtabci.ExtendedVoteInfo{
+			mockVoteExtension("val1Bridge", 100, tmproto.BlockIDFlagCommit, events...),
+		},
+	}
+
+	extractor := newMockAssetsLockedExtractor()
+	// The pause short-circuits before the extraction so this call is optional.
+	extractor.On(
+		"CanonicalEvents",
+		s.ctx,
+		extendedCommitInfo,
+		s.requestHeight,
+	).Return(events, nil).Maybe()
+
+	// Override the default assetsLockedExtractor with a test one.
+	s.handler.assetsLockedExtractor = extractor
+
+	req := &cmtabci.RequestPrepareProposal{
+		// Fill only the fields that are relevant for the test.
+		Height:          s.requestHeight,
+		Txs:             txsVector("tx1", "tx2"),
+		LocalLastCommit: extendedCommitInfo,
+	}
+
+	res, err := s.handler.PrepareProposalHandler()(s.ctx, req)
+
+	voteExtensionsValidator.AssertNotCalled(
+		s.T(),
+		"call",
+		s.ctx,
+		valStore,
+		s.requestHeight,
+		s.ctx.ChainID(),
+		extendedCommitInfo,
+	)
+
+	extractor.AssertNotCalled(
+		s.T(),
+		"CanonicalEvents",
+		s.ctx,
+		extendedCommitInfo,
+		s.requestHeight,
+	)
+
+	s.Require().NoError(err, "expected no error")
+
+	s.Require().Nil(
+		extractInjectedTx(req, res),
+		"expected no injected pseudo-tx",
+	)
+
+	s.Require().Equal(
+		txsVector("tx1", "tx2"),
+		res.Txs,
+		"expected different chain transactions",
+	)
+}
+
 func (s *ProposalHandlerTestSuite) TestProcessProposal() {
 	marshalExtCommitInfo := func(extCommitInfo cmtabci.ExtendedCommitInfo) []byte {
 		extCommitInfoBytes, err := extCommitInfo.Marshal()
@@ -317,6 +410,7 @@ func (s *ProposalHandlerTestSuite) TestProcessProposal() {
 
 	tests := []struct {
 		name                    string
+		bridgeInPaused          bool
 		voteExtensionsValidator *mockVoteExtensionsValidator
 		assetsLockedExtractorFn func(cmtabci.ExtendedCommitInfo) *mockAssetsLockedExtractor
 		reqTxsFn                func() [][]byte
@@ -659,11 +753,91 @@ func (s *ProposalHandlerTestSuite) TestProcessProposal() {
 			},
 			errContains: "",
 		},
+		{
+			name:                    "bridge-in paused, injected tx present",
+			bridgeInPaused:          true,
+			voteExtensionsValidator: newMockVoteExtensionsValidator(nil),
+			assetsLockedExtractorFn: func(extCommitInfo cmtabci.ExtendedCommitInfo) *mockAssetsLockedExtractor {
+				extractor := newMockAssetsLockedExtractor()
+
+				var voteExtension types.VoteExtension
+				err := voteExtension.Unmarshal(extCommitInfo.Votes[0].VoteExtension)
+				s.Require().NoError(err)
+
+				// The pause short-circuits before the re-creation of the
+				// canonical sequence so this call is optional.
+				extractor.On(
+					"CanonicalEvents",
+					s.ctx,
+					extCommitInfo,
+					s.requestHeight,
+				).Return(voteExtension.AssetsLockedEvents, nil).Maybe()
+
+				return extractor
+			},
+			reqTxsFn: func() [][]byte {
+				// The injected tx is valid. The pause alone makes the
+				// proposal invalid.
+				events := []bridgetypes.AssetsLockedEvent{
+					mockEvent(201, recipient1, 100, token),
+					mockEvent(202, recipient2, 200, token),
+					mockEvent(203, recipient3, 300, token),
+				}
+
+				return append(
+					[][]byte{
+						marshalInjectedTx(
+							types.InjectedTx{
+								AssetsLockedEvents: events,
+								ExtendedCommitInfo: marshalExtCommitInfo(
+									cmtabci.ExtendedCommitInfo{
+										Round: 1,
+										Votes: []cmtabci.ExtendedVoteInfo{
+											// The mock extractor returns the canonical sequence based
+											// on the first vote so use a single vote to keep the test simple.
+											mockVoteExtension(
+												"val1Bridge",
+												102,
+												tmproto.BlockIDFlagCommit,
+												events...,
+											),
+										},
+									},
+								),
+							},
+						),
+					},
+					txsVector("tx1", "tx2")...,
+				)
+			},
+			expectedRes: &cmtabci.ResponseProcessProposal{
+				Status: cmtabci.ResponseProcessProposal_REJECT,
+			},
+			errContains: "bridge-in is paused",
+		},
+		{
+			name:                    "bridge-in paused, empty injected tx",
+			bridgeInPaused:          true,
+			voteExtensionsValidator: newMockVoteExtensionsValidator(nil),
+			assetsLockedExtractorFn: func(_ cmtabci.ExtendedCommitInfo) *mockAssetsLockedExtractor {
+				return newMockAssetsLockedExtractor()
+			},
+			reqTxsFn: func() [][]byte { return txsVector("") },
+			expectedRes: &cmtabci.ResponseProcessProposal{
+				Status: cmtabci.ResponseProcessProposal_ACCEPT,
+			},
+			errContains: "",
+		},
 	}
 
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			s.SetupTest()
+
+			s.bridgeKeeper.On(
+				"IsBridgeInPaused",
+				s.ctx,
+			).Return(test.bridgeInPaused)
 
 			valStore := newMockValidatorStore()
 			voteExtensionsValidator := test.voteExtensionsValidator
@@ -707,17 +881,37 @@ func (s *ProposalHandlerTestSuite) TestProcessProposal() {
 
 			// Make sure VE validation occurred if and only if there was
 			// an unmarshalable injected tx holding unmarshalable extended
-			// commit info.
+			// commit info. A pause rejects the proposal before that point.
 			if extCommitInfoOk {
-				voteExtensionsValidator.AssertCalled(
-					s.T(),
-					"call",
-					s.ctx,
-					valStore,
-					s.requestHeight,
-					s.ctx.ChainID(),
-					extCommitInfo,
-				)
+				if test.bridgeInPaused {
+					voteExtensionsValidator.AssertNotCalled(
+						s.T(),
+						"call",
+						s.ctx,
+						valStore,
+						s.requestHeight,
+						s.ctx.ChainID(),
+						extCommitInfo,
+					)
+
+					extractor.AssertNotCalled(
+						s.T(),
+						"CanonicalEvents",
+						s.ctx,
+						extCommitInfo,
+						s.requestHeight,
+					)
+				} else {
+					voteExtensionsValidator.AssertCalled(
+						s.T(),
+						"call",
+						s.ctx,
+						valStore,
+						s.requestHeight,
+						s.ctx.ChainID(),
+						extCommitInfo,
+					)
+				}
 			}
 
 			extractor.AssertExpectations(s.T())

--- a/x/bridge/abci/vote_extension_test.go
+++ b/x/bridge/abci/vote_extension_test.go
@@ -796,3 +796,8 @@ func (mbk *mockBridgeKeeper) ProcessTripartyBridgeRequests(
 	args := mbk.Called(ctx)
 	return args.Error(0)
 }
+
+func (mbk *mockBridgeKeeper) IsBridgeInPaused(ctx sdk.Context) bool {
+	args := mbk.Called(ctx)
+	return args.Bool(0)
+}


### PR DESCRIPTION
References: [MEZO-5000](https://linear.app/thesis-co/issue/MEZO-5000/graduated-chain-lockdown-mode)

### Introduction

Level 1 of the emergency lockdown (`setBridgeLockdown`) pauses bridge-out and the triparty bridge-in path. The validator-observed bridge-in path stayed open: `AssetsLocked` events observed on Ethereum still minted BTC while `bridgeIn` was true. This PR closes that gap, so the `bridgeIn` flag now covers both inbound paths.

### Changes

#### Bridge-in pause enforcement in the proposal handlers

The `AssetsLocked` pipeline runs through custom ABCI handlers, not transactions, so the check sits in the proposal phase of `x/bridge`:

- `PrepareProposal` returns the proposal without the `AssetsLocked` pseudo-transaction while `IsBridgeInPaused` is true. The handler short-circuits before vote-extension validation and event extraction.
- `ProcessProposal` rejects any proposal that carries the pseudo-transaction while the flag is true. The flag lives in state, so every validator evaluates it identically, and a misbehaving proposer cannot mint during the pause.

The pause defers events instead of dropping them. The sequence tip does not advance, the Ethereum sidecar keeps serving events from the tip, and processing resumes after `setBridgeLockdown(false, ...)`. No event is lost.

There is no PreBlock gate. The flag changes only through transactions, which execute after PreBlock, so the proposal phase and PreBlock of one block always see the same flag value.

#### Documentation

`docs/emergency-controls.md` now documents both inbound paths under level 1, describes the deferral semantics in the recovery section, and drops the roadmap note about the gap.

### Testing

- New unit tests in `x/bridge/abci/proposal_test.go` cover: the paused `PrepareProposal` short-circuit (no injection, untouched transaction vector, no vote-extension validation), the paused `ProcessProposal` rejection of a valid pseudo-transaction, and the paused acceptance of a proposal without one.
- `make test-unit` passes.
- `golangci-lint run ./x/bridge/...` (v1.64.8) is clean.
- No system test: the localnode bridge is disabled (bogus `source_btc_token`), so the validator-observed path cannot run there. A bridge-capable localnet drill (pause, verify deferral, unpause, verify resume) covers the live path before release.
